### PR TITLE
Fixes sentence matching with tags

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -11,11 +11,11 @@ var getSubheadings = require( "./getSubheadings.js" ).getSubheadings;
 var sentenceDelimiters = ".?!:;";
 
 /**
- * Checks if the period is followed with a whitespace. If not, it is no ending of a sentence.
+ * Checks if the period is followed with a whitespace or < for an html-tag. If not, it is no ending of a sentence.
  *
  * @param {string} text The text to split in sentences.
  * @param {number} index The current index to look for.
- * @returns {boolean} True if it doesn't match a whitespace.
+ * @returns {boolean} True if it doesn't match a whitespace or < .
  */
 var invalidateOnWhiteSpace = function( text, index ) {
 	return text.substring( index, index + 1 ).match( /\s|</ ) === null;

--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -18,7 +18,7 @@ var sentenceDelimiters = ".?!:;";
  * @returns {boolean} True if it doesn't match a whitespace.
  */
 var invalidateOnWhiteSpace = function( text, index ) {
-	return text.substring( index, index + 1 ).match( /\s/ ) === null;
+	return text.substring( index, index + 1 ).match( /\s|</ ) === null;
 };
 
 /**
@@ -32,11 +32,15 @@ var invalidateOnWhiteSpace = function( text, index ) {
  */
 var invalidateOnCapital = function( text, positions, i ) {
 
+	if( text.substring( positions[ i ], positions[ i ] + 1 ) === "<" ) {
+		return false;
+	}
+
 	// The current index + 1 should be the first character of the new sentence. We use a range of 1, since we only need the first character.
 	var firstChar = text.substring( positions[ i ] + 1, positions[ i ] + 2 );
 
 	// If a sentence starts with a number or a whitespace, it shouldn't invalidate
-	if ( firstChar === firstChar.toLocaleLowerCase() && isNaN( parseInt( firstChar, 10 ) ) && firstChar.match( /[\s<]/ ) === null ) {
+	if ( firstChar === firstChar.toLocaleLowerCase() && isNaN( parseInt( firstChar, 10 ) ) && firstChar.match( /\s|</ ) === null ) {
 		return true;
 	}
 };
@@ -83,9 +87,72 @@ var splitOnIndex = function( positions, text ) {
  */
 var findSubheadings = function( text ) {
 	var subheadings = getSubheadings( text );
-	return map ( subheadings, function( subheading ) {
+	return map( subheadings, function( subheading ) {
 		return subheading.index + subheading[ 0 ].length;
 	} );
+};
+
+/**
+ * Matches a partial tag. If a sentence starts with a tag it should end with it. If it doesn't
+ * it is a partial tag and it should be removed since it can break markers.
+ * @param {string} sentence The sentence to check for tags.
+ * @returns {{startTag: string, endTag: string}} The start and endtag. If no tags are found, both return an empty string.
+ */
+var matchPartialTag = function( sentence ) {
+
+	// Matches a starttag at the beginning of the sentence.
+	var beginMatch = sentence.match( /^<(.\S|>+)/ ) || [];
+
+	// Matches an endtag at the end of the sentence.
+	var endMatch = sentence.match( /\/(.\S+)>$/ ) || [];
+
+	var startTag = "";
+	var endTag = "";
+	if ( !isUndefined( beginMatch.length > 1 ) ) {
+		startTag = beginMatch[ 1 ];
+	}
+	if ( !isUndefined( endMatch.length > 1 ) ) {
+		endTag = endMatch[ 1 ];
+	}
+	return{
+		startTag: startTag,
+		endTag: endTag
+	};
+};
+
+/**
+ * Removes partial tags at the beginning of a sentence. Runs it untill it cannot find partial tags at the beginning.
+ * @param {string} sentence The sentence to check for partial tags.
+ * @returns {string} the sentence with replaced tags.
+ */
+var stripPartialStartTag = function( sentence ) {
+	var tags = matchPartialTag( sentence );
+	while( tags.startTag !== tags.endTag ) {
+		sentence = sentence.replace( /(<([^>]+)>)/, "" );
+		tags = matchPartialTag( sentence );
+	}
+	return sentence;
+};
+
+/**
+ * Strips the sentence from excess whitespace and partial tags.
+ * @param {string} sentence The sentence to clean.
+ * @returns {string} The cleaned sentence.
+ */
+var cleanSentence = function( sentence ) {
+
+	// Strip whitespaces at the beginning of the sentence.
+	sentence = sentence.replace( /^\s/, "" );
+
+	// Strip endtag at the beginning of sentence.
+	while( sentence.match( /^(<\/[^>]+>)/ ) !== null ) {
+		sentence = sentence.replace( /^(<\/[^>]+>)/, "" );
+	}
+
+	// Strip partial tags in the sentence.
+	sentence = stripPartialStartTag( sentence );
+
+	return sentence;
 };
 
 /**
@@ -118,9 +185,9 @@ module.exports = function( text ) {
 	} );
 	var sentences = splitOnIndex( positions, originalText );
 
-	// Remove whitespace on start of sentence.
+	// Clean sentences by stripping HTMLtags
 	sentences = map( sentences, function( sentence ) {
-		return sentence.replace( /^\s/, "" );
+		return cleanSentence( sentence );
 	} );
 
 	return filter( sentences, function( sentence ) {

--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -32,7 +32,7 @@ var invalidateOnWhiteSpace = function( text, index ) {
  */
 var invalidateOnCapital = function( text, positions, i ) {
 
-	if( text.substring( positions[ i ], positions[ i ] + 1 ) === "<" ) {
+	if ( text.substring( positions[ i ], positions[ i ] + 1 ) === "<" ) {
 		return false;
 	}
 
@@ -108,13 +108,16 @@ var matchPartialTag = function( sentence ) {
 
 	var startTag = "";
 	var endTag = "";
+
 	if ( !isUndefined( beginMatch.length > 1 ) ) {
 		startTag = beginMatch[ 1 ];
 	}
+
 	if ( !isUndefined( endMatch.length > 1 ) ) {
 		endTag = endMatch[ 1 ];
 	}
-	return{
+
+	return {
 		startTag: startTag,
 		endTag: endTag
 	};
@@ -131,6 +134,7 @@ var stripPartialStartTag = function( sentence ) {
 		sentence = sentence.replace( /(<([^>]+)>)/, "" );
 		tags = matchPartialTag( sentence );
 	}
+
 	return sentence;
 };
 
@@ -185,7 +189,7 @@ module.exports = function( text ) {
 	} );
 	var sentences = splitOnIndex( positions, originalText );
 
-	// Clean sentences by stripping HTMLtags
+	// Clean sentences by stripping HTMLtags.
 	sentences = map( sentences, function( sentence ) {
 		return cleanSentence( sentence );
 	} );

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -30,5 +30,21 @@ describe("Get sentences from text", function(){
 			"<h2>Positive feedback</h2>" +
 			"First, the positive feedback. ";
 		expect( getSentences( text ) ).toEqual( ["<h2>Four types of comments</h2>","The comments people leave on blogs can be divided into four types:","<h2>Positive feedback</h2>","First, the positive feedback. "] );
+	});
+
+	it( "returns a sentence with incomplete tags", function() {
+		var text = "<p>Some text. More Text.</p>";
+		expect( getSentences( text ) ).toEqual( [ "Some text.", "More Text."] );
+	});
+
+	it( "returns a sentence with incomplete tags per sentence", function() {
+		var text = "<p><span>Some text. More Text.</span></p>";
+		expect( getSentences( text ) ).toEqual( [ "Some text.", "More Text."] );
+	});
+
+	it( "returns a sentence with incomplete tags with a link", function() {
+		var text = "Some text. More Text with <a href='http://yoast.com'>a link</a>.";
+		expect( getSentences( text ) ).toEqual( [ "Some text.", "More Text with <a href='http://yoast.com'>a link</a>."] );
 	})
+
 });


### PR DESCRIPTION
When matching a sentence checks for partial HTML-tags. If a sentence starts with an endtag, it should be stripped. Sentences that end with an endtag, but don't have the starttag, should be stripped as well, since they can break marks. 

For testing: check of a sentence with a partial tag is stripped correctly. The easiest way is to check the marks.