### PR TITLE
Enable test coverage locally and on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp-spec/
 .idea/
 node_modules/
 out/
+coverage/

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,5 @@
+instrumentation:
+    root: js
+    extensions:
+        - .js
+    include-all-sources: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ cache:
 
 before_script:
 - npm install -g grunt-cli
+- npm install -g codeclimate-test-reporter
 - npm install
 
 script:
-- npm test
+- npm test --coverage
+- codeclimate-test-reporter < coverage/lcov.info
 - grunt check
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "url": "https://github.com/Yoast/js-text-analysis"
   },
   "scripts": {
-    "test": "jasmine"
+    "test": "istanbul test jasmine"
   },
   "bin": {
-    "jasmine": "./bin/jasmine.js"
+    "jasmine": "./bin/jasmine.js",
+    "istanbul": "./bin/istanbul.js"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -33,6 +34,7 @@
     "grunt-po2json": "^0.3.0",
     "grunt-shell": "^1.1.2",
     "io.js": "0.0.0",
+    "istanbul": "^0.4.0",
     "jasmine": "~2.2.1",
     "jsdom": "^5.4.3",
     "load-grunt-config": "^0.17.0",


### PR DESCRIPTION
After this you can generate coverage locally using `npm test --coverage`. Travis will report the coverage to code climate, this only works on the master branch.