### PR TITLE
Fixes empty sentence error

### DIFF
--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -45,11 +45,14 @@ module.exports = function( paper ) {
 	var sentences = getSentences( paper.getText() );
 	var sentenceBeginnings = sentences.map( function( sentence ) {
 		var words = getWords( stripSpaces( sentence ) );
-		var firstWord = removeNonWordCharacters( words[ 0 ] );
-		if ( firstWordExceptions.indexOf( firstWord ) > -1 ) {
-			firstWord += " " + removeNonWordCharacters( words[ 1 ] );
+		if( words.length > 0 ) {
+			var firstWord = removeNonWordCharacters( words[ 0 ] );
+			if ( firstWordExceptions.indexOf( firstWord ) > -1 ) {
+				firstWord += " " + removeNonWordCharacters( words[ 1 ] );
+			}
+			return firstWord;
 		}
-		return firstWord;
+		return "";
 	} );
 	return compareFirstWords( sentenceBeginnings );
 };

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -45,14 +45,14 @@ module.exports = function( paper ) {
 	var sentences = getSentences( paper.getText() );
 	var sentenceBeginnings = sentences.map( function( sentence ) {
 		var words = getWords( stripSpaces( sentence ) );
-		if( words.length > 0 ) {
-			var firstWord = removeNonWordCharacters( words[ 0 ] );
-			if ( firstWordExceptions.indexOf( firstWord ) > -1 ) {
-				firstWord += " " + removeNonWordCharacters( words[ 1 ] );
-			}
-			return firstWord;
+		if( words.length === 0 ) {
+			return "";
 		}
-		return "";
+		var firstWord = removeNonWordCharacters( words[ 0 ] );
+		if ( firstWordExceptions.indexOf( firstWord ) > -1 ) {
+			firstWord += " " + removeNonWordCharacters( words[ 1 ] );
+		}
+		return firstWord;
 	} );
 	return compareFirstWords( sentenceBeginnings );
 };

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -35,4 +35,8 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "One two" );
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 3 );
 	} );
+	it( "returns an empty string if only enters or whitespaces in a string", function() {
+		var mockPaper = new Paper( "   \n</div>" );
+		expect( sentenceBeginnings( mockPaper) [ 0 ].word ).toBe( "" );
+	} );
 } );


### PR DESCRIPTION
If a sentence is empty (containing only enters or whitespaces) the first word would error. This makes sure there is a first word.