### PR TITLE
Add trailing slash to snippet editor

### DIFF
--- a/dist/yoast-seo.js
+++ b/dist/yoast-seo.js
@@ -2375,6 +2375,10 @@ YoastSEO.SnippetPreview.prototype.formatCite = function() {
 	if ( cite === "" ) {
 		cite = this.refObj.config.sampleText.snippetCite;
 	}
+	if ( cite.indexOf( "/" ) !== ( cite.length - 1 ) ) {
+		cite = cite + "/";
+	}
+
 	return this.formatKeywordUrl( cite );
 };
 

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -93,6 +93,7 @@ YoastSEO.SnippetPreview.prototype.formatCite = function() {
 	if ( cite.indexOf( "/" ) !== ( cite.length - 1 ) ) {
 		cite = cite + "/";
 	}
+	cite = cite.replace( /\s/g, "-" );
 
 	return this.formatKeywordUrl( cite );
 };

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -90,6 +90,10 @@ YoastSEO.SnippetPreview.prototype.formatCite = function() {
 	if ( cite === "" ) {
 		cite = this.refObj.config.sampleText.snippetCite;
 	}
+	if ( cite.indexOf( "/" ) !== ( cite.length - 1 ) ) {
+		cite = cite + "/";
+	}
+
 	return this.formatKeywordUrl( cite );
 };
 


### PR DESCRIPTION
Adds trailing slash to the snippet editor and replaces the whitespaces with dashes so it matches the UX of the slug in WordPress. 
Fixes #166 