### PR TITLE
Adds keyword requirement for used keywords plugin

### DIFF
--- a/js/bundledPlugins/previouslyUsedKeywords.js
+++ b/js/bundledPlugins/previouslyUsedKeywords.js
@@ -33,7 +33,12 @@ var PreviouslyUsedKeyword = function( app, args ) {
  * Registers the assessment with the assessor.
  */
 PreviouslyUsedKeyword.prototype.registerPlugin = function() {
-	this.app.registerAssessment( "usedKeywords", { getResult: this.assess.bind( this ), isApplicable: function( paper ){ return paper.hasKeyword() } }, "previouslyUsedKeywords" );
+	this.app.registerAssessment( "usedKeywords", {
+		getResult: this.assess.bind( this ),
+		isApplicable: function( paper ) {
+			return paper.hasKeyword();
+		}
+	}, "previouslyUsedKeywords" );
 };
 
 /**

--- a/js/bundledPlugins/previouslyUsedKeywords.js
+++ b/js/bundledPlugins/previouslyUsedKeywords.js
@@ -33,7 +33,7 @@ var PreviouslyUsedKeyword = function( app, args ) {
  * Registers the assessment with the assessor.
  */
 PreviouslyUsedKeyword.prototype.registerPlugin = function() {
-	this.app.registerAssessment( "usedKeywords", { getResult: this.assess.bind( this ) }, "previouslyUsedKeywords" );
+	this.app.registerAssessment( "usedKeywords", { getResult: this.assess.bind( this ), isApplicable: function( paper ){ return paper.hasKeyword() } }, "previouslyUsedKeywords" );
 };
 
 /**


### PR DESCRIPTION
The previously used keywords plugin in the bundled plugins was always fired because there was no isApplicable set to this assessment. 

Added this so it will only trigger when keyword is present. 

Fixes #421