### PR TITLE
Integrates transliteration for matching keyword

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -83,7 +83,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 var keywordDensityAssessment = function( paper, researcher, i18n ) {
 
 	var keywordDensity = researcher.getResearch( "getKeywordDensity" );
-	var keywordCount = matchWords( paper.getText(), paper.getKeyword() );
+	var keywordCount = matchWords( paper.getText(), paper.getKeyword(), paper.getLocale() );
 
 	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n, keywordCount );
 	var assessmentResult = new AssessmentResult();

--- a/js/researches/findKeywordInFirstParagraph.js
+++ b/js/researches/findKeywordInFirstParagraph.js
@@ -13,5 +13,5 @@ var wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
  */
 module.exports = function( paper ) {
 	var paragraph = matchParagraphs( paper.getText() );
-	return wordMatch( paragraph[ 0 ], paper.getKeyword() );
+	return wordMatch( paragraph[ 0 ], paper.getKeyword(), paper.getLocale() );
 };

--- a/js/researches/findKeywordInPageTitle.js
+++ b/js/researches/findKeywordInPageTitle.js
@@ -13,8 +13,9 @@ var wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
 module.exports = function( paper ) {
 	var title = paper.getTitle();
 	var keyword = paper.getKeyword();
+	var locale = paper.getLocale();
 	var result = { matches: 0, position: -1 };
-	result.matches = wordMatch( title, keyword );
+	result.matches = wordMatch( title, keyword, locale );
 	result.position = title.toLocaleLowerCase().indexOf( keyword );
 
 	return result;

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -12,10 +12,11 @@ var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
 module.exports = function( paper ) {
 	var keyword = paper.getKeyword();
 	var text = paper.getText();
+	var locale = paper.getLocale();
 	var wordCount = countWords( text );
 	if ( wordCount === 0 ) {
 		return 0;
 	}
-	var keywordCount = matchWords( text, keyword );
+	var keywordCount = matchWords( text, keyword, locale );
 	return ( keywordCount / wordCount ) * 100;
 };

--- a/js/researches/getLinkStatistics.js
+++ b/js/researches/getLinkStatistics.js
@@ -9,14 +9,15 @@ var checkNofollow = require( "../stringProcessing/checkNofollow.js" );
  * Checks whether or not an anchor contains the passed keyword.
  * @param {string} keyword The keyword to look for.
  * @param {string} anchor The anchor to check against.
+ * @param {string} locale The locale used for transliteration.
  * @returns {boolean} Whether or not the keyword was found.
  */
-var keywordInAnchor = function( keyword, anchor ) {
+var keywordInAnchor = function( keyword, anchor, locale ) {
 	if ( keyword === "" ) {
 		return false;
 	}
 
-	return findKeywordInUrl( anchor, keyword );
+	return findKeywordInUrl( anchor, keyword, locale );
 };
 
 /**
@@ -42,6 +43,7 @@ var keywordInAnchor = function( keyword, anchor ) {
 var countLinkTypes = function( paper ) {
 	var url = paper.getUrl();
 	var keyword = paper.getKeyword();
+	var locale = paper.getLocale();
 	var anchors = getLinks( paper.getText() );
 
 	var linkCount = {
@@ -65,7 +67,7 @@ var countLinkTypes = function( paper ) {
 	for ( var i = 0; i < anchors.length; i++ ) {
 		var currentAnchor = anchors[ i ];
 
-		if ( keywordInAnchor( keyword, currentAnchor ) ) {
+		if ( keywordInAnchor( keyword, currentAnchor, locale ) ) {
 
 			linkCount.keyword.totalKeyword++;
 			linkCount.keyword.matchedAnchors.push( currentAnchor );

--- a/js/researches/imageAltTags.js
+++ b/js/researches/imageAltTags.js
@@ -10,9 +10,10 @@ var wordMatch = require( "../stringProcessing/matchTextWithWord" );
  *
  * @param {Array} imageMatches Array with all the matched images in the text
  * @param {string} keyword the keyword to check for.
+ * @param {string} locale The locale used for transliteration.
  * @returns {object} altProperties Object with all alt-tags that were found.
  */
-var matchAltProperties = function( imageMatches, keyword ) {
+var matchAltProperties = function( imageMatches, keyword, locale ) {
 	var altProperties = {
 		noAlt: 0,
 		withAlt: 0,
@@ -35,14 +36,14 @@ var matchAltProperties = function( imageMatches, keyword ) {
 			continue;
 		}
 
-		if ( wordMatch( alttag, keyword ) === 0 && alttag !== "" ) {
+		if ( wordMatch( alttag, keyword, locale ) === 0 && alttag !== "" ) {
 
 			// Match for keywords?
 			altProperties.withAltNonKeyword++;
 			continue;
 		}
 
-		if ( wordMatch( alttag, keyword ) > 0 ) {
+		if ( wordMatch( alttag, keyword, locale ) > 0 ) {
 			altProperties.withAltKeyword++;
 			continue;
 		}
@@ -58,5 +59,5 @@ var matchAltProperties = function( imageMatches, keyword ) {
  * @returns {object} Object containing all types of found images
  */
 module.exports = function( paper ) {
-	return matchAltProperties( imageInText( paper.getText() ), paper.getKeyword() );
+	return matchAltProperties( imageInText( paper.getText() ), paper.getKeyword(), paper.getLocale() );
 };

--- a/js/researches/keywordCountInUrl.js
+++ b/js/researches/keywordCountInUrl.js
@@ -10,5 +10,5 @@ var wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
 module.exports = function( paper ) {
 	var keyword = paper.getKeyword().replace( "'", "" ).replace( /\s/ig, "-" );
 
-	return wordMatch( paper.getUrl(), keyword );
+	return wordMatch( paper.getUrl(), keyword, paper.getLocale() );
 };

--- a/js/researches/matchKeywordInSubheadings.js
+++ b/js/researches/matchKeywordInSubheadings.js
@@ -14,13 +14,14 @@ var getSubheadingContents = require( "../stringProcessing/getSubheadings.js" ).g
 module.exports = function( paper ) {
 	var text = paper.getText();
 	var keyword = paper.getKeyword();
+	var locale = paper.getLocale();
 	var result = { count: 0 };
 	text = stripSomeTags( text );
 	var matches = getSubheadingContents( text );
 
 	if ( 0 !== matches.length ) {
 		result.count = matches.length;
-		result.matches = subheadingMatch( matches, keyword );
+		result.matches = subheadingMatch( matches, keyword, locale );
 	}
 
 	return result;

--- a/js/researches/metaDescriptionKeyword.js
+++ b/js/researches/metaDescriptionKeyword.js
@@ -11,6 +11,6 @@ module.exports = function( paper ) {
 	if ( paper.getDescription() === "" ) {
 		return -1;
 	}
-	return matchTextWithWord( paper.getDescription(), paper.getKeyword() );
+	return matchTextWithWord( paper.getDescription(), paper.getKeyword(), paper.getLocale() );
 };
 

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -738,12 +738,14 @@ SnippetPreview.prototype.formatKeyword = function( textString ) {
 	} );
 
 	// Transliterate the keyword for highlighting
-	keyword = transliterate( keyword, this.refObj.rawData.locale );
-	keywordRegex = stringToRegex( keyword, "", false );
-
-	return textString.replace( keywordRegex, function( str ) {
-		return "<strong>" + str + "</strong>";
-	} );
+	var transliterateKeyword = transliterate( keyword, this.refObj.rawData.locale );
+	if( transliterateKeyword !== keyword ) {
+		keywordRegex = stringToRegex( keyword, "", false );
+		textString = textString.replace( keywordRegex, function( str ) {
+			return "<strong>" + str + "</strong>";
+		} );
+	}
+	return textString;
 };
 
 /**

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -13,6 +13,7 @@ var stripHTMLTags = require( "../js/stringProcessing/stripHTMLTags.js" );
 var sanitizeString = require( "../js/stringProcessing/sanitizeString.js" );
 var stripSpaces = require( "../js/stringProcessing/stripSpaces.js" );
 var replaceDiacritics = require( "../js/stringProcessing/replaceDiacritics.js" );
+var transliterate = require( "../js/stringProcessing/transliterate.js" );
 var analyzerConfig = require( "./config/config.js" );
 
 var templates = require( "./templates.js" );
@@ -726,9 +727,9 @@ SnippetPreview.prototype.getPeriodMatches = function() {
  * @returns {string} The formatted keyword.
  */
 SnippetPreview.prototype.formatKeyword = function( textString ) {
-
 	// Removes characters from the keyword that could break the regex, or give unwanted results.
 	var keyword = this.refObj.rawData.keyword.replace( /[\[\]\{\}\(\)\*\+\?\.\^\$\|]/g, " " );
+	keyword = transliterate( keyword, this.refObj.rawData.locale );
 
 	// Match keyword case-insensitively.
 	var keywordRegex = stringToRegex( keyword, "", false );
@@ -747,6 +748,7 @@ SnippetPreview.prototype.formatKeyword = function( textString ) {
  */
 SnippetPreview.prototype.formatKeywordUrl = function( textString ) {
 	var keyword = sanitizeString( this.refObj.rawData.keyword );
+	keyword = transliterate( keyword, this.refObj.rawData.locale );
 	keyword = keyword.replace( /'/, "" );
 
 	var dashedKeyword = keyword.replace( /\s/g, "-" );

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -729,10 +729,18 @@ SnippetPreview.prototype.getPeriodMatches = function() {
 SnippetPreview.prototype.formatKeyword = function( textString ) {
 	// Removes characters from the keyword that could break the regex, or give unwanted results.
 	var keyword = this.refObj.rawData.keyword.replace( /[\[\]\{\}\(\)\*\+\?\.\^\$\|]/g, " " );
-	keyword = transliterate( keyword, this.refObj.rawData.locale );
 
 	// Match keyword case-insensitively.
 	var keywordRegex = stringToRegex( keyword, "", false );
+
+	textString = textString.replace( keywordRegex, function( str ) {
+		return "<strong>" + str + "</strong>";
+	} );
+
+	// Transliterate the keyword for highlighting
+	keyword = transliterate( keyword, this.refObj.rawData.locale );
+	keywordRegex = stringToRegex( keyword, "", false );
+
 	return textString.replace( keywordRegex, function( str ) {
 		return "<strong>" + str + "</strong>";
 	} );

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -739,7 +739,7 @@ SnippetPreview.prototype.formatKeyword = function( textString ) {
 
 	// Transliterate the keyword for highlighting
 	var transliterateKeyword = transliterate( keyword, this.refObj.rawData.locale );
-	if( transliterateKeyword !== keyword ) {
+	if ( transliterateKeyword !== keyword ) {
 		keywordRegex = stringToRegex( keyword, "", false );
 		textString = textString.replace( keywordRegex, function( str ) {
 			return "<strong>" + str + "</strong>";

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -745,7 +745,6 @@ SnippetPreview.prototype.formatKeyword = function( textString ) {
 			return "<strong>" + str + "</strong>";
 		} );
 	}
-	console.log( textString );
 	return textString;
 };
 

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -740,11 +740,12 @@ SnippetPreview.prototype.formatKeyword = function( textString ) {
 	// Transliterate the keyword for highlighting
 	var transliterateKeyword = transliterate( keyword, this.refObj.rawData.locale );
 	if ( transliterateKeyword !== keyword ) {
-		keywordRegex = stringToRegex( keyword, "", false );
+		keywordRegex = stringToRegex( transliterateKeyword, "", false );
 		textString = textString.replace( keywordRegex, function( str ) {
 			return "<strong>" + str + "</strong>";
 		} );
 	}
+	console.log( textString );
 	return textString;
 };
 

--- a/js/stringProcessing/findKeywordInUrl.js
+++ b/js/stringProcessing/findKeywordInUrl.js
@@ -7,14 +7,15 @@ var matchTextWithTransliteration = require( "./matchTextWithTransliteration.js" 
  *
  * @param {string} url The url to check for keyword
  * @param {string} keyword The keyword to check if it is in the URL
+ * @param {string} locale The locale used for transliteration.
  * @returns {boolean} If a keyword is found, returns true
  */
-module.exports = function( url, keyword ) {
+module.exports = function( url, keyword, locale ) {
 	var formatUrl = url.match( />(.*)/ig );
 
 	if ( formatUrl !== null ) {
 		formatUrl = formatUrl[ 0 ].replace( /<.*?>\s?/ig, "" );
-		return matchTextWithTransliteration( formatUrl, keyword ).length > 0;
+		return matchTextWithTransliteration( formatUrl, keyword, locale ).length > 0;
 	}
 	return false;
 };

--- a/js/stringProcessing/matchTextWithTransliteration.js
+++ b/js/stringProcessing/matchTextWithTransliteration.js
@@ -1,21 +1,11 @@
 var map = require( "lodash/map" );
 var addWordBoundary = require( "./addWordboundary.js" );
 var stripSpaces = require( "./stripSpaces.js" );
-
-/**
- * Transliterates the keyword.
- * // todo this needs to be implemented when we have the transliterations. It should take the keyword, transliterate it
- * and return it.
- * @param {String} keyword The keyword to transliterate.
- * @returns {String} The transliterated keyword.
- */
-var transliterate = function( keyword ) {
-	return keyword;
-};
+var transliterate = require( "./transliterate.js" );
 
 /**
  * Creates a regex from the keyword with included wordboundaries.
- * @param {String} keyword The keyword to create a regex from.
+ * @param {string} keyword The keyword to create a regex from.
  * @returns {RegExp} Regular expression of the keyword with wordboundaries.
  */
 var toRegex = function( keyword ) {
@@ -25,17 +15,18 @@ var toRegex = function( keyword ) {
 
 /**
  * Matches a string with and without transliteration.
- * @param {String} text The text to match.
- * @param {String} keyword The keyword to match in the text.
+ * @param {string} text The text to match.
+ * @param {string} keyword The keyword to match in the text.
+ * @param {string} locale The locale used for transliteration.
  * @returns {Array} All matches from the original as the transliterated text and keyword.
  */
-module.exports = function( text, keyword ) {
+module.exports = function( text, keyword, locale ) {
 	var keywordRegex = toRegex( keyword );
 	var matches = text.match( keywordRegex ) || [];
 
 	text = text.replace( keywordRegex, "" );
 
-	var transliterateKeyword = transliterate( keyword );
+	var transliterateKeyword = transliterate( keyword, locale );
 	var transliterateKeywordRegex = toRegex( transliterateKeyword );
 	var transliterateMatches = text.match( transliterateKeywordRegex ) || [];
 

--- a/js/stringProcessing/matchTextWithWord.js
+++ b/js/stringProcessing/matchTextWithWord.js
@@ -9,12 +9,13 @@ var matchStringWithTransliteration = require( "../stringProcessing/matchTextWith
  *
  * @param {string} text The text to use for matching the wordToMatch.
  * @param {string} wordToMatch The word to match in the text
+ * @param {string} locale The locale used for transliteration.
  * @param {string} [extraBoundary] An extra string that can be added to the wordboundary regex
  * @returns {number} The amount of matches found.
  */
-module.exports = function( text, wordToMatch, extraBoundary ) {
+module.exports = function( text, wordToMatch, locale, extraBoundary ) {
 	text = stripSomeTags( text );
 	text = unifyWhitespace( text );
-	var matches = matchStringWithTransliteration( text, wordToMatch, extraBoundary );
+	var matches = matchStringWithTransliteration( text, wordToMatch, locale, extraBoundary );
 	return matches.length;
 };

--- a/js/stringProcessing/subheadingsMatch.js
+++ b/js/stringProcessing/subheadingsMatch.js
@@ -7,9 +7,10 @@ var matchTextWithTransliteration = require( "../stringProcessing/matchTextWithTr
  *
  * @param {Array} matches The array with the matched headings.
  * @param {String} keyword The keyword to match
+ * @param {string} locale The locale used for transliteration.
  * @returns {number} The number of occurrences of the keyword in the headings.
  */
-module.exports = function( matches, keyword ) {
+module.exports = function( matches, keyword, locale ) {
 	var foundInHeader;
 	if ( matches === null ) {
 		foundInHeader = -1;
@@ -22,8 +23,8 @@ module.exports = function( matches, keyword ) {
 				matches[ i ], removalWords
 			);
 			if (
-				matchTextWithTransliteration( formattedHeaders, keyword ).length > 0 ||
-				matchTextWithTransliteration( matches[ i ], keyword ).length > 0
+				matchTextWithTransliteration( formattedHeaders, keyword, locale ).length > 0 ||
+				matchTextWithTransliteration( matches[ i ], keyword, locale ).length > 0
 			) {
 				foundInHeader++;
 			}

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -26,4 +26,10 @@ describe( "the metadescription keyword match research", function() {
 		expect( result ).toBe( -1 );
 	});
 
+	it( "returns the number ( 1 ) of keywords found", function() {
+		var paper = new Paper( "", { keyword: "keywörd", description: "a description with a keyword", locale: "en_US" } );
+		var result = metaDescriptionKeyword( paper );
+		expect( result ).toBe( 1 );
+	});
+
 });

--- a/spec/stringProcessing/matchStringWithTransliterationSpec.js
+++ b/spec/stringProcessing/matchStringWithTransliterationSpec.js
@@ -8,6 +8,10 @@ describe( "matches a string to it's transliterated value", function( ) {
 	} );
 	it( "returns a match in a string with spaces", function(){
 		keyword = "the keyword";
-		expect( matchStringWithTransliteration( str, keyword )[ 0 ] ).toBe( "the keyword");
+		expect( matchStringWithTransliteration( str, keyword )[ 0 ] ).toBe( "the keyword" );
 	} );
+	it( "matches transliteration", function() {
+		keyword = "këyword";
+		expect( matchStringWithTransliteration( str, keyword, "en_US" )[ 0 ] ).toBe( "keyword" );
+	});
 } );

--- a/spec/stringProcessing/wordMatchSpec.js
+++ b/spec/stringProcessing/wordMatchSpec.js
@@ -7,10 +7,7 @@ describe("Counts the occurences of a word in a string", function(){
 		//this fails now because the regex isn't working properly for wordboundaries.
 		//expect(wordMatch("this is a test test test", "test")).toBe(3);
 		expect(wordMatch("test with maïs", "maïs")).toBe(1);
-
-		// This fails without the literations.
-		// Todo: test this when literations are implemented.
-		//expect(wordMatch("test with mais", "maïs")).toBe(1);
+		expect(wordMatch("test with mais", "maïs", "nl_NL")).toBe(1);
 	});
 
 	it( "should not match in HTML tags", function() {


### PR DESCRIPTION
This matches the keyword with transliteration. Passes the locale to all places we match the keyword, so we can also match the transliterated versions. 

Fixes #293 


For testing: check if the transliterated version matches. The locale in the example is en_US
ie: maïs should match mais as well.