### PR TITLE
Change page title into SEO title

### DIFF
--- a/js/assessments/titleKeywordAssessment.js
+++ b/js/assessments/titleKeywordAssessment.js
@@ -13,18 +13,18 @@ var titleHasKeywordAssessment = function( paper, researcher, i18n ) {
 
 	if ( keywordMatches.matches === 0 ) {
 		score = 2;
-		text = i18n.sprintf( i18n.dgettext( "js-text-analysis", "The focus keyword '%1$s' does not appear in the page title." ), paper.getKeyword() );
+		text = i18n.sprintf( i18n.dgettext( "js-text-analysis", "The focus keyword '%1$s' does not appear in the SEO title." ), paper.getKeyword() );
 	}
 
 	if ( keywordMatches.matches > 0 && keywordMatches.position === 0 ) {
 		score = 9;
-		text = i18n.dgettext( "js-text-analysis", "The page title contains the focus keyword, at the beginning which is considered " +
+		text = i18n.dgettext( "js-text-analysis", "The SEO title contains the focus keyword, at the beginning which is considered " +
 			"to improve rankings." );
 	}
 
 	if ( keywordMatches.matches > 0 && keywordMatches.position > 0 ) {
 		score = 6;
-		text = i18n.dgettext( "js-text-analysis", "The page title contains the focus keyword, but it does not appear at the beginning;" +
+		text = i18n.dgettext( "js-text-analysis", "The SEO title contains the focus keyword, but it does not appear at the beginning;" +
 			" try and move it to the beginning." );
 	}
 	var assessmentResult = new AssessmentResult();

--- a/spec/assessments/titleKeywordSpec.js
+++ b/spec/assessments/titleKeywordSpec.js
@@ -11,7 +11,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( {matches: 0} ), i18n );
 
 		expect( assessment.getScore() ).toBe(2);
-		expect( assessment.getText() ).toBe( "The focus keyword 'keyword' does not appear in the page title.");
+		expect( assessment.getText() ).toBe( "The focus keyword 'keyword' does not appear in the SEO title.");
 
 	} );
 
@@ -22,7 +22,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( {matches: 1, position: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toBe(9);
-		expect( assessment.getText() ).toBe( "The page title contains the focus keyword, at the beginning which is considered to improve rankings." );
+		expect( assessment.getText() ).toBe( "The SEO title contains the focus keyword, at the beginning which is considered to improve rankings." );
 
 	} );
 
@@ -33,7 +33,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( {matches: 1, position: 2} ), i18n );
 
 		expect( assessment.getScore() ).toBe(6);
-		expect( assessment.getText() ).toBe( "The page title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning." );
+		expect( assessment.getText() ).toBe( "The SEO title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning." );
 
 	} );
 } );


### PR DESCRIPTION
It is confusing when there is a title field (in wordpress) and an SEO field. But the SEO field is the one being used.