### PR TITLE
Massively improve performance of passive voice

### DIFF
--- a/js/stringProcessing/stringToRegex.js
+++ b/js/stringProcessing/stringToRegex.js
@@ -4,6 +4,8 @@ var replaceDiacritics = require( "../stringProcessing/replaceDiacritics.js" );
 var sanitizeString = require( "../stringProcessing/sanitizeString.js" );
 var addWordBoundary = require( "../stringProcessing/addWordboundary.js" );
 
+var memoize = require( "lodash/memoize" );
+
 /**
  * Creates a regex from a string so it can be matched everywhere in the same way.
  *
@@ -12,7 +14,7 @@ var addWordBoundary = require( "../stringProcessing/addWordboundary.js" );
  * @param {boolean} [doReplaceDiacritics=true] If set to false, it doesn't replace diacritics. Defaults to true.
  * @returns {RegExp} regex The regex made from the keyword
  */
-module.exports = function( string, extraBoundary, doReplaceDiacritics ) {
+module.exports = memoize( function( string, extraBoundary, doReplaceDiacritics ) {
 	if ( isUndefined( extraBoundary ) ) {
 		extraBoundary = "";
 	}
@@ -24,4 +26,4 @@ module.exports = function( string, extraBoundary, doReplaceDiacritics ) {
 	string = sanitizeString( string );
 	string = addWordBoundary( string, extraBoundary );
 	return new RegExp( string, "ig" );
-};
+} );


### PR DESCRIPTION
The passive voice makes extensive use of giant list of words that need
to be transformed to regexes. We were transforming these each time we
needed the regex. Now we cache them using lodash's memoize.

This can be much improved over time by shipping a data structure that is
already optimized instead of relying on the memory to save time.

To test this: Just make sure everything still work, I have already
tested this. If you really want to test this: Grab a giant text and put
it in the standalone version.