### PR TITLE
Measure title and metadescription

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -15,7 +15,9 @@ var stripSpaces = require( "../js/stringProcessing/stripSpaces.js" );
 var replaceDiacritics = require( "../js/stringProcessing/replaceDiacritics.js" );
 var analyzerConfig = require( "./config/config.js" );
 
-var snippetEditorTemplate = require( "./templates.js" ).snippetEditor;
+var templates = require( "./templates.js" );
+var snippetEditorTemplate = templates.snippetEditor;
+var hiddenElement = templates.hiddenSpan;
 
 var defaults = {
 	data: {
@@ -308,6 +310,9 @@ function updateProgressBar( element, value, maximum, rating ) {
  * @property {HTMLElement} element.rendered.urlBase       - The rendered url base element.
  * @property {HTMLElement} element.rendered.metaDesc      - The rendered meta description element.
  *
+ * @property {HTMLElement} element.measure.titleWidth    - The rendered title width element.
+ * @property {HTMLElement} element.measure.metaHeight    - The rendered meta height element.
+ *
  * @property {Object}      element.input                  - The input elements.
  * @property {HTMLElement} element.input.title            - The title input element.
  * @property {HTMLElement} element.input.urlPath          - The url path input element.
@@ -414,6 +419,10 @@ SnippetPreview.prototype.renderTemplate = function() {
 	} );
 
 	this.element = {
+		measure : {
+			titleWidth: null,
+			metaHeight: null
+		},
 		rendered: {
 			title: document.getElementById( "snippet_title" ),
 			urlBase: document.getElementById( "snippet_citeBase" ),
@@ -1157,46 +1166,50 @@ SnippetPreview.prototype.setMetaDescription = function( metaDesc ) {
  * Creates elements with the purpose to calculate the sizes of elements and puts these elemenents to the body.
  */
 SnippetPreview.prototype.createMeasurementElements = function() {
-	var titleElement = document.createElement( "span" );
-	var metaDescriptionElement = document.createElement( "span" );
+	var titleElement, metaDescriptionElement, spanHolder;
 
-	titleElement.id = "measureTitle";
-	titleElement.style.width = "auto";
-	titleElement.style.height = "auto";
-	titleElement.style.position = "absolute";
-	titleElement.style.visibility = "hidden";
-	titleElement.style.whiteSpace = "nowrap";
+	titleElement = hiddenElement( {
+		width: "auto",
+		whiteSpace: "nowrap"
+	} );
 
-	metaDescriptionElement.id = "measureDescription";
-	metaDescriptionElement.style.width = document.getElementById( "meta_container" ).offsetWidth + "px";
-	metaDescriptionElement.style.height = "auto";
-	metaDescriptionElement.style.position = "absolute";
-	metaDescriptionElement.style.visibility = "hidden";
+	metaDescriptionElement = hiddenElement(
+		{
+			width: document.getElementById( "meta_container" ).offsetWidth + "px",
+			whiteSpace: ""
+		}
+	);
 
-	document.body.appendChild( titleElement );
-	document.body.appendChild( metaDescriptionElement );
+	spanHolder = document.createElement( "div" );
+
+	spanHolder.innerHTML = titleElement + metaDescriptionElement;
+
+	document.body.appendChild( spanHolder );
+	
+	this.element.measure.titleWidth = spanHolder.childNodes[ 0 ];
+	this.element.measure.metaHeight = spanHolder.childNodes[ 1 ];
 };
 
 /**
- * Copies the title text to the title measure element to calculate the widht in pixels.
+ * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	var titleElement = document.getElementById( "measureTitle" );
+	var titleWidthElement = this.element.measure.titleWidth;
 
-	titleElement.innerHTML = this.element.rendered.title.innerHTML;
+	titleWidthElement.innerHTML = this.element.rendered.title.innerHTML;
 
-	this.data.titleWidth = titleElement.offsetWidth;
+	this.data.titleWidth = titleWidthElement.offsetWidth;
 };
 
 /**
  * Copies the metadescription text to the metadescription measure element to calculate the height in pixels.
  */
 SnippetPreview.prototype.measureMetaDescription = function() {
-	var metaDescriptionElement = document.getElementById( "measureDescription" );
+	var metaHeightElement = this.element.measure.metaHeight;
 
-	metaDescriptionElement.innerHTML = this.element.rendered.metaDesc.innerHTML;
+	metaHeightElement.innerHTML = this.element.rendered.metaDesc.innerHTML;
 
-	this.data.metaHeight = metaDescriptionElement.offsetHeight;
+	this.data.metaHeight = metaHeightElement.offsetHeight;
 };
 
 /* jshint ignore:start */

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -21,7 +21,8 @@ var defaults = {
 	data: {
 		title: "",
 		metaDesc: "",
-		urlPath: ""
+		urlPath: "",
+		titleWidth: 0
 	},
 	placeholder: {
 		title:    "This is an example title - edit by clicking here",
@@ -319,6 +320,7 @@ function updateProgressBar( element, value, maximum, rating ) {
  * @property {string}      data.title                     - The title.
  * @property {string}      data.urlPath                   - The url path.
  * @property {string}      data.metaDesc                  - The meta description.
+ * @property {int}         data.titleWidth                - The width of the title in pixels.
  *
  * @property {string}      baseURL                        - The basic URL as it will be displayed in google.
  *
@@ -456,6 +458,7 @@ SnippetPreview.prototype.renderTemplate = function() {
 	}
 
 	this.opened = false;
+	this.createMeasurementElements();
 	this.updateProgressBars();
 };
 
@@ -467,6 +470,7 @@ SnippetPreview.prototype.refresh = function() {
 	this.output = this.htmlOutput();
 	this.renderOutput();
 	this.renderSnippetStyle();
+	this.measureTitle();
 	this.updateProgressBars();
 };
 
@@ -1145,6 +1149,31 @@ SnippetPreview.prototype.setMetaDescription = function( metaDesc ) {
 
 	this.changedInput();
 };
+
+/**
+ * Creates elements with the purpose to calculate the sizes of elements.
+ */
+SnippetPreview.prototype.createMeasurementElements = function() {
+	var titleElement = document.createElement( 'span' );
+
+	titleElement.id = 'measureTitle';
+	titleElement.style.width = 'auto';
+	titleElement.style.height = 'auto';
+	titleElement.style.position = 'absolute';
+	titleElement.style.visibility = 'hidden';
+	titleElement.style.whiteSpace = 'nowrap';
+
+	document.body.appendChild( titleElement );
+};
+
+SnippetPreview.prototype.measureTitle = function() {
+	var titleElement = document.getElementById( 'measureTitle' );
+
+	titleElement.innerHTML = this.element.rendered.title.innerHTML;
+
+	this.data.titleWidth = titleElement.offsetWidth;
+};
+
 
 /* jshint ignore:start */
 /* eslint-disable */

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -310,8 +310,8 @@ function updateProgressBar( element, value, maximum, rating ) {
  * @property {HTMLElement} element.rendered.urlBase       - The rendered url base element.
  * @property {HTMLElement} element.rendered.metaDesc      - The rendered meta description element.
  *
- * @property {HTMLElement} element.measure.titleWidth    - The rendered title width element.
- * @property {HTMLElement} element.measure.metaHeight    - The rendered meta height element.
+ * @property {HTMLElement} element.measurers.titleWidth   - The rendered title width element.
+ * @property {HTMLElement} element.measurers.metaHeight   - The rendered meta height element.
  *
  * @property {Object}      element.input                  - The input elements.
  * @property {HTMLElement} element.input.title            - The title input element.
@@ -1186,15 +1186,15 @@ SnippetPreview.prototype.createMeasurementElements = function() {
 
 	document.body.appendChild( spanHolder );
 
-	this.element.measure.titleWidth = spanHolder.childNodes[ 0 ];
-	this.element.measure.metaHeight = spanHolder.childNodes[ 1 ];
+	this.element.measurers.titleWidth = spanHolder.childNodes[ 0 ];
+	this.element.measurers.metaHeight = spanHolder.childNodes[ 1 ];
 };
 
 /**
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	var titleWidthElement = this.element.measure.titleWidth;
+	var titleWidthElement = this.element.measurers.titleWidth;
 
 	titleWidthElement.innerHTML = this.element.rendered.title.innerHTML;
 
@@ -1205,7 +1205,7 @@ SnippetPreview.prototype.measureTitle = function() {
  * Copies the metadescription text to the metadescription measure element to calculate the height in pixels.
  */
 SnippetPreview.prototype.measureMetaDescription = function() {
-	var metaHeightElement = this.element.measure.metaHeight;
+	var metaHeightElement = this.element.measurers.metaHeight;
 
 	metaHeightElement.innerHTML = this.element.rendered.metaDesc.innerHTML;
 

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -419,7 +419,7 @@ SnippetPreview.prototype.renderTemplate = function() {
 	} );
 
 	this.element = {
-		measure : {
+		measure: {
 			titleWidth: null,
 			metaHeight: null
 		},
@@ -1185,7 +1185,7 @@ SnippetPreview.prototype.createMeasurementElements = function() {
 	spanHolder.innerHTML = titleElement + metaDescriptionElement;
 
 	document.body.appendChild( spanHolder );
-	
+
 	this.element.measure.titleWidth = spanHolder.childNodes[ 0 ];
 	this.element.measure.metaHeight = spanHolder.childNodes[ 1 ];
 };

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -22,7 +22,8 @@ var defaults = {
 		title: "",
 		metaDesc: "",
 		urlPath: "",
-		titleWidth: 0
+		titleWidth: 0,
+		metaHeight: 0
 	},
 	placeholder: {
 		title:    "This is an example title - edit by clicking here",
@@ -321,6 +322,7 @@ function updateProgressBar( element, value, maximum, rating ) {
  * @property {string}      data.urlPath                   - The url path.
  * @property {string}      data.metaDesc                  - The meta description.
  * @property {int}         data.titleWidth                - The width of the title in pixels.
+ * @property {int}         data.metaHeight                - The height of the meta description in pixels.
  *
  * @property {string}      baseURL                        - The basic URL as it will be displayed in google.
  *
@@ -471,6 +473,7 @@ SnippetPreview.prototype.refresh = function() {
 	this.renderOutput();
 	this.renderSnippetStyle();
 	this.measureTitle();
+	this.measureMetaDescription();
 	this.updateProgressBars();
 };
 
@@ -1151,10 +1154,11 @@ SnippetPreview.prototype.setMetaDescription = function( metaDesc ) {
 };
 
 /**
- * Creates elements with the purpose to calculate the sizes of elements.
+ * Creates elements with the purpose to calculate the sizes of elements and puts these elemenents to the body.
  */
 SnippetPreview.prototype.createMeasurementElements = function() {
 	var titleElement = document.createElement( 'span' );
+	var metaDescriptionElement = document.createElement( 'span' );
 
 	titleElement.id = 'measureTitle';
 	titleElement.style.width = 'auto';
@@ -1163,9 +1167,19 @@ SnippetPreview.prototype.createMeasurementElements = function() {
 	titleElement.style.visibility = 'hidden';
 	titleElement.style.whiteSpace = 'nowrap';
 
+	metaDescriptionElement.id = 'measureDescription';
+	metaDescriptionElement.style.width = document.getElementById( 'meta_container' ).offsetWidth + 'px';
+	metaDescriptionElement.style.height = 'auto';
+	metaDescriptionElement.style.position = 'absolute';
+	metaDescriptionElement.style.visibility = 'hidden';
+
 	document.body.appendChild( titleElement );
+	document.body.appendChild( metaDescriptionElement );
 };
 
+/**
+ * Copies the title text to the title measure element to calculate the widht in pixels.
+ */
 SnippetPreview.prototype.measureTitle = function() {
 	var titleElement = document.getElementById( 'measureTitle' );
 
@@ -1174,6 +1188,16 @@ SnippetPreview.prototype.measureTitle = function() {
 	this.data.titleWidth = titleElement.offsetWidth;
 };
 
+/**
+ * Copies the metadescription text to the metadescription measure element to calculate the height in pixels.
+ */
+SnippetPreview.prototype.measureMetaDescription = function() {
+	var metaDescriptionElement = document.getElementById( 'measureDescription' );
+
+	metaDescriptionElement.innerHTML = this.element.rendered.metaDesc.innerHTML;
+
+	this.data.metaHeight = metaDescriptionElement.offsetHeight;
+};
 
 /* jshint ignore:start */
 /* eslint-disable */

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1157,21 +1157,21 @@ SnippetPreview.prototype.setMetaDescription = function( metaDesc ) {
  * Creates elements with the purpose to calculate the sizes of elements and puts these elemenents to the body.
  */
 SnippetPreview.prototype.createMeasurementElements = function() {
-	var titleElement = document.createElement( 'span' );
-	var metaDescriptionElement = document.createElement( 'span' );
+	var titleElement = document.createElement( "span" );
+	var metaDescriptionElement = document.createElement( "span" );
 
-	titleElement.id = 'measureTitle';
-	titleElement.style.width = 'auto';
-	titleElement.style.height = 'auto';
-	titleElement.style.position = 'absolute';
-	titleElement.style.visibility = 'hidden';
-	titleElement.style.whiteSpace = 'nowrap';
+	titleElement.id = "measureTitle";
+	titleElement.style.width = "auto";
+	titleElement.style.height = "auto";
+	titleElement.style.position = "absolute";
+	titleElement.style.visibility = "hidden";
+	titleElement.style.whiteSpace = "nowrap";
 
-	metaDescriptionElement.id = 'measureDescription';
-	metaDescriptionElement.style.width = document.getElementById( 'meta_container' ).offsetWidth + 'px';
-	metaDescriptionElement.style.height = 'auto';
-	metaDescriptionElement.style.position = 'absolute';
-	metaDescriptionElement.style.visibility = 'hidden';
+	metaDescriptionElement.id = "measureDescription";
+	metaDescriptionElement.style.width = document.getElementById( "meta_container" ).offsetWidth + "px";
+	metaDescriptionElement.style.height = "auto";
+	metaDescriptionElement.style.position = "absolute";
+	metaDescriptionElement.style.visibility = "hidden";
 
 	document.body.appendChild( titleElement );
 	document.body.appendChild( metaDescriptionElement );
@@ -1181,7 +1181,7 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the widht in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	var titleElement = document.getElementById( 'measureTitle' );
+	var titleElement = document.getElementById( "measureTitle" );
 
 	titleElement.innerHTML = this.element.rendered.title.innerHTML;
 
@@ -1192,7 +1192,7 @@ SnippetPreview.prototype.measureTitle = function() {
  * Copies the metadescription text to the metadescription measure element to calculate the height in pixels.
  */
 SnippetPreview.prototype.measureMetaDescription = function() {
-	var metaDescriptionElement = document.getElementById( 'measureDescription' );
+	var metaDescriptionElement = document.getElementById( "measureDescription" );
 
 	metaDescriptionElement.innerHTML = this.element.rendered.metaDesc.innerHTML;
 

--- a/js/templates.js
+++ b/js/templates.js
@@ -38,7 +38,7 @@
   var undefined;
 
   /** Used as the semantic version number. */
-  var VERSION = '4.11.2';
+  var VERSION = '4.6.1';
 
   /** Used as references for various `Number` constants. */
   var INFINITY = 1 / 0;
@@ -128,8 +128,7 @@
   var objectProto = Object.prototype;
 
   /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+   * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
    * of values.
    */
   var objectToString = objectProto.toString;
@@ -147,34 +146,11 @@
   /*------------------------------------------------------------------------*/
 
   /**
-   * The base implementation of `_.toString` which doesn't convert nullish
-   * values to empty strings.
-   *
-   * @private
-   * @param {*} value The value to process.
-   * @returns {string} Returns the string.
-   */
-  function baseToString(value) {
-    // Exit early for strings to avoid a performance hit in some environments.
-    if (typeof value == 'string') {
-      return value;
-    }
-    if (isSymbol(value)) {
-      return symbolToString ? symbolToString.call(value) : '';
-    }
-    var result = (value + '');
-    return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
-  }
-
-  /*------------------------------------------------------------------------*/
-
-  /**
    * Checks if `value` is object-like. A value is object-like if it's not `null`
    * and has a `typeof` result of "object".
    *
    * @static
    * @memberOf _
-   * @since 4.0.0
    * @category Lang
    * @param {*} value The value to check.
    * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
@@ -201,11 +177,9 @@
    *
    * @static
    * @memberOf _
-   * @since 4.0.0
    * @category Lang
    * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is correctly classified,
-   *  else `false`.
+   * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
    * @example
    *
    * _.isSymbol(Symbol.iterator);
@@ -220,12 +194,11 @@
   }
 
   /**
-   * Converts `value` to a string. An empty string is returned for `null`
-   * and `undefined` values. The sign of `-0` is preserved.
+   * Converts `value` to a string if it's not one. An empty string is returned
+   * for `null` and `undefined` values. The sign of `-0` is preserved.
    *
    * @static
    * @memberOf _
-   * @since 4.0.0
    * @category Lang
    * @param {*} value The value to process.
    * @returns {string} Returns the string.
@@ -241,7 +214,18 @@
    * // => '1,2,3'
    */
   function toString(value) {
-    return value == null ? '' : baseToString(value);
+    // Exit early for strings to avoid a performance hit in some environments.
+    if (typeof value == 'string') {
+      return value;
+    }
+    if (value == null) {
+      return '';
+    }
+    if (isSymbol(value)) {
+      return symbolToString ? symbolToString.call(value) : '';
+    }
+    var result = (value + '');
+    return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
   }
 
   /*------------------------------------------------------------------------*/
@@ -255,22 +239,20 @@
    *
    * Though the ">" character is escaped for symmetry, characters like
    * ">" and "/" don't need escaping in HTML and have no special meaning
-   * unless they're part of a tag or unquoted attribute value. See
-   * [Mathias Bynens's article](https://mathiasbynens.be/notes/ambiguous-ampersands)
+   * unless they're part of a tag or unquoted attribute value.
+   * See [Mathias Bynens's article](https://mathiasbynens.be/notes/ambiguous-ampersands)
    * (under "semi-related fun fact") for more details.
    *
    * Backticks are escaped because in IE < 9, they can break out of
    * attribute values or HTML comments. See [#59](https://html5sec.org/#59),
    * [#102](https://html5sec.org/#102), [#108](https://html5sec.org/#108), and
-   * [#133](https://html5sec.org/#133) of the
-   * [HTML5 Security Cheatsheet](https://html5sec.org/) for more details.
+   * [#133](https://html5sec.org/#133) of the [HTML5 Security Cheatsheet](https://html5sec.org/)
+   * for more details.
    *
-   * When working with HTML you should always
-   * [quote attribute values](http://wonko.com/post/html-escaping) to reduce
-   * XSS vectors.
+   * When working with HTML you should always [quote attribute values](http://wonko.com/post/html-escaping)
+   * to reduce XSS vectors.
    *
    * @static
-   * @since 0.1.0
    * @memberOf _
    * @category String
    * @param {string} [string=''] The string to escape.
@@ -295,6 +277,7 @@
 
   var templates = {
     'assessmentPresenterResult': {},
+    'hiddenSpan': {},
     'snippetEditor': {}
   };
 
@@ -320,6 +303,24 @@
     __p += '\n        </li>\n    ';
      }
     __p += '\n</ul>\n';
+
+    }
+    return __p
+  };
+
+  templates['hiddenSpan'] =   function(obj) {
+    obj || (obj = {});
+    var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
+    function print() { __p += __j.call(arguments, '') }
+    with (obj) {
+    __p += '<span style="width: ' +
+    __e( width ) +
+    '; height: auto; position: absolute; visibility: hidden; ';
+     if ( "" !== whiteSpace ) {
+    __p += 'white-space: ' +
+    __e(whiteSpace );
+       }
+    __p += '">\n\n</span>';
 
     }
     return __p

--- a/templates/hiddenSpan.jst
+++ b/templates/hiddenSpan.jst
@@ -1,0 +1,3 @@
+<span style="width: <%- width %>; height: auto; position: absolute; visibility: hidden; <% if ( "" !== whiteSpace ) { %>white-space: <%-whiteSpace %><%   } %>">
+
+</span>


### PR DESCRIPTION
Measures the title width in pixels and the metadescription height in pixels. The measurements are executed on keypress.

These results of the measurements are stored in the snippetpreview object as `this.data.titleWidth` and `this.data.metaHeight`.

For testing: 
I suggest to do a `console.log` of the data object to see these values being stored.

Fixes #521 