### PR TITLE
Fixed a rounding issue and altered the result text slightly.

### DIFF
--- a/js/assessments/sentenceLengthInTextAssessment.js
+++ b/js/assessments/sentenceLengthInTextAssessment.js
@@ -19,19 +19,21 @@ var calculateSentenceLengthResult = function( sentences, i18n ) {
 	var score = calculateTooLongSentences( percentage );
 
 	if ( score >= 7 ) {
-		return{
+		return {
 			score: score,
 
-			// Translators: %1$s expands to number of sentences.
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than %3$s words, " +
+			// Translators: %1$s expands to the percentage of sentences, %2$d expands to the maximum percentage of sentences.
+			// %3$s expands to the recommended amount of words.
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than %3$d words, " +
 				"which is less than the recommended maximum of %2$s." ), percentage + "%", maximumPercentage + "%", recommendedValue )
 		};
 	}
-	return{
+	return {
 		score: score,
 
-		// Translators: %1$s expands to number of sentences.
-		text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than %3$s words, " +
+		// Translators: %1$s expands to the percentage of sentences, %2$d expands to the maximum percentage of sentences.
+		// %3$s expands to the recommended amount of words.
+		text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than %3$d words, " +
 			"which is more than the recommended maximum of %2$s. Try to shorten your sentences." ),
 			percentage + "%", maximumPercentage + "%", recommendedValue )
 	};

--- a/js/assessments/sentenceLengthInTextAssessment.js
+++ b/js/assessments/sentenceLengthInTextAssessment.js
@@ -1,6 +1,7 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var countTooLongSentences = require( "./../assessmentHelpers/checkForTooLongSentences.js" );
 var calculateTooLongSentences = require( "./../assessmentHelpers/sentenceLengthPercentageScore.js" );
+var fixFloatingPoint = require( "../helpers/fixFloatingPoint.js" );
 
 /**
  * Calculates sentence length score
@@ -13,7 +14,7 @@ var calculateSentenceLengthResult = function( sentences, i18n ) {
 	var maximumPercentage = 25;
 
 	var tooLong = countTooLongSentences( sentences, recommendedValue );
-	var percentage = ( tooLong / sentences.length ) * 100;
+	var percentage = fixFloatingPoint( ( tooLong / sentences.length ) * 100 );
 
 	var score = calculateTooLongSentences( percentage );
 
@@ -21,17 +22,18 @@ var calculateSentenceLengthResult = function( sentences, i18n ) {
 		return{
 			score: score,
 
-			// translators: %1$s expands to number of sentences.
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than 20 words, " +
-				"which is within the recommended range." ), percentage + "%" )
+			// Translators: %1$s expands to number of sentences.
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than %3$s words, " +
+				"which is less than the recommended maximum of %2$s." ), percentage + "%", maximumPercentage + "%", recommendedValue )
 		};
 	}
 	return{
 		score: score,
 
-		// translators: %1$s expands to number of sentences.
-		text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than 20 words, " +
-			"which is more than the recommended maximum of %2$s. Try to shorten your sentences." ), percentage + "%", maximumPercentage + "%" )
+		// Translators: %1$s expands to number of sentences.
+		text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%1$s of the sentences contain more than %3$s words, " +
+			"which is more than the recommended maximum of %2$s. Try to shorten your sentences." ),
+			percentage + "%", maximumPercentage + "%", recommendedValue )
 	};
 };
 /**

--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -12,7 +12,7 @@ describe( "An assessment for sentence length", function(){
 
 		expect( assessment.hasScore()).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "0% of the sentences contain more than 20 words, which is within the recommended range." );
+		expect( assessment.getText() ).toEqual ( "0% of the sentences contain more than 20 words, which is less than the recommended maximum of 25%." );
 	} );
 	it( "returns the score for 50% long sentences", function(){
 		mockPaper = new Paper();
@@ -38,8 +38,7 @@ describe( "An assessment for sentence length", function(){
 
 		expect( assessment.hasScore()).toBe( true );
 		expect( assessment.getScore() ).toEqual( 7.02 );
-		expect( assessment.getText() ).toEqual ( "25% of the sentences contain more than 20 words, " +
-			"which is within the recommended range." );
+		expect( assessment.getText() ).toEqual ( "25% of the sentences contain more than 20 words, which is less than the recommended maximum of 25%." );
 	} );
 	it( "returns the score for 30% long sentences", function(){
 		mockPaper = new Paper();


### PR DESCRIPTION
Text is now more uniform. Also, no longer will the percentage be something along the lines of `33.333333`.

Fixes #477 

Small side-note: I noticed the following test result being expected, which seems off to me.

```
expect( assessment.getText() ).toEqual ( "25% of the sentences contain more than 20 words, which is less than the recommended maximum of 25%." );
```

@IreneStr, could you please elaborate on why this is the way it is?