### PR TITLE
Mark duplicate words correctly

### DIFF
--- a/js/assessor.js
+++ b/js/assessor.js
@@ -1,5 +1,7 @@
 var Researcher = require( "./researcher.js" );
 var MissingArgument = require( "./errors/missingArgument" );
+var removeDuplicateMarks = require( "./markers/removeDuplicateMarks" );
+
 var isUndefined = require( "lodash/isUndefined" );
 var isFunction = require( "lodash/isFunction" );
 var forEach = require( "lodash/forEach" );
@@ -84,6 +86,9 @@ Assessor.prototype.getMarker = function( assessment, paper, researcher ) {
 
 	return function() {
 		var marks = assessment.getMarks( paper, researcher );
+
+		marks = removeDuplicateMarks( marks );
+
 		specificMarker( paper, marks );
 	};
 };

--- a/js/markers/removeDuplicateMarks.js
+++ b/js/markers/removeDuplicateMarks.js
@@ -1,0 +1,15 @@
+var uniqBy = require( "lodash/uniqBy" );
+
+/**
+ * Removes duplicate marks from an array
+ *
+ * @param {Array} marks The marks to remove duplications from
+ * @returns {Array} A list of de-duplicated marks.
+ */
+function removeDuplicateMarks( marks ) {
+	return uniqBy( marks, function( mark ) {
+		return mark.getOriginal();
+	} );
+}
+
+module.exports = removeDuplicateMarks;

--- a/js/values/Mark.js
+++ b/js/values/Mark.js
@@ -40,7 +40,8 @@ Mark.prototype.getMarked = function() {
  * @returns {string} The A new text with the mark applied to it.
  */
 Mark.prototype.applyWithReplace = function( text ) {
-	return text.replace( this._properties.original, this._properties.marked );
+	// Cute method to replace everything in a string without using regex.
+	return text.split( this._properties.original ).join( this._properties.marked );
 };
 
 module.exports = Mark;

--- a/spec/markers/removeDuplicateMarks.js
+++ b/spec/markers/removeDuplicateMarks.js
@@ -1,0 +1,34 @@
+var Mark = require( "../../js/values/Mark" );
+var removeDuplicateMarks = require( "../../js/markers/removeDuplicateMarks" );
+
+describe( "removeDuplicateMarks", function() {
+	it( "should not touch an empty array", function() {
+		expect( removeDuplicateMarks( [] ) ).toEqual( [] );
+	});
+
+	it( "should remove duplicated marks from the array", function() {
+		var marks = [
+			new Mark({ original: "original", marked: "marked" }),
+			new Mark({ original: "original", marked: "marked" })
+		];
+		var expected = [
+			new Mark({ original: "original", marked: "marked" })
+		];
+
+		expect( removeDuplicateMarks( marks ) ).toEqual( expected );
+	});
+
+	it( "should remove duplicated marks from the array", function() {
+		var marks = [
+			new Mark({ original: "original", marked: "marked" }),
+			new Mark({ original: "original2", marked: "marked" }),
+			new Mark({ original: "original", marked: "marked" })
+		];
+		var expected = [
+			new Mark({ original: "original", marked: "marked" }),
+			new Mark({ original: "original2", marked: "marked" })
+		];
+
+		expect( removeDuplicateMarks( marks ) ).toEqual( expected );
+	});
+});

--- a/spec/values/markSpec.js
+++ b/spec/values/markSpec.js
@@ -25,14 +25,12 @@ describe( "a mark value object", function() {
 			expect( mark.applyWithReplace( text ) ).toBe( expected );
 		});
 
-		it( "should only apply to the first occurence", function() {
+		it( "should only apply all occurences", function() {
 			var mark = new Mark({ original: "original", marked: "marked" });
 			var text = "original original original original original original original";
-			var expected = "marked original original original original original original";
+			var expected = "marked marked marked marked marked marked marked";
 
 			expect( mark.applyWithReplace( text ) ).toBe( expected );
 		});
 	});
-
-
 } );


### PR DESCRIPTION
Apply exactly one <yoastmark> to each word. Do this by removing duplicated marks from the array of marks and then applying each mark globally in the text instead of on one occurence.

How to test this: Have duplicate words in your text with more than 4 syllables and test if they are all marked correctly with one <yoastmark> element.