### PR TITLE
Icon eye buttons focus and active style

### DIFF
--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -92,8 +92,9 @@ li.score {
 		&.icon-eye {
 			&-inactive, &-active {
 				border: 0;
-				width: 16px;
-				height: 16px;
+				width: 28px;
+				height: 28px;
+				padding: 4px;
 				outline: none;
 				background: no-repeat center;
 				background-size: 16px;
@@ -108,12 +109,19 @@ li.score {
 				background-image: url(svg-icon-eye($color_marker_active));
 			}
 		}
+
+		&:focus {
+			border-radius: 100%;
+			box-shadow: 0 0 0 1px #5b9dd9,
+			0 0 2px 1px rgba(30, 140, 190, 0.8);
+		}
 	}
 
 	&__remove-marks {
 		border: 0;
-		width: 16px;
-		height: 16px;
+		width: 28px;
+		height: 28px;
+		padding: 4px;
 		outline: none;
 		background: url(svg-icon-eye-slash($color_marker_inactive)) no-repeat center;
 		background-size: 16px;
@@ -121,5 +129,11 @@ li.score {
 		margin-top: -16px;
 
 		float: right;
+
+		&:focus {
+			border-radius: 100%;
+			box-shadow: 0 0 0 1px #5b9dd9,
+			0 0 2px 1px rgba(30, 140, 190, 0.8);
+		}
 	}
 }

--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -6,17 +6,20 @@
 	padding-right: 0px;
 }
 .wpseo-score-text {
-	display: inline-block;
+	float: left;
 	width: 86%;
+	/* make room for score and mark icons, consider to use a better layout model */
+	width: calc( 100% - 56px );
 }
-.wpseo-score-icon {
-	display: inline-block;
+
+/* needs higher specificity than other score icons */
+.assessment-results .wpseo-score-icon {
+	float: left;
 	width: 12px;
 	height: 12px;
-	margin: 3px 10px 0 3px;
+	margin: 3px 10px 0 0;
 	border-radius: 50%;
 	background: #888;
-	vertical-align: top;
 }
 
 .wpseo-score-icon.good {
@@ -42,6 +45,12 @@
 li.score {
 	list-style-type: none !important;
 	margin-bottom: 6px;
+}
+
+li.score:after {
+	content: "";
+	display: table;
+	clear: both;
 }
 
 .screen-reader-text {
@@ -87,22 +96,21 @@ li.score {
 }
 
 .assessment-results {
-	padding-top: 16px;
 
 	&__mark {
 		&.icon-eye {
 			&-inactive, &-active {
+				float: left;
 				border: 0;
 				width: 28px;
 				height: 28px;
-				margin-top: -5px;
+				margin: -5px 0 0 3px;
 				padding: 4px;
 				border-radius: 100%;
 				outline: none;
 				background: no-repeat center;
 				background-size: 16px;
 				cursor: pointer;
-				vertical-align: top;
 			}
 
 			&-inactive {

--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -7,7 +7,7 @@
 }
 .wpseo-score-text {
 	display: inline-block;
-	width: 90%;
+	width: 86%;
 }
 .wpseo-score-icon {
 	display: inline-block;
@@ -95,10 +95,12 @@ li.score {
 				width: 28px;
 				height: 28px;
 				padding: 4px;
+				border-radius: 100%;
 				outline: none;
 				background: no-repeat center;
 				background-size: 16px;
 				cursor: pointer;
+				vertical-align: top;
 			}
 
 			&-inactive {
@@ -107,6 +109,7 @@ li.score {
 
 			&-active {
 				background-image: url(svg-icon-eye($color_marker_active));
+				background-color: #a4286a;
 			}
 		}
 
@@ -122,6 +125,7 @@ li.score {
 		width: 28px;
 		height: 28px;
 		padding: 4px;
+		border-radius: 100%;
 		outline: none;
 		background: url(svg-icon-eye-slash($color_marker_inactive)) no-repeat center;
 		background-size: 16px;
@@ -131,7 +135,6 @@ li.score {
 		float: right;
 
 		&:focus {
-			border-radius: 100%;
 			box-shadow: 0 0 0 1px #5b9dd9,
 			0 0 2px 1px rgba(30, 140, 190, 0.8);
 		}

--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -41,6 +41,7 @@
 
 li.score {
 	list-style-type: none !important;
+	margin-bottom: 6px;
 }
 
 .screen-reader-text {
@@ -94,6 +95,7 @@ li.score {
 				border: 0;
 				width: 28px;
 				height: 28px;
+				margin-top: -5px;
 				padding: 4px;
 				border-radius: 100%;
 				outline: none;

--- a/css/_colors.scss
+++ b/css/_colors.scss
@@ -20,4 +20,4 @@ $color_headings: #555555;
 $color_buttons: #555555;
 
 $color_marker_inactive: #555555;
-$color_marker_active: #1074a8;
+$color_marker_active: #ffffff;


### PR DESCRIPTION
First pass for new icon-eye buttons style. Fixes #571 

We may need to adjust the position and vertical alignment of the buttons. The buttons are taller now and in order to align the "eye" with the text on the left we need some margin between the list items. Notice that when used in WordPress, list items already inherit some bottom margin. By the way, when the assessment text is in just one line, the margin between items can be uneven:

<img width="689" alt="screen shot 2016-06-01 at 13 07 41" src="https://cloud.githubusercontent.com/assets/1682452/15707988/1cfe1686-27fc-11e6-9c86-bf3838b79b4b.png">
 
One way to fix this would be making the buttons "overlap" a bit (backgrounds in the screenshot below are just for testing purposes):

<img width="665" alt="screen shot 2016-06-01 at 13 06 20" src="https://cloud.githubusercontent.com/assets/1682452/15707998/331deea0-27fc-11e6-98b2-96cbc8d8d5fc.png">

Or maybe try to make the buttons a bit smaller, but I'd rather accept the slightly uneven margin.
