### PR TITLE
Remove %% from the text strings

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -5,37 +5,69 @@ var inRange = require( "lodash/inRange" );
 
 /**
  * Returns the scores and text for keyword density
+ *
  * @param {string} keywordDensity The keyword density
  * @param {object} i18n The i18n object used for translations
- * @returns {{score: number, text: *}} the assessmentresult
+ * @param {number} keywordCount The number of times the keyword has been found in the text.
+ * @returns {{score: number, text: *}} The assessment result
  */
-var calculateKeywordDensityResult = function( keywordDensity, i18n ) {
+var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount ) {
+	var score, text, max;
+
+	var keywordDensityPercentage = keywordDensity.toFixed( 1 ) + '%';
+
 	if ( keywordDensity > 3.5 ) {
-		return {
-			score: -50,
-			text: i18n.dgettext( "js-text-analysis", "The keyword density is %1$s%%, which is way over the advised 2.5%% maximum;" +
-				" the focus keyword was found %2$d times." )
-		};
+		score = -50;
+
+		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count, %3$s expands to the maximum keyword density percentage. */
+		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
+			" which is way over the advised %3$s maximum;" +
+			" the focus keyword was found %2$d times." );
+
+		/* translators: This is the maximum keyword density, localize the number for your language (e.g. 2,5) */
+		max = i18n.dgettext( "js-text-analysis", "2.5" ) + '%';
+
+		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}
+
 	if ( inRange( keywordDensity, 2.5, 3.5 ) ) {
-		return {
-			score: -10,
-			text: i18n.dgettext( "js-text-analysis", "The keyword density is %1$s%%, which is over the advised 2.5%% maximum;" +
-				" the focus keyword was found %2$d times." )
-		};
+		score = -10;
+
+		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count, %3$s expands to the maximum keyword density percentage. */
+		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
+			" which is over the advised %3$s maximum;" +
+			" the focus keyword was found %2$d times." );
+
+		/* translators: This is the maximum keyword density, localize the number for your language (e.g. 2,5) */
+		max = i18n.dgettext( "js-text-analysis", "2.5" ) + '%';
+
+		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}
+
 	if ( inRange( keywordDensity, 0.5, 2.5 ) ) {
-		return {
-			score: 9,
-			text: i18n.dgettext( "js-text-analysis", "The keyword density is %1$s%%, which is great; the focus keyword was found %2$d times." )
-		};
+		score = 9;
+
+		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
+		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is great;" +
+			" the focus keyword was found %2$d times." );
+
+		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
 	}
+
 	if ( inRange( keywordDensity, 0, 0.5 ) ) {
-		return {
-			score: 4,
-			text: i18n.dgettext( "js-text-analysis", "The keyword density is %1$s%%, which is a bit low; the focus keyword was found %2$d times." )
-		};
+		score = 4;
+
+		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
+		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is a bit low;" +
+			" the focus keyword was found %2$d times." );
+
+		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
 	}
+
+	return {
+		score: score,
+		text: text
+	};
 };
 
 /**
@@ -50,13 +82,12 @@ var keywordDensityAssessment = function( paper, researcher, i18n ) {
 
 	var keywordDensity = researcher.getResearch( "getKeywordDensity" );
 	var keywordCount = matchWords( paper.getText(), paper.getKeyword() );
-	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n );
+
+	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n, keywordCount );
 	var assessmentResult = new AssessmentResult();
 
-	var text = i18n.sprintf( keywordDensityResult.text, keywordDensity.toFixed( 1 ), keywordCount );
-
 	assessmentResult.setScore( keywordDensityResult.score );
-	assessmentResult.setText( text );
+	assessmentResult.setText( keywordDensityResult.text );
 
 	return assessmentResult;
 };

--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -14,18 +14,19 @@ var inRange = require( "lodash/inRange" );
 var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount ) {
 	var score, text, max;
 
-	var keywordDensityPercentage = keywordDensity.toFixed( 1 ) + '%';
+	var keywordDensityPercentage = keywordDensity.toFixed( 1 ) + "%";
 
 	if ( keywordDensity > 3.5 ) {
 		score = -50;
 
-		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count, %3$s expands to the maximum keyword density percentage. */
+		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
+		%3$s expands to the maximum keyword density percentage. */
 		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
 			" which is way over the advised %3$s maximum;" +
 			" the focus keyword was found %2$d times." );
 
 		/* translators: This is the maximum keyword density, localize the number for your language (e.g. 2,5) */
-		max = i18n.dgettext( "js-text-analysis", "2.5" ) + '%';
+		max = i18n.dgettext( "js-text-analysis", "2.5" ) + "%";
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}
@@ -33,13 +34,14 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 	if ( inRange( keywordDensity, 2.5, 3.5 ) ) {
 		score = -10;
 
-		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count, %3$s expands to the maximum keyword density percentage. */
+		/* translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
+		%3$s expands to the maximum keyword density percentage. */
 		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
 			" which is over the advised %3$s maximum;" +
 			" the focus keyword was found %2$d times." );
 
 		/* translators: This is the maximum keyword density, localize the number for your language (e.g. 2,5) */
-		max = i18n.dgettext( "js-text-analysis", "2.5" ) + '%';
+		max = i18n.dgettext( "js-text-analysis", "2.5" ) + "%";
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}

--- a/languages/yoast-seo.pot
+++ b/languages/yoast-seo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yoastseo 1.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-19 16:54+0200\n"
+"POT-Creation-Date: 2016-04-21 13:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,28 +84,40 @@ msgstr ""
 msgid "Your keyphrase is over 10 words, a keyphrase should be shorter."
 msgstr ""
 
-#: js/assessments/keywordDensityAssessment.js:16
+#. translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
+#. %3$s expands to the maximum keyword density percentage.
+#: js/assessments/keywordDensityAssessment.js:24
 msgid ""
-"The keyword density is %1$s%%, which is way over the advised 2.5%% maximum; "
-"the focus keyword was found %2$d times."
-msgstr ""
-
-#: js/assessments/keywordDensityAssessment.js:23
-msgid ""
-"The keyword density is %1$s%%, which is over the advised 2.5%% maximum; the "
+"The keyword density is %1$s, which is way over the advised %3$s maximum; the "
 "focus keyword was found %2$d times."
 msgstr ""
 
-#: js/assessments/keywordDensityAssessment.js:30
+#. translators: This is the maximum keyword density, localize the number for your language (e.g. 2,5)
+#: js/assessments/keywordDensityAssessment.js:29
+#: js/assessments/keywordDensityAssessment.js:44
+msgid "2.5"
+msgstr ""
+
+#. translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
+#. %3$s expands to the maximum keyword density percentage.
+#: js/assessments/keywordDensityAssessment.js:39
 msgid ""
-"The keyword density is %1$s%%, which is great; the focus keyword was found "
+"The keyword density is %1$s, which is over the advised %3$s maximum; the "
+"focus keyword was found %2$d times."
+msgstr ""
+
+#. translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count.
+#: js/assessments/keywordDensityAssessment.js:53
+msgid ""
+"The keyword density is %1$s, which is great; the focus keyword was found "
 "%2$d times."
 msgstr ""
 
-#: js/assessments/keywordDensityAssessment.js:36
+#. translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count.
+#: js/assessments/keywordDensityAssessment.js:63
 msgid ""
-"The keyword density is %1$s%%, which is a bit low; the focus keyword was "
-"found %2$d times."
+"The keyword density is %1$s, which is a bit low; the focus keyword was found "
+"%2$d times."
 msgstr ""
 
 #: js/assessments/keywordStopWordsAssessment.js:17


### PR DESCRIPTION
It is very confusing for translators to have to keep the double
percentage-signs in the string and this has bitten us in the 3.2 release
of Yoast SEO.