### PR TITLE
Removes score for metadescription keyword if there is no metadescription

### DIFF
--- a/js/assessments/metaDescriptionKeyword.js
+++ b/js/assessments/metaDescriptionKeyword.js
@@ -12,10 +12,12 @@ var calculateKeywordMatchesResult = function( keywordMatches, i18n ) {
 			text: i18n.dgettext( "js-text-analysis", "The meta description contains the focus keyword." )
 		};
 	}
-	return {
-		score: 3,
-		text: i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it does not contain the focus keyword." )
-	};
+	if ( keywordMatches === 0 ) {
+		return {
+			score: 3,
+			text: i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it does not contain the focus keyword." )
+		};
+	}
 };
 
 /**

--- a/js/assessments/metaDescriptionKeyword.js
+++ b/js/assessments/metaDescriptionKeyword.js
@@ -18,6 +18,7 @@ var calculateKeywordMatchesResult = function( keywordMatches, i18n ) {
 			text: i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it does not contain the focus keyword." )
 		};
 	}
+	return {};
 };
 
 /**

--- a/js/researches/metaDescriptionKeyword.js
+++ b/js/researches/metaDescriptionKeyword.js
@@ -8,6 +8,9 @@ var matchTextWithWord = require( "../stringProcessing/matchTextWithWord.js" );
  * @returns {number} The number of matches with the keyword
  */
 module.exports = function( paper ) {
+	if ( paper.getDescription() === "" ) {
+		return -1;
+	}
 	return matchTextWithWord( paper.getDescription(), paper.getKeyword() );
 };
 

--- a/spec/assessments/metadescriptionKeywordAsssessmentSpec.js
+++ b/spec/assessments/metadescriptionKeywordAsssessmentSpec.js
@@ -24,5 +24,14 @@ describe( "the metadescription keyword assessment", function() {
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The meta description contains the focus keyword." );
 	} );
+
+	it( "should not score since there is no meta", function() {
+		var paper = new Paper( "text", { keyword: "keyword", description: "" } );
+		var researcher = factory.buildMockResearcher( -1 );
+
+		var result = metaDescriptionKeyword( paper, researcher, i18n );
+
+		expect( result.getText() ).toBe( "" );
+	} );
 } );
 

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -19,4 +19,11 @@ describe( "the metadescription keyword match research", function() {
 		var result = metaDescriptionKeyword( paper );
 		expect( result ).toBe( 0 );
 	});
+
+	it( "returns -1 because there is no meta", function() {
+		var paper = new Paper( "", { keyword: "word", description: "" } );
+		var result = metaDescriptionKeyword( paper );
+		expect( result ).toBe( -1 );
+	});
+
 });


### PR DESCRIPTION
The researcher returns -1 when there is no meta description. If there is no metadescription we cannot score for keywords in the metadescription.