### PR TITLE
Fixes '/' in focus keyword

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -755,10 +755,10 @@ SnippetPreview.prototype.getPeriodMatches = function() {
  */
 SnippetPreview.prototype.formatKeyword = function( textString ) {
 
-	// removes characters from the keyword that could break the regex, or give unwanted results
-	var keyword = this.refObj.rawData.keyword.replace( /[\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, " " );
+	// Removes characters from the keyword that could break the regex, or give unwanted results.
+	var keyword = this.refObj.rawData.keyword.replace( /[\[\]\{\}\(\)\*\+\?\.\^\$\|]/g, " " );
 
-	// Match keyword case-insensitively
+	// Match keyword case-insensitively.
 	var keywordRegex = stringToRegex( keyword, "", false );
 	return textString.replace( keywordRegex, function( str ) {
 		return "<strong>" + str + "</strong>";

--- a/js/stringProcessing/sanitizeString.js
+++ b/js/stringProcessing/sanitizeString.js
@@ -10,7 +10,7 @@ var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
  * @returns {String} The text without characters.
  */
 module.exports = function( text ) {
-	text = text.replace( /[\[\]\/\{\}\(\)\*\+\?\\\^\$\|]/g, "" );
+	text = text.replace( /[\[\]\{\}\(\)\*\+\?\^\$\|]/g, "" );
 	text = stripTags( text );
 	text = stripSpaces( text );
 

--- a/spec/stringProcessing/sanitizeStringSpec.js
+++ b/spec/stringProcessing/sanitizeStringSpec.js
@@ -2,7 +2,11 @@ var sanitizeString = require("../../js/stringProcessing/sanitizeString.js");
 
 describe("Test for removing unwanted characters", function(){
 	it("returns cleaned string", function(){
-		expect(sanitizeString("keyword*")).toBe("keyword");
-		expect(sanitizeString("keyword<p></p>")).toBe("keyword");
+		expect( sanitizeString( "keyword*" ) ).toBe( "keyword" );
+		expect( sanitizeString( "keyword<p></p>" ) ).toBe( "keyword" );
 	});
+	it("returns cleaned string containing /", function(){
+		expect( sanitizeString( "50/50")).toBe( "50/50" );
+		expect( sanitizeString( "<p>50/50</p>" ) ).toBe( "50/50" );
+	})
 });


### PR DESCRIPTION
Updated regex so it matches slashes in the focus keyword.

Fixes https://github.com/Yoast/wordpress-seo/issues/3839