### PR TITLE
Fix off by one error in meta description length

### DIFF
--- a/js/config/scoring.js
+++ b/js/config/scoring.js
@@ -200,7 +200,7 @@ YoastSEO.AnalyzerScoring = function( i18n ) {
         {
             scoreName: "metaDescriptionLength",
             metaMinLength: 120,
-            metaMaxLength: 156,
+            metaMaxLength: 157,
             scoreArray: [
                 {
                     max: 0,
@@ -215,7 +215,7 @@ YoastSEO.AnalyzerScoring = function( i18n ) {
                     text: i18n.dgettext('js-text-analysis', "The meta description is under %1$d characters, however up to %2$d characters are available.")
                 },
                 {
-                    min: 156,
+                    min: 157,
                     score: 6,
 
                     /* translators: %2$d expands to the maximum length for the meta description */
@@ -223,7 +223,7 @@ YoastSEO.AnalyzerScoring = function( i18n ) {
                 },
                 {
                     min: 120,
-                    max: 156,
+                    max: 157,
                     score: 9,
                     text: i18n.dgettext('js-text-analysis', "In the specified meta description, consider: How does it compare to the competition? Could it be made more appealing?")
                 }

--- a/spec/scoringSpec.js
+++ b/spec/scoringSpec.js
@@ -61,3 +61,20 @@ describe("a test for the scoring function of all functions in the analyzer", fun
        expect(analyzeScore[14].text).toBe("This page has 3 outbound link(s).");
    });
 });
+
+var scoreArgs2 = {
+    text: "",
+    keyword: "",
+    meta: "Liquorice sweet roll sesame snaps sweet roll croissant gummies. Chocolate bar gummies icing cake jelly beans. Jelly beans pie soufflé fruitcake pie jelly br", // Meta description with length 156
+    queue: ["metaDescriptionLength"]
+};
+describe("A meta description scoring", function() {
+    it("should correctly report maximum length", function() {
+        var analyzer = Factory.buildAnalyzer(scoreArgs2);
+        analyzer.runQueue();
+        var score = analyzer.analyzeScorer.__score;
+
+        expect(score[0].text).toBe("In the specified meta description, consider: How does it compare to the competition? Could it be made more appealing?");
+        expect(score[0].score).toBe(9);
+    });
+});


### PR DESCRIPTION
A meta description of exactly 156 characters should be inside the bounds

Introduce a unit test

Fixes https://github.com/Yoast/wordpress-seo/issues/3072