### PR TITLE
Change Flesch scoring

### DIFF
--- a/js/config/scoring.js
+++ b/js/config/scoring.js
@@ -153,7 +153,7 @@ YoastSEO.AnalyzerScoring = function( i18n ) {
                 {min: 90, score: 9, text: "{{text}}", resultText: "very easy", note: ""},
                 {min: 80, max: 89.9, score: 9, text: "{{text}}", resultText: "easy", note: ""},
                 {min: 70, max: 79.9, score: 8, text: "{{text}}", resultText: "fairly easy", note: ""},
-                {min: 60, max: 69.9, score: 7, text: "{{text}}", resultText: "ok", note: ""},
+                {min: 60, max: 69.9, score: 8, text: "{{text}}", resultText: "ok", note: ""},
                 {
                     min: 50,
                     max: 59.9,


### PR DESCRIPTION
For a text that is "ok" to read we shouldn't throw an orange bubble, so upping score to 8.