### PR TITLE
introduce baseUrl

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -70,7 +70,7 @@ YoastSEO.SnippetPreview.prototype.formatTitle = function() {
  * @returns formatted url
  */
 YoastSEO.SnippetPreview.prototype.formatUrl = function() {
-	var url = this.refObj.rawData.url;
+	var url = this.refObj.rawData.baseUrl;
 
 	//removes the http(s) part of the url
 	url.replace( /https?:\/\//ig, "" );


### PR DESCRIPTION
Replaces #93 

After some more thinking, realized that it makes no sense if the url is not the full url. In the snippet preview we need the base url, so let's just require it as an extra parameter.