### PR TITLE
Fixes scoring of alttags

### DIFF
--- a/js/assessments/textImagesAssessment.js
+++ b/js/assessments/textImagesAssessment.js
@@ -25,18 +25,11 @@ var calculateImageCountResult = function( imageCount, i18n ) {
  * @returns {object} The resulting score object.
  */
 var assessImages = function( altProperties, i18n ) {
-	if ( altProperties.noAlt > 0 ) {
+	// Has alt-tag and keywords
+	if ( altProperties.withAltKeyword > 0 ) {
 		return {
-			score: 5,
-			text: i18n.dgettext( "js-text-analysis", "The images on this page are missing alt attributes." )
-		};
-	}
-
-	// Has alt-tag, but no keyword is set
-	if ( altProperties.withAlt > 0 ) {
-		return {
-			score: 5,
-			text: i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes." )
+			score: 9,
+			text: i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes with the focus keyword." )
 		};
 	}
 
@@ -48,11 +41,19 @@ var assessImages = function( altProperties, i18n ) {
 		};
 	}
 
-	// Has alt-tag and keywords
-	if ( altProperties.withAltKeyword > 0 ) {
+	// Has alt-tag, but no keyword is set
+	if ( altProperties.withAlt > 0 ) {
 		return {
-			score: 9,
-			text: i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes with the focus keyword." )
+			score: 5,
+			text: i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes." )
+		};
+	}
+
+	// Has no alt-tag
+	if ( altProperties.noAlt > 0 ) {
+		return {
+			score: 5,
+			text: i18n.dgettext( "js-text-analysis", "The images on this page are missing alt attributes." )
 		};
 	}
 

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -71,4 +71,35 @@ describe( "An image count assessment", function() {
 
 		expect( assessment.getScore() ).toEqual( 9 );
 	} );
+
+	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample"
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			noAlt: 0,
+			withAlt: 0,
+			withAltKeyword: 1,
+			withAltNonKeyword: 1
+		} ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+	} );
+
+	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample"
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			noAlt: 4,
+			withAlt: 0,
+			withAltKeyword: 1,
+			withAltNonKeyword: 1
+		} ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+	} );
+
 } );


### PR DESCRIPTION
When there are multiple images in a text, but only 1 has a keyword, it was reported that images did not have the keyword. Since it isn't necessary for every image to have the keyword in the alt-tag, this pull fixes the order of scoring.