### PR TITLE
Make removeMarks more robust

### DIFF
--- a/js/markers/removeMarks.js
+++ b/js/markers/removeMarks.js
@@ -6,6 +6,6 @@
  */
 module.exports = function( text ) {
 	return text
-		.replace( new RegExp( "<yoastmark class='yoast-text-mark'>", "g" ), "" )
+		.replace( new RegExp( "<yoastmark[^>]*>", "g" ), "" )
 		.replace( new RegExp( "</yoastmark>", "g" ), "" );
 };

--- a/spec/markers/removeMarkSpec.js
+++ b/spec/markers/removeMarkSpec.js
@@ -20,4 +20,22 @@ describe( "removeMarks", function() {
 
 		expect( removeMarks( input ) ).toBe( "Another text with another <span>mark.</span>" );
 	});
+
+	it( "should support arbitrary HTML attributes", function() {
+		var input = "Another <yoastmark class='some-class yoast-text-mark' style='border-bottom: 1px solid red'>Marked</yoastmark>";
+
+		expect( removeMarks( input  ) ) .toBe( "Another Marked" );
+	});
+
+	it( "should support different quote styles", function() {
+		var input = 'Marked <yoastmark class="yoast-text-mark">marked</yoastmark>';
+
+		expect( removeMarks( input ) ).toBe( "Marked marked" );
+	});
+
+	it( "should remove marks without HTML attributes", function() {
+		var input = "Marked <yoastmark>marked</yoastmark>";
+
+		expect( removeMarks( input ) ).toBe( "Marked marked" );
+	});
 });


### PR DESCRIPTION
It should now remove the marks even when they are jumbled by tinyMCE or
if other HTML attributes are added.

You can test this by running the unit tests