### PR TITLE
Check if the value is defined.

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -187,8 +187,8 @@ var isHavingException = function( subSentence, verbs ) {
 	if ( indexOfHaving > -1 ) {
 		var verbIndices = matchArray( subSentence, verbs );
 
-		if ( ! isUndefined( verbIndices[ 0 ] ) && ! isUndefined( verbIndices[ 0 ].index ) ) {
-			// 7 is the number of characters of the word 'having' including space
+		if ( !isUndefined( verbIndices[ 0 ] ) && !isUndefined( verbIndices[ 0 ].index ) ) {
+			// 7 is the number of characters of the word 'having' including space.
 			return verbIndices[ 0 ].index  <= subSentence.indexOf( "having" ) + 7;
 		}
 	}

--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -187,8 +187,10 @@ var isHavingException = function( subSentence, verbs ) {
 	if ( indexOfHaving > -1 ) {
 		var verbIndices = matchArray( subSentence, verbs );
 
-		// 7 is the number of characters of the word 'having' including space
-		return verbIndices[ 0 ].index <= subSentence.indexOf( "having" ) + 7;
+		if ( ! isUndefined( verbIndices[ 0 ] ) && ! isUndefined( verbIndices[ 0 ].index ) ) {
+			// 7 is the number of characters of the word 'having' including space
+			return verbIndices[ 0 ].index  <= subSentence.indexOf( "having" ) + 7;
+		}
 	}
 	return false;
 };


### PR DESCRIPTION
Check if the value in `verbIndices` is defined, before use that one.

Fixes #543 

Test:
Add a text containing `having`, for example: 
> Imagine yourself having an Italian food blog for example with the categories pasta, salads, meat dishes and desserts.