### PR TITLE
Check for empty string in keyword density

### DIFF
--- a/js/assessments/keywordDensity.js
+++ b/js/assessments/keywordDensity.js
@@ -50,7 +50,6 @@ var getKeyworDensityAssessment = function( paper,  researcher, i18n ) {
 	var keywordDensity = researcher.getResearch( "getKeywordDensity" );
 	var keywordCount = matchWords( paper.getText(), paper.getKeyword() );
 	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n );
-
 	var assessmentResult = new AssessmentResult();
 
 	var text = i18n.sprintf( keywordDensityResult.text, keywordDensity, keywordCount );

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -13,6 +13,9 @@ module.exports = function( paper ) {
 	var keyword = paper.getKeyword();
 	var text = paper.getText();
 	var wordCount = countWords( text );
+	if ( wordCount === 0 ) {
+		return "0.0";
+	}
 	var keywordCount = matchWords ( text, keyword );
 	var keywordDensity = ( keywordCount / wordCount ) * 100;
 	return keywordDensity.toFixed( 1 );

--- a/js/stringProcessing/matchTextWithWord.js
+++ b/js/stringProcessing/matchTextWithWord.js
@@ -18,7 +18,10 @@ module.exports = function( text, wordToMatch, extraBoundary ) {
 	text = unifyWhitespace( text );
 	text = replaceDiacritics( text );
 
-	var matches = text.match( stringToRegex( wordToMatch, extraBoundary ) );
+	var matches = null;
+	if ( text !== "" ) {
+		matches = text.match( stringToRegex( wordToMatch, extraBoundary ) );
+	}
 
 	if ( matches === null ) {
 		return 0;

--- a/spec/researches/keywordDensitySpec.js
+++ b/spec/researches/keywordDensitySpec.js
@@ -23,5 +23,7 @@ describe("Test for counting the keyword density in a text", function(){
 		expect( keywordDensity( mockPaper ) ).toBe( "0.0" );
 		mockPaper = new Paper( "a string of text with the key&word in it, density should be 7.7%", {keyword: "key&word"} );
 		expect( keywordDensity( mockPaper ) ).toBe( "7.7" );
+		mockPaper = new Paper( "<img src='http://plaatje.com/plaatje.png'>", {keyword: "key&word"} );
+		expect( keywordDensity( mockPaper ) ).toBe( "0.0" );
 	});
 });


### PR DESCRIPTION
Fixes a bug where an empty string could give errors. 
If after sanitizing the string was empty (ie there is only an imagetag in the text) it generated an error. 

Now when the text is empty and a keyword is entered, it no longer generates javascript errors.