### PR TITLE
Move the remove all marks button outside of the list.

### DIFF
--- a/js/templates.js
+++ b/js/templates.js
@@ -38,7 +38,7 @@
   var undefined;
 
   /** Used as the semantic version number. */
-  var VERSION = '4.12.0';
+  var VERSION = '4.11.2';
 
   /** Used as references for various `Number` constants. */
   var INFINITY = 1 / 0;
@@ -304,9 +304,9 @@
     var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
     function print() { __p += __j.call(arguments, '') }
     with (obj) {
-    __p += '<ul class="wpseoanalysis assessment-results">\n    <button type="button" class="assessment-results__remove-marks js-assessment-results__remove-marks"><span class="screen-reader-text">' +
+    __p += '<button type="button" class="assessment-results__remove-marks js-assessment-results__remove-marks"><span class="screen-reader-text">' +
     ((__t = ( i18n.removeMarks )) == null ? '' : __t) +
-    '</span></button>\n    ';
+    '</span></button>\n<ul class="wpseoanalysis assessment-results">\n    ';
      for (var i in scores) {
     __p += '\n        <li class="score">\n            <span class="wpseo-score-icon ' +
     __e( scores[ i ].className ) +

--- a/templates/assessmentPresenterResult.jst
+++ b/templates/assessmentPresenterResult.jst
@@ -1,5 +1,5 @@
+<button type="button" class="assessment-results__remove-marks js-assessment-results__remove-marks"><span class="screen-reader-text"><%= i18n.removeMarks %></span></button>
 <ul class="wpseoanalysis assessment-results">
-    <button type="button" class="assessment-results__remove-marks js-assessment-results__remove-marks"><span class="screen-reader-text"><%= i18n.removeMarks %></span></button>
     <% for (var i in scores) { %>
         <li class="score">
             <span class="wpseo-score-icon <%- scores[ i ].className %>"></span>


### PR DESCRIPTION
Fixes #574 

Makes the markup valid and lets assistive technologies correctly report the number of items in the list. As far as I can tell, should not harm anything... unless I'm missing something :)