### PR TITLE
Modulize scoreformatter

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ var Jed = require( "jed" );
 
 var Assessor = require( "./assessor.js" );
 var Researcher = require( "./researcher.js" );
-var ScoreFormatter = require( "./scoreFormatter.js" );
+var AssessorPresenter = require( "./renderers/AssessorPresenter.js" );
 var Pluggable = require( "./pluggable.js" );
 var Paper = require( "./values/Paper.js" );
 
@@ -430,14 +430,14 @@ App.prototype.runAnalyzer = function() {
 	this.assessor.assess( this.paper );
 
 	// Pass the assessor result through to the formatter
-	this.scoreFormatter = new ScoreFormatter( {
+	this.assessorPresenter = new AssessorPresenter( {
 		targets: this.config.targets,
 		keyword: this.paper.getKeyword(),
 		assessor: this.assessor,
 		i18n: this.i18n
 	} );
 
-	this.scoreFormatter.renderScore();
+	this.assessorPresenter.render();
 	this.callbacks.saveScores( this.assessor.calculateOverallScore() );
 
 	if ( this.config.dynamicDelay ) {

--- a/js/assessor.js
+++ b/js/assessor.js
@@ -146,7 +146,7 @@ Assessor.prototype.calculateOverallScore  = function() {
 	var totalScore = 0;
 
 	forEach( results, function( assessmentResult ) {
-		totalScore += assessmentResult.result.getScore();
+		totalScore += assessmentResult.getScore();
 	} );
 
 	return Math.round( totalScore / ( results.length * ScoreRating ) * 100 );

--- a/js/config/presenter.js
+++ b/js/config/presenter.js
@@ -1,0 +1,25 @@
+/**
+ * Returns the configuration used for score ratings and the AssessorPresenter.
+ * @param {Jed} i18n The translator object.
+ * @returns {Object} The config object.
+ */
+module.exports = function ( i18n ) {
+	return {
+		feedback: {
+			class: "na",
+			screenReaderText: i18n.dgettext( "js-text-analysis", "Feedback")
+		},
+		bad: {
+			class: "bad",
+			screenReaderText: i18n.dgettext( "js-text-analysis", "Bad SEO score")
+		},
+		ok: {
+			class: "ok",
+			screenReaderText: i18n.dgettext( "js-text-analysis", "Ok SEO score")
+		},
+		good: {
+			class: "good",
+			screenReaderText: i18n.dgettext( "js-text-analysis", "Good SEO score")
+		}
+	};
+};

--- a/js/interpreters/scoreToRating.js
+++ b/js/interpreters/scoreToRating.js
@@ -1,8 +1,8 @@
 /**
  * Interpreters a score and gives it a particular rating.
+ *
  * @param {Number} score The score to interpreter.
  * @returns {string} The rating, given based on the score.
- * @constructor
  */
 var ScoreToRating = function( score ) {
 

--- a/js/interpreters/scoreToRating.js
+++ b/js/interpreters/scoreToRating.js
@@ -1,0 +1,22 @@
+
+var ScoreToRating = function( score ) {
+	if ( score === 0 ) {
+		return "feedback";
+	}
+
+	if ( score <= 4 ) {
+		return "bad";
+	}
+
+	if ( score > 4 && score <= 7 ) {
+		return "ok";
+	}
+
+	if ( score > 7 ) {
+		return "good";
+	}
+
+	return "";
+};
+
+module.exports = ScoreToRating;

--- a/js/interpreters/scoreToRating.js
+++ b/js/interpreters/scoreToRating.js
@@ -1,4 +1,9 @@
-
+/**
+ * Interpreters a score and gives it a particular rating.
+ * @param {Number} score The score to interpreter.
+ * @returns {string} The rating, given based on the score.
+ * @constructor
+ */
 var ScoreToRating = function( score ) {
 	if ( score === 0 ) {
 		return "feedback";

--- a/js/interpreters/scoreToRating.js
+++ b/js/interpreters/scoreToRating.js
@@ -5,6 +5,7 @@
  * @constructor
  */
 var ScoreToRating = function( score ) {
+
 	if ( score === 0 ) {
 		return "feedback";
 	}

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -7,7 +7,7 @@ var isUndefined = require( "lodash/isUndefined" );
 var difference = require( "lodash/difference" );
 var template = require( "../templates.js" ).assessmentPresenterResult;
 var scoreToRating = require( "../interpreters/scoreToRating.js" );
-var config = require( "../config/presenter.js" );
+var createConfig = require( "../config/presenter.js" );
 
 /**
  * Constructs the AssessorPresenter.
@@ -27,7 +27,7 @@ var AssessorPresenter = function( args ) {
 	this.i18n = args.i18n;
 	this.output = args.targets.output;
 	this.overall = args.targets.overall || "overallScore";
-	this.presenterConfig = config( args.i18n );
+	this.presenterConfig = createConfig( args.i18n );
 };
 
 /**

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -2,6 +2,7 @@
 
 var forEach = require( "lodash/forEach" );
 var isNumber = require( "lodash/isNumber" );
+var isObject = require( "lodash/isObject" );
 var isUndefined = require( "lodash/isUndefined" );
 var difference = require( "lodash/difference" );
 var template = require( "../templates.js" ).assessmentPresenterResult;
@@ -82,6 +83,10 @@ AssessorPresenter.prototype.getIndicatorScreenReaderText = function( rating ) {
  * @returns {Object} The Assessment result object with the rating added.
  */
 AssessorPresenter.prototype.resultToRating = function( result ) {
+	if ( !isObject( result ) ) {
+		return "";
+	}
+
 	result.rating = scoreToRating( result.score );
 
 	return result;
@@ -157,20 +162,20 @@ AssessorPresenter.prototype.addRating = function( item ) {
 /**
  * Calculates the overall rating score based on the overall score.
  * @param {Number} overallScore The overall score to use in the calculation.
- * @returns {Number} The rating score.
+ * @returns {Object} The rating based on the score.
  */
 AssessorPresenter.prototype.getOverallRating = function( overallScore ) {
 	var rating = 0;
 
 	if ( this.keyword === "" ) {
-		return rating;
+		return this.resultToRating( { score: rating } );
 	}
 
 	if ( isNumber( overallScore ) ) {
 		rating = ( overallScore / 10 );
 	}
 
-	return rating;
+	return this.resultToRating( { score: rating } );
 };
 
 /**
@@ -196,15 +201,14 @@ AssessorPresenter.prototype.renderIndividualRatings = function() {
  * Renders out the overall rating.
  */
 AssessorPresenter.prototype.renderOverallRating = function() {
-	var overallScore = this.getOverallRating( this.assessor.calculateOverallScore() );
-	var rating = this.resultToRating( { score: overallScore } );
+	var overallRating = this.getOverallRating( this.assessor.calculateOverallScore() );
 	var overallRatingElement = document.getElementById( this.overall );
 
 	if ( !overallRatingElement ) {
 		return;
 	}
 
-	overallRatingElement.className = "overallScore " + this.getIndicatorColorClass( rating.rating );
+	overallRatingElement.className = "overallScore " + this.getIndicatorColorClass( overallRating.rating );
 };
 
 module.exports = AssessorPresenter;

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -5,25 +5,8 @@ var isNumber = require( "lodash/isNumber" );
 var isUndefined = require( "lodash/isUndefined" );
 var difference = require( "lodash/difference" );
 var template = require( "../templates.js" ).assessmentPresenterResult;
-
-var presenterConfig = {
-	feedback: {
-		class: "na",
-		screenReaderText: "Feedback"
-	},
-	bad: {
-		class: "bad",
-		screenReaderText: "Bad SEO score"
-	},
-	ok: {
-		class: "ok",
-		screenReaderText: "Ok SEO score"
-	},
-	good: {
-		class: "good",
-		screenReaderText: "Good SEO score"
-	}
-};
+var scoreToRating = require( "../interpreters/scoreToRating.js" );
+var config = require( "../config/presenter.js" );
 
 /**
  * Constructs the AssessorPresenter.
@@ -43,6 +26,7 @@ var AssessorPresenter = function( args ) {
 	this.i18n = args.i18n;
 	this.output = args.targets.output;
 	this.overall = args.targets.overall || "overallScore";
+	this.presenterConfig = config( args.i18n );
 };
 
 /**
@@ -51,7 +35,7 @@ var AssessorPresenter = function( args ) {
  * @returns {boolean} Whether or not the property exists.
  */
 AssessorPresenter.prototype.configHasProperty = function( property ) {
-	return presenterConfig.hasOwnProperty( property );
+	return this.presenterConfig.hasOwnProperty( property );
 };
 
 /**
@@ -76,7 +60,7 @@ AssessorPresenter.prototype.getIndicatorColorClass = function( rating ) {
 		return "";
 	}
 
-	return presenterConfig[ rating ].class;
+	return this.presenterConfig[ rating ].class;
 };
 
 /**
@@ -89,7 +73,7 @@ AssessorPresenter.prototype.getIndicatorScreenReaderText = function( rating ) {
 		return "";
 	}
 
-	return this.i18n.dgettext( "js-text-analysis", presenterConfig[ rating ].screenReaderText );
+	return this.presenterConfig[ rating ].screenReaderText;
 };
 
 /**
@@ -98,31 +82,7 @@ AssessorPresenter.prototype.getIndicatorScreenReaderText = function( rating ) {
  * @returns {Object} The Assessment result object with the rating added.
  */
 AssessorPresenter.prototype.resultToRating = function( result ) {
-	result.rating = "";
-
-	if ( result.score === 0 ) {
-		result.rating = "feedback";
-
-		return result;
-	}
-
-	if ( result.score <= 4 ) {
-		result.rating = "bad";
-
-		return result;
-	}
-
-	if ( result.score > 4 && result.score <= 7 ) {
-		result.rating = "ok";
-
-		return result;
-	}
-
-	if ( result.score > 7 ) {
-		result.rating = "good";
-
-		return result;
-	}
+	result.rating = scoreToRating( result.score );
 
 	return result;
 };

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -57,7 +57,7 @@ AssessorPresenter.prototype.configHasProperty = function( property ) {
 /**
  * Gets a fully formatted indicator object that can be used.
  * @param {string} rating The rating to use.
- * @returns {Object} An object containing
+ * @returns {Object} An object containing the class and screen reader text.
  */
 AssessorPresenter.prototype.getIndicator = function( rating ) {
 	return {
@@ -66,6 +66,11 @@ AssessorPresenter.prototype.getIndicator = function( rating ) {
 	};
 };
 
+/**
+ * Gets the indicator color class from the presenter configuration, if it exists.
+ * @param {string} rating The rating to check against the config.
+ * @returns {string} String containing the CSS class to be used.
+ */
 AssessorPresenter.prototype.getIndicatorColorClass = function( rating ) {
 	if ( !this.configHasProperty( rating ) ) {
 		return "";
@@ -74,6 +79,11 @@ AssessorPresenter.prototype.getIndicatorColorClass = function( rating ) {
 	return presenterConfig[ rating ].class;
 };
 
+/**
+ * Get the indicator screen reader text from the presenter configuration, if it exists.
+ * @param {string} rating The rating to check against the config.
+ * @returns {string} Translated string containing the screen reader text to be used.
+ */
 AssessorPresenter.prototype.getIndicatorScreenReaderText = function( rating ) {
 	if ( !this.configHasProperty( rating ) ) {
 		return "";
@@ -82,6 +92,11 @@ AssessorPresenter.prototype.getIndicatorScreenReaderText = function( rating ) {
 	return this.i18n.dgettext( "js-text-analysis", presenterConfig[ rating ].screenReaderText );
 };
 
+/**
+ * Adds a rating based on the numeric score.
+ * @param {Object} result Object based on the Assessment result. Requires a score property to work.
+ * @returns {Object} The Assessment result object with the rating added.
+ */
 AssessorPresenter.prototype.resultToRating = function( result ) {
 	result.rating = "";
 
@@ -112,6 +127,10 @@ AssessorPresenter.prototype.resultToRating = function( result ) {
 	return result;
 };
 
+/**
+ *
+ * @returns {{}}
+ */
 AssessorPresenter.prototype.getIndividualRatings = function() {
 	var ratings = {};
 	var validResults = this.sort( this.assessor.getValidResults() );

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -1,0 +1,192 @@
+/* jshint browser: true */
+
+var forEach = require( "lodash/forEach" );
+var isNumber = require( "lodash/isNumber" );
+var isUndefined = require( "lodash/isUndefined" );
+var difference = require( "lodash/difference" );
+var template = require( "../templates.js" ).assessmentPresenterResult;
+
+var presenterConfig = {
+	feedback: {
+		class: "na",
+		screenReaderText: "Feedback"
+	},
+	bad: {
+		class: "bad",
+		screenReaderText: "Bad SEO score"
+	},
+	ok: {
+		class: "ok",
+		screenReaderText: "Ok SEO score"
+	},
+	good: {
+		class: "good",
+		screenReaderText: "Good SEO score"
+	}
+};
+
+/**
+ * Constructs the AssessorPresenter.
+ *
+ * @param {App} args
+ * @param {object} args.targets
+ * @param {string} args.targets.output
+ * @param {string} args.targets.overall
+ * @param {string} args.keyword
+ * @param {Assessor} args.assessor
+ * @param {Jed} args.i18n
+ * @constructor
+ */
+var AssessorPresenter = function( args ) {
+	this.keyword = args.keyword;
+	this.assessor = args.assessor;
+	this.i18n = args.i18n;
+	this.output = args.targets.output;
+	this.overall = args.targets.overall || "overallScore";
+};
+
+/**
+ * Checks whether or not a specific property exists in the presenter configuration.
+ * @param {string} property The property name to search for.
+ * @returns {boolean} Whether or not the property exists.
+ */
+AssessorPresenter.prototype.configHasProperty = function( property ) {
+	return presenterConfig.hasOwnProperty( property );
+};
+
+/**
+ * Gets a fully formatted indicator object that can be used.
+ * @param {string} rating The rating to use.
+ * @returns {Object} An object containing
+ */
+AssessorPresenter.prototype.getIndicator = function( rating ) {
+	return {
+		class: this.getIndicatorColorClass( rating ),
+		screenReaderText: this.getIndicatorScreenReaderText( rating )
+	};
+};
+
+AssessorPresenter.prototype.getIndicatorColorClass = function( rating ) {
+	if ( !this.configHasProperty( rating ) ) {
+		return "";
+	}
+
+	return presenterConfig[ rating ].class;
+};
+
+AssessorPresenter.prototype.getIndicatorScreenReaderText = function( rating ) {
+	if ( !this.configHasProperty( rating ) ) {
+		return "";
+	}
+
+	return this.i18n.dgettext( "js-text-analysis", presenterConfig[ rating ].screenReaderText );
+};
+
+AssessorPresenter.prototype.resultToRating = function( result ) {
+	result.rating = "";
+
+	if ( result.score === 0 ) {
+		result.rating = "feedback";
+
+		return result;
+	}
+
+	if ( result.score <= 4 ) {
+		result.rating = "bad";
+
+		return result;
+	}
+
+	if ( result.score > 4 && result.score <= 7 ) {
+		result.rating = "ok";
+
+		return result;
+	}
+
+	if ( result.score > 7 ) {
+		result.rating = "good";
+
+		return result;
+	}
+
+	return result;
+};
+
+AssessorPresenter.prototype.getIndividualRatings = function() {
+	var ratings = {};
+	var validResults = this.sort( this.assessor.getValidResults() );
+	var mappedResults = validResults.map( this.resultToRating );
+
+	forEach( mappedResults, function( item, key ) {
+		ratings[ key ] = this.addRating( item );
+	}.bind( this ) );
+
+	return ratings;
+};
+
+AssessorPresenter.prototype.sort = function ( results ) {
+	var unsortables = this.getUndefinedScores( results );
+	var sortables = difference( results, unsortables );
+
+	sortables.sort( function( a, b ) {
+		return a.score - b.score;
+	} );
+
+	return unsortables.concat( sortables );
+};
+
+AssessorPresenter.prototype.getUndefinedScores = function ( results ) {
+	var undefinedScores = results.filter( function( result ) {
+		return isUndefined( result.score ) || result.score === 0;
+	} );
+
+	return undefinedScores;
+};
+
+AssessorPresenter.prototype.addRating = function( item ) {
+	var indicator = this.getIndicator( item.rating );
+	indicator.text = item.text;
+
+	return indicator;
+};
+
+AssessorPresenter.prototype.getOverallRating = function( overallScore ) {
+	var rating = 0;
+
+	if ( this.keyword === "" ) {
+		return rating;
+	}
+
+	if ( isNumber( overallScore ) ) {
+		rating = ( overallScore / 10 );
+	}
+
+	return rating;
+};
+
+AssessorPresenter.prototype.render = function() {
+	this.renderIndividualRatings();
+	this.renderOverallRating();
+};
+
+AssessorPresenter.prototype.renderIndividualRatings = function() {
+	var outputTarget = document.getElementById( this.output );
+
+	outputTarget.innerHTML = template( {
+		scores: this.getIndividualRatings()
+	} );
+};
+
+AssessorPresenter.prototype.renderOverallRating = function() {
+	var overallScore = this.getOverallRating( this.assessor.calculateOverallScore() );
+	var rating = this.resultToRating( { score: overallScore } );
+	var overallRatingElement = document.getElementById( this.overall );
+
+	if ( !overallRatingElement ) {
+		return;
+	}
+
+	overallRatingElement.className = "overallScore " + this.getIndicatorColorClass( rating.rating );
+};
+
+module.exports = AssessorPresenter;

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -140,11 +140,9 @@ AssessorPresenter.prototype.sort = function ( results ) {
  * @returns {Array} A subset of results containing items with an undefined score or where the score is zero.
  */
 AssessorPresenter.prototype.getUndefinedScores = function ( results ) {
-	var undefinedScores = results.filter( function( result ) {
+	return results.filter( function( result ) {
 		return isUndefined( result.score ) || result.score === 0;
 	} );
-
-	return undefinedScores;
 };
 
 /**

--- a/js/templates.js
+++ b/js/templates.js
@@ -276,11 +276,11 @@
   /*----------------------------------------------------------------------------*/
 
   var templates = {
-    'scoreResult': {},
+    'assessmentPresenterResult': {},
     'snippetEditor': {}
   };
 
-  templates['scoreResult'] =   function(obj) {
+  templates['assessmentPresenterResult'] =   function(obj) {
     obj || (obj = {});
     var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
     function print() { __p += __j.call(arguments, '') }
@@ -288,9 +288,9 @@
     __p += '<ul class="wpseoanalysis">\n    ';
      for (var i in scores) {
     __p += '\n        <li class="score">\n            <span class="wpseo-score-icon ' +
-    __e( scores[ i ].rating ) +
+    __e( scores[ i ].class ) +
     '"></span>\n            <span class="screen-reader-text">' +
-    ((__t = ( scores[ i ].screenreaderText )) == null ? '' : __t) +
+    ((__t = ( scores[ i ].screenReaderText )) == null ? '' : __t) +
     '</span>\n            <span class="wpseo-score-text">' +
     ((__t = ( scores[ i ].text )) == null ? '' : __t) +
     '</span>\n        </li>\n    ';

--- a/spec/renderers/AssessorPresenterSpec.js
+++ b/spec/renderers/AssessorPresenterSpec.js
@@ -1,0 +1,66 @@
+var AssessorPresenter = require( "../../js/renderers/AssessorPresenter.js" );
+var Factory = require( "../helpers/factory.js" );
+
+describe("A function to transform a textual score into a description", function() {
+	AssessorPresenter.prototype.outputScore = function() {};
+	AssessorPresenter.prototype.outputOverallScore = function() {};
+
+	var i18n = Factory.buildJed();
+
+	var assessorPresenter = new AssessorPresenter({
+		scorer: { __score: [], __totalScore: 0 },
+		targets: { output: "", overall: "" },
+		keyword: "",
+		assessor: {},
+		i18n: i18n
+	});
+
+	it("should know how to transform the score", function() {
+		expect( assessorPresenter.resultToRating( { score: 0 } ).rating ).toBe( "feedback" );
+		expect( assessorPresenter.resultToRating( { score: 1 } ).rating ).toBe( "bad" );
+		expect( assessorPresenter.resultToRating( { score: 5 } ).rating ).toBe( "ok" );
+		expect( assessorPresenter.resultToRating( { score: 8 } ).rating ).toBe( "good" );
+	});
+
+	it("should return an empty string with invalid scores", function() {
+		expect( assessorPresenter.resultToRating( "" ) ).toEqual( "" );
+		expect( assessorPresenter.resultToRating( "some invalid string" ) ).toEqual( "" );
+	})
+});
+
+describe("A function to transform a numeric overall score into a textual score", function() {
+	var i18n = Factory.buildJed();
+
+	var assessorPresenter = new AssessorPresenter({
+		scorer: { __score: [], __totalScore: 0 },
+		targets: { output: "", overall: "" },
+		keyword: "Keyword",
+		i18n: i18n,
+		assessor: {}
+	});
+
+	var expectations = [
+		[ 0, 'feedback', "Feedback" ],
+		[ 1, 'bad', "Bad SEO score" ],
+		[ 23, 'bad', "Bad SEO score" ],
+		[ 40, 'bad', "Bad SEO score" ],
+		[ 41, 'ok', "Ok SEO score" ],
+		[ 55, 'ok', "Ok SEO score" ],
+		[ 70, 'ok', "Ok SEO score" ],
+		[ 71, 'good', "Good SEO score" ],
+		[ 83, 'good', "Good SEO score" ],
+		[ 100, 'good', "Good SEO score" ]
+	];
+
+	it("should know how to transform the score", function() {
+		expectations.forEach( function( item ) {
+			expect( assessorPresenter.getOverallRating( item[0] ).rating ).toBe( item[1] );
+		});
+	})
+
+	it("should know how to transform the score and retrieve the proper translation from config", function() {
+		expectations.forEach( function( item ) {
+			expect( assessorPresenter.getIndicatorScreenReaderText( assessorPresenter.getOverallRating( item[0] ).rating ) ).toBe( item[ 2 ] );
+		});
+	})
+});

--- a/spec/renderers/AssessorPresenterSpec.js
+++ b/spec/renderers/AssessorPresenterSpec.js
@@ -1,66 +1,104 @@
 var AssessorPresenter = require( "../../js/renderers/AssessorPresenter.js" );
+var AssessmentResult = require( "../../js/values/AssessmentResult" );
 var Factory = require( "../helpers/factory.js" );
 
-describe("A function to transform a textual score into a description", function() {
-	AssessorPresenter.prototype.outputScore = function() {};
-	AssessorPresenter.prototype.outputOverallScore = function() {};
+describe( "an AssessorPresenter", function() {
+	var i18n;
+	var assessorPresenter;
 
-	var i18n = Factory.buildJed();
+	beforeEach( function() {
+		i18n = Factory.buildJed();
+		assessorPresenter = new AssessorPresenter( {
+			scorer: { __score: [], __totalScore: 0 },
+			targets: { output: "", overall: "" },
+			keyword: "",
+			assessor: {},
+			i18n: i18n
+		} );
+	} );
 
-	var assessorPresenter = new AssessorPresenter({
-		scorer: { __score: [], __totalScore: 0 },
-		targets: { output: "", overall: "" },
-		keyword: "",
-		assessor: {},
-		i18n: i18n
-	});
 
-	it("should know how to transform the score", function() {
-		expect( assessorPresenter.resultToRating( { score: 0 } ).rating ).toBe( "feedback" );
-		expect( assessorPresenter.resultToRating( { score: 1 } ).rating ).toBe( "bad" );
-		expect( assessorPresenter.resultToRating( { score: 5 } ).rating ).toBe( "ok" );
-		expect( assessorPresenter.resultToRating( { score: 8 } ).rating ).toBe( "good" );
-	});
+	describe("A function to transform a textual score into a description", function() {
+		AssessorPresenter.prototype.outputScore = function() {};
+		AssessorPresenter.prototype.outputOverallScore = function() {};
 
-	it("should return an empty string with invalid scores", function() {
-		expect( assessorPresenter.resultToRating( "" ) ).toEqual( "" );
-		expect( assessorPresenter.resultToRating( "some invalid string" ) ).toEqual( "" );
-	})
-});
-
-describe("A function to transform a numeric overall score into a textual score", function() {
-	var i18n = Factory.buildJed();
-
-	var assessorPresenter = new AssessorPresenter({
-		scorer: { __score: [], __totalScore: 0 },
-		targets: { output: "", overall: "" },
-		keyword: "Keyword",
-		i18n: i18n,
-		assessor: {}
-	});
-
-	var expectations = [
-		[ 0, 'feedback', "Feedback" ],
-		[ 1, 'bad', "Bad SEO score" ],
-		[ 23, 'bad', "Bad SEO score" ],
-		[ 40, 'bad', "Bad SEO score" ],
-		[ 41, 'ok', "Ok SEO score" ],
-		[ 55, 'ok', "Ok SEO score" ],
-		[ 70, 'ok', "Ok SEO score" ],
-		[ 71, 'good', "Good SEO score" ],
-		[ 83, 'good', "Good SEO score" ],
-		[ 100, 'good', "Good SEO score" ]
-	];
-
-	it("should know how to transform the score", function() {
-		expectations.forEach( function( item ) {
-			expect( assessorPresenter.getOverallRating( item[0] ).rating ).toBe( item[1] );
+		it("should know how to transform the score", function() {
+			expect( assessorPresenter.resultToRating( { score: 0 } ).rating ).toBe( "feedback" );
+			expect( assessorPresenter.resultToRating( { score: 1 } ).rating ).toBe( "bad" );
+			expect( assessorPresenter.resultToRating( { score: 5 } ).rating ).toBe( "ok" );
+			expect( assessorPresenter.resultToRating( { score: 8 } ).rating ).toBe( "good" );
 		});
-	})
 
-	it("should know how to transform the score and retrieve the proper translation from config", function() {
-		expectations.forEach( function( item ) {
-			expect( assessorPresenter.getIndicatorScreenReaderText( assessorPresenter.getOverallRating( item[0] ).rating ) ).toBe( item[ 2 ] );
+		it("should return an empty string with invalid scores", function() {
+			expect( assessorPresenter.resultToRating( "" ) ).toEqual( "" );
+			expect( assessorPresenter.resultToRating( "some invalid string" ) ).toEqual( "" );
+		})
+	});
+
+	describe("A function to transform a numeric overall score into a textual score", function() {
+		var expectations = [
+			[ 0, 'feedback', "Feedback" ],
+			[ 1, 'bad', "Bad SEO score" ],
+			[ 23, 'bad', "Bad SEO score" ],
+			[ 40, 'bad', "Bad SEO score" ],
+			[ 41, 'ok', "Ok SEO score" ],
+			[ 55, 'ok', "Ok SEO score" ],
+			[ 70, 'ok', "Ok SEO score" ],
+			[ 71, 'good', "Good SEO score" ],
+			[ 83, 'good', "Good SEO score" ],
+			[ 100, 'good', "Good SEO score" ]
+		];
+
+		beforeEach( function() {
+			assessorPresenter.keyword = "keyword";
+		});
+
+		it("should know how to transform the score", function() {
+			expectations.forEach( function( item ) {
+				expect( assessorPresenter.getOverallRating( item[0] ).rating ).toBe( item[1] );
+			});
+		});
+
+		it("should know how to transform the score and retrieve the proper translation from config", function() {
+			expectations.forEach( function( item ) {
+				expect( assessorPresenter.getIndicatorScreenReaderText( assessorPresenter.getOverallRating( item[0] ).rating ) ).toBe( item[ 2 ] );
+			});
+		});
+
+		it( "should rate a paper without a keyword as na (no keyword)", function() {
+			assessorPresenter.keyword = "";
+
+			expect( assessorPresenter.getOverallRating( 41 ).rating ).toBe( "feedback" );
+		});
+
+		it( "should gracefully deal with invalid scores", function() {
+			expect( assessorPresenter.getOverallRating( false ).rating ).toBe( "feedback" );
+		});
+	});
+
+	describe( "assessment result sorting", function() {
+		var result1, result2;
+
+		beforeEach( function() {
+			result1 = new AssessmentResult();
+			result2 = new AssessmentResult();
+			result1.setScore( 50 );
+			result2.setScore( 25 );
+		});
+
+		it( "should be able to sort assessment results", function() {
+			var assessments = [ result1, result2 ];
+			var expectation = [ result2, result1 ];
+
+			expect( assessorPresenter.sort( assessments ) ).toEqual( expectation );
+		});
+
+		it( "should order undefined results lower than defined results", function() {
+			var result3 = new AssessmentResult();
+			var assessments = [ result1, result2, result3 ];
+			var expectation = [ result3, result2, result1 ];
+
+			expect( assessorPresenter.sort( assessments ) ).toEqual( expectation );
 		});
 	})
 });

--- a/templates/assessmentPresenterResult.jst
+++ b/templates/assessmentPresenterResult.jst
@@ -1,8 +1,8 @@
 <ul class="wpseoanalysis">
     <% for (var i in scores) { %>
         <li class="score">
-            <span class="wpseo-score-icon <%- scores[ i ].rating %>"></span>
-            <span class="screen-reader-text"><%= scores[ i ].screenreaderText %></span>
+            <span class="wpseo-score-icon <%- scores[ i ].class %>"></span>
+            <span class="screen-reader-text"><%= scores[ i ].screenReaderText %></span>
             <span class="wpseo-score-text"><%= scores[ i ].text %></span>
         </li>
     <% } %>


### PR DESCRIPTION
This PR introduces an AssessorPresenter class for generating the ratings (both the individual and overall rating) and thus deprecates ScoreFormatter.

This also splits off some of the scoring code into its own module, allowing it to be used throughout the entire code base, if necessary.

Fixes #400