### PR TITLE
Massively improve transition words assessment

### DIFF
--- a/js/researches/findTransitionWords.js
+++ b/js/researches/findTransitionWords.js
@@ -5,13 +5,16 @@ var getSentences = require( "../stringProcessing/getSentences.js" );
 var createRegexFromArray = require( "../stringProcessing/createRegexFromArray.js" );
 var forEach = require( "lodash/forEach" );
 
+var twoPartTransitionWordsRegex = createRegexFromDoubleArray( twoPartTransitionWords() );
+var transitionWordsRegex = createRegexFromArray( transitionWords() );
+
 /**
  * Matches the sentence against two part transition words.
  * @param {string} sentence The sentence to match against.
  * @returns {Array} The found transitional words.
  */
 var matchTwoPartTransitionWords = function( sentence ) {
-	return sentence.match( createRegexFromDoubleArray( twoPartTransitionWords() ) );
+	return sentence.match( twoPartTransitionWordsRegex );
 };
 
 /**
@@ -20,7 +23,7 @@ var matchTwoPartTransitionWords = function( sentence ) {
  * @returns {Array} The found transitional words.
  */
 var matchTransitionWords = function( sentence ) {
-	return sentence.match( createRegexFromArray( transitionWords() ) );
+	return sentence.match( transitionWordsRegex );
 };
 
 /**


### PR DESCRIPTION
We were creating the transition words regex every single time when
matching a sentence. The regex stays the same so we can move this to
when the module is loaded.

To test this: Just make sure everything still work, I have already
tested this. If you really want to test this: Grab a giant text and put
it in the standalone version.