### PR TITLE
Fixed Grunt recreating the example folder

### DIFF
--- a/grunt/config/uglify.js
+++ b/grunt/config/uglify.js
@@ -9,7 +9,7 @@ module.exports = {
 			"dist/yoast-seo.min.js": [
 				"dist/yoast-seo.js"
 			],
-			"example/standalone/example-scraper.min.js": [
+			"examples/standalone/example-scraper.min.js": [
 				"examples/standalone/example-scraper.js"
 			]
 		}


### PR DESCRIPTION
Fixed Grunt recreating the example folder instead of using the examples folder