### PR TITLE
Filter on subheadings in sentencedetection

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -7,6 +7,9 @@ var isNaN = require( "lodash/isNaN" );
 
 var getSubheadings = require( "./getSubheadings.js" ).getSubheadings;
 
+// All characters that indicate a sentence delimiter.
+var sentenceDelimiters = ".?!:;";
+
 /**
  * Checks if the period is followed with a whitespace. If not, it is no ending of a sentence.
  *
@@ -80,11 +83,9 @@ var splitOnIndex = function( positions, text ) {
  */
 var findSubheadings = function( text ) {
 	var subheadings = getSubheadings( text );
-	var position = [];
-	forEach( subheadings, function( subheading ) {
-		position.push( subheading.index + subheading[ 0 ].length );
+	return map ( subheadings, function( subheading ) {
+		return subheading.index + subheading[ 0 ].length;
 	} );
-	return position;
 };
 
 /**
@@ -98,7 +99,7 @@ module.exports = function( text ) {
 	var originalText = text;
 
 	// Unify all terminators.
-	text = text.replace( /[.?!\:;]/g, "." );
+	text = text.replace( new RegExp( "[" + sentenceDelimiters + "]", "g" ), "." );
 
 	// Add period in case it is missing.
 	text += ".";

--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -68,7 +68,6 @@ var splitOnIndex = function( positions, text ) {
 	forEach( positions, function( index ) {
 		sentences.push( text.substring( curIndex, index ) );
 
-		// Adds 1 to skip the period.
 		curIndex = index;
 	} );
 	return sentences;

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -2,36 +2,27 @@ var getSentences = require( "../../js/stringProcessing/getSentences.js" );
 describe("Get sentences from text", function(){
 	it("returns sentences", function () {
 		var sentence = "Hello. How are you? Bye";
-		expect( getSentences( sentence )[0] ).toBe( "Hello.");
-		expect( getSentences( sentence )[1] ).toBe( "How are you?");
-		expect( getSentences( sentence )[2] ).toBe( "Bye");
+		expect( getSentences( sentence ) ).toEqual( ["Hello.","How are you?","Bye"] );
 	});
 	it("returns sentences with digits", function () {
 		var sentence = "Hello. 123 Bye";
-		expect( getSentences( sentence )[0] ).toBe( "Hello.");
-		expect( getSentences( sentence )[1] ).toBe( "123 Bye");
+		expect( getSentences( sentence ) ).toEqual( [ "Hello.","123 Bye"] );
 	});
 
 	it("returns sentences with abbreviations", function () {
 		var sentence = "It was a lot. Approx. two hundred";
-		expect( getSentences( sentence )[0] ).toBe( "It was a lot.");
-		expect( getSentences( sentence )[1] ).toBe( "Approx. two hundred");
+		expect( getSentences( sentence ) ).toEqual( ["It was a lot.","Approx. two hundred"] );
 	});
 
 	it("returns sentences with a ! in it (should not be converted to . )", function () {
 		var sentence = "It was a lot. Approx! two hundred";
-		expect( getSentences( sentence )[0] ).toBe( "It was a lot.");
-		expect( getSentences( sentence )[1] ).toBe( "Approx! two hundred");
+		expect( getSentences( sentence ) ).toEqual( [ "It was a lot.","Approx! two hundred" ] );
 	});
 	it("returns sentences with a text with H2 tags", function() {
 		var text = "<h2>Four types of comments</h2>" +
 			"The comments people leave on blogs can be divided into four types: " +
 			"<h2>Positive feedback</h2>" +
 			"First, the positive feedback. ";
-		expect( getSentences( text ).length ).toBe( 4 );
-		expect( getSentences( text )[ 0 ] ).toBe( "<h2>Four types of comments</h2>" );
-		expect( getSentences( text )[ 1 ] ).toBe( "The comments people leave on blogs can be divided into four types:" );
-		expect( getSentences( text )[ 2 ] ).toBe( "<h2>Positive feedback</h2>" );
-		expect( getSentences( text )[ 3 ] ).toBe( "First, the positive feedback. " );
+		expect( getSentences( text ) ).toEqual( ["<h2>Four types of comments</h2>","The comments people leave on blogs can be divided into four types:","<h2>Positive feedback</h2>","First, the positive feedback. "] );
 	})
 });

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -2,25 +2,36 @@ var getSentences = require( "../../js/stringProcessing/getSentences.js" );
 describe("Get sentences from text", function(){
 	it("returns sentences", function () {
 		var sentence = "Hello. How are you? Bye";
-		expect( getSentences( sentence )[0] ).toBe( "Hello");
-		expect( getSentences( sentence )[1] ).toBe( " How are you");
-		expect( getSentences( sentence )[2] ).toBe( " Bye");
+		expect( getSentences( sentence )[0] ).toBe( "Hello.");
+		expect( getSentences( sentence )[1] ).toBe( "How are you?");
+		expect( getSentences( sentence )[2] ).toBe( "Bye");
 	});
 	it("returns sentences with digits", function () {
 		var sentence = "Hello. 123 Bye";
-		expect( getSentences( sentence )[0] ).toBe( "Hello");
-		expect( getSentences( sentence )[1] ).toBe( " 123 Bye");
+		expect( getSentences( sentence )[0] ).toBe( "Hello.");
+		expect( getSentences( sentence )[1] ).toBe( "123 Bye");
 	});
 
 	it("returns sentences with abbreviations", function () {
 		var sentence = "It was a lot. Approx. two hundred";
-		expect( getSentences( sentence )[0] ).toBe( "It was a lot");
-		expect( getSentences( sentence )[1] ).toBe( " Approx. two hundred");
+		expect( getSentences( sentence )[0] ).toBe( "It was a lot.");
+		expect( getSentences( sentence )[1] ).toBe( "Approx. two hundred");
 	});
 
 	it("returns sentences with a ! in it (should not be converted to . )", function () {
 		var sentence = "It was a lot. Approx! two hundred";
-		expect( getSentences( sentence )[0] ).toBe( "It was a lot");
-		expect( getSentences( sentence )[1] ).toBe( " Approx! two hundred");
+		expect( getSentences( sentence )[0] ).toBe( "It was a lot.");
+		expect( getSentences( sentence )[1] ).toBe( "Approx! two hundred");
 	});
+	it("returns sentences with a text with H2 tags", function() {
+		var text = "<h2>Four types of comments</h2>" +
+			"The comments people leave on blogs can be divided into four types: " +
+			"<h2>Positive feedback</h2>" +
+			"First, the positive feedback. ";
+		expect( getSentences( text ).length ).toBe( 4 );
+		expect( getSentences( text )[ 0 ] ).toBe( "<h2>Four types of comments</h2>" );
+		expect( getSentences( text )[ 1 ] ).toBe( "The comments people leave on blogs can be divided into four types:" );
+		expect( getSentences( text )[ 2 ] ).toBe( "<h2>Positive feedback</h2>" );
+		expect( getSentences( text )[ 3 ] ).toBe( "First, the positive feedback. " );
+	})
 });


### PR DESCRIPTION
When a subheading was used in a text, it was regarded as part of the sentence following this subheading. This fixes this. 
Because of this fix, the sentence detection is improved. It now captures the sentence terminator, and removes a trailing whitespace (so we can still see a difference between sentences when it is marked). 
Fixes an invalidation on whitespace that didn't work properly with multiple terminators, and also marks these. 
Adds : and ; as sentence terminator

Fixes #541 

For testing, use texts with subheadings, these should be seen as seperate sentences. 