### PR TITLE
Adds subheading presence

### DIFF
--- a/js/assessments/subheadingPresenceAssessment.js
+++ b/js/assessments/subheadingPresenceAssessment.js
@@ -1,0 +1,51 @@
+var AssessmentResult = require( "../values/AssessmentResult.js" );
+
+var calculateSubheadingPresenceResult = function( subheadingPresence, i18n ) {
+	if( subheadingPresence > 0 ) {
+		return {
+			score: 9,
+
+			// translators: %1$d expands to the number of subheadings
+			text: i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					"The text contains %1$d subheading, which is great.",
+					"The text contains %1$d subheadings, which is great.",
+					subheadingPresence
+				), subheadingPresence
+			)
+		};
+	}
+
+	return {
+		score: 3,
+		text: i18n.dgettext( "js-text-analysis", "The text does not contain any subheadings. Add at least one subheading." )
+	};
+};
+
+/**
+ * Runs the getSubheadingLength research and checks scores based on length.
+ *
+ * @param {Paper} paper The paper to use for the assessment.
+ * @param {object} researcher The researcher used for calling research.
+ * @param {object} i18n The object used for translations.
+ * @returns {object} The Assessmentresult
+ */
+var getSubheadingPresence = function( paper, researcher, i18n ) {
+	var subheadingPresence = researcher.getResearch( "getSubheadingPresence" );
+	var result = calculateSubheadingPresenceResult( subheadingPresence, i18n );
+	var assessmentResult = new AssessmentResult();
+
+	assessmentResult.setScore( result.score );
+	assessmentResult.setText( result.text );
+
+	return assessmentResult;
+};
+
+module.exports = {
+	getResult: getSubheadingPresence,
+	isApplicable: function( paper ) {
+		return paper.hasText();
+	}
+};
+

--- a/js/assessments/subheadingPresenceAssessment.js
+++ b/js/assessments/subheadingPresenceAssessment.js
@@ -1,7 +1,7 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 
 /**
- * Returns the score based on the number of subheadings found. 
+ * Returns the score based on the number of subheadings found.
  * @param {number} subheadingPresence The number of subheadings found.
  * @param {object} i18n The object used for translations.
  * @returns {Object} An object with values for the assessment result.

--- a/js/assessments/subheadingPresenceAssessment.js
+++ b/js/assessments/subheadingPresenceAssessment.js
@@ -1,5 +1,11 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 
+/**
+ * Returns the score based on the number of subheadings found. 
+ * @param {number} subheadingPresence The number of subheadings found.
+ * @param {object} i18n The object used for translations.
+ * @returns {Object} An object with values for the assessment result.
+ */
 var calculateSubheadingPresenceResult = function( subheadingPresence, i18n ) {
 	if( subheadingPresence > 0 ) {
 		return {

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -2,6 +2,7 @@ var Assessor = require( "./assessor.js" );
 
 var fleschReadingEase = require( "./assessments/fleschReadingEaseAssessment.js" );
 var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
+var subheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
 
 /**
  * Creates the Assessor
@@ -13,7 +14,8 @@ var ContentAssessor = function( i18n ) {
 	Assessor.call( this, i18n );
 	this._assessments = {
 		fleschReadingEase:		fleschReadingEase,
-		subHeadingLength:		subHeadingLength
+		subHeadingLength:		subHeadingLength,
+		subheadingPresence:	subheadingPresence
 	};
 };
 

--- a/js/researcher.js
+++ b/js/researcher.js
@@ -4,7 +4,7 @@ var MissingArgument = require( "./errors/missingArgument" );
 var isUndefined = require( "lodash/isUndefined" );
 var isEmpty = require( "lodash/isEmpty" );
 
-// assessments
+// Researches
 var wordCountInText = require( "./researches/wordCountInText.js" );
 var getLinkStatistics = require( "./researches/getLinkStatistics.js" );
 var linkCount = require( "./researches/countLinks.js" );
@@ -24,6 +24,7 @@ var keywordCountInUrl = require( "./researches/keywordCountInUrl" );
 var findKeywordInFirstParagraph = require( "./researches/findKeywordInFirstParagraph.js" );
 var pageTitleLength = require( "./researches/pageTitleLength.js" );
 var getSubheadingLength = require( "./researches/getSubheadingLength.js" );
+var getSubheadingPresence = require( "./researches/getSubheadingPresence.js" );
 
 /**
  * This contains all possible, default researches.
@@ -53,7 +54,8 @@ var Researcher = function( paper ) {
 		"firstParagraph": findKeywordInFirstParagraph,
 		"metaDescriptionKeyword": metaDescriptionKeyword,
 		"pageTitleLength": pageTitleLength,
-		"getSubheadingLength": getSubheadingLength
+		"getSubheadingLength": getSubheadingLength,
+		"getSubheadingPresence": getSubheadingPresence
 	};
 
 	this.customResearches = {};

--- a/js/researches/getSubheadingPresence.js
+++ b/js/researches/getSubheadingPresence.js
@@ -1,0 +1,13 @@
+var getSubheadings = require( "../stringProcessing/getSubheadings.js" );
+
+/**
+ * Checks if there is a subheading present in the text
+ * @param {Paper} paper The Paper object to get the text from.
+ * @returns {number} Number of headings found.
+ */
+module.exports = function( paper ) {
+	var text = paper.getText();
+	var headings = getSubheadings( text ) || [];
+	return headings.length;
+};
+

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -35,6 +35,4 @@ describe( "An descriptionLength assessment", function(){
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual ( "In the specified meta description, consider: How does it compare to the competition? Could it be made more appealing?" );
 	} );
-
-
 } );

--- a/spec/assessments/subheadingPresenceSpec.js
+++ b/spec/assessments/subheadingPresenceSpec.js
@@ -1,0 +1,30 @@
+var subheadingPresence = require( "../../js/assessments/subheadingPresenceAssessment.js" );
+var Paper = require( "../../js/values/Paper.js" );
+var Factory = require( "../helpers/factory.js" );
+var i18n = Factory.buildJed();
+
+describe( "Assesses presence of subheadings", function(){
+	it( "assesses no subheadings", function() {
+		var mockPaper = new Paper();
+		var assessment = subheadingPresence.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual ( "The text does not contain any subheadings. Add at least one subheading." );
+	} );
+
+	it( "assesses 1 subheading", function() {
+		var mockPaper = new Paper();
+		var assessment = subheadingPresence.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual ( "The text contains 1 subheading, which is great." );
+	} );
+
+	it( "assesses 1 subheading", function() {
+		var mockPaper = new Paper();
+		var assessment = subheadingPresence.getResult( mockPaper, Factory.buildMockResearcher( 4 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual ( "The text contains 4 subheadings, which is great." );
+	} );
+} );

--- a/spec/researches/getSubheadingPresenceSpec.js
+++ b/spec/researches/getSubheadingPresenceSpec.js
@@ -1,0 +1,25 @@
+var subheadingPresence = require( "../../js/researches/getSubheadingPresence.js" );
+var Paper = require( "../../js/values/Paper.js" );
+
+describe( "checks if there is a subheading in text", function() {
+
+	it( "returns 0", function() {
+		var paper = new Paper( "this is text" );
+		expect( subheadingPresence( paper ) ).toBe( 0 );
+	} );
+
+	it( "returns 1", function() {
+		paper = new Paper( "<h2>this is text</h2>" );
+		expect( subheadingPresence( paper ) ).toBe( 1 );
+	} );
+
+	it( "returns 2", function() {
+		paper = new Paper( "<h2>this is text</h2><h1>this is more text</h1>" );
+		expect( subheadingPresence( paper ) ).toBe( 2 );
+	} );
+
+	it( "returns 0", function() {
+		paper = new Paper( "<h2>this is text</h3>" );
+		expect( subheadingPresence( paper ) ).toBe( 0 );
+	} );
+} );


### PR DESCRIPTION
Fixes #335

Adds the subheading presence to the content assessor. 

For testing, run `grunt build` and test in the browserified example