### PR TITLE
(Sub)Headings without focus keyword was worse than no headers

### DIFF
--- a/js/assessments/subheadingsKeywordAssessment.js
+++ b/js/assessments/subheadingsKeywordAssessment.js
@@ -10,7 +10,7 @@ var AssessmentResult = require( "../values/AssessmentResult.js" );
 var calculateKeywordMatchesResult = function( subHeadings, i18n ) {
 	if ( subHeadings.matches === 0 ) {
 		return {
-			score: 3,
+			score: 6,
 			text: i18n.dgettext( "js-text-analysis", "You have not used your focus keyword in any subheading (such as an H2) in your copy." )
 		};
 	}

--- a/js/assessments/textSubheadingsAssessment.js
+++ b/js/assessments/textSubheadingsAssessment.js
@@ -10,7 +10,7 @@ var AssessmentResult = require( "../values/AssessmentResult.js" );
 var calculateSubheadingMatchesResult = function( subHeadings, i18n ) {
 	if ( subHeadings.count === 0 ) {
 		return {
-			score: 7,
+			score: 4,
 			text: i18n.dgettext( "js-text-analysis", "No subheading tags (like an H2) appear in the copy." )
 		};
 	}

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -16,7 +16,7 @@ describe( "An assessment for matching keywords in subheadings", function(){
 		var mockPaper = new Paper();
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
 
-		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( "You have not used your focus keyword in any subheading (such as an H2) in your copy." );
 	} );
 	it( "assesses a string with subheadings and keywords", function(){

--- a/spec/assessments/textSubheadingsSpec.js
+++ b/spec/assessments/textSubheadingsSpec.js
@@ -13,7 +13,7 @@ describe( "An assessment for matching keywords in subheadings", function(){
 	it( "assesses a string without subheadings", function(){
 		var result = matchKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { count: 0 } ), i18n );
 
-		expect( result.getScore() ).toEqual( 7 );
+		expect( result.getScore() ).toEqual( 4 );
 		expect( result.getText() ).toEqual ( "No subheading tags (like an H2) appear in the copy." );
 	} );
 


### PR DESCRIPTION
Updated the assessment result ratings. No headings are now worse than
no focus keyword in the subheadings.

Fixes https://github.com/Yoast/wordpress-seo/issues/3266