### PR TITLE
Adds extra characters to check for sentence ending

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -14,14 +14,23 @@ var sentenceDelimiters = ".?!:;";
 var sentenceEndingRegex = /[\s<\)\]\"\']/;
 
 /**
- * Checks if the period is followed with a character that is a valid sentence ending. If not, it is no ending of a sentence.
+ * Checks if the character following a sentence is an invalid sentence ending.
+ * @param {string} character The character to match on.
+ * @returns {boolean} true if it matches.
+ */
+var isInvalidSentenceEnding = function( character ) {
+	return character.match( sentenceEndingRegex ) !== null;
+};
+
+/**
+ * Checks if the period is followed with a character that is a valid sentence ending. If not, it is not an ending of a sentence.
  *
  * @param {string} text The text to split in sentences.
  * @param {number} index The current index to look for.
  * @returns {boolean} True if it doesn't match a whitespace.
  */
 var invalidateOnCharacter = function( text, index ) {
-	return text.substring( index, index + 1 ).match( sentenceEndingRegex ) === null;
+	return !isInvalidSentenceEnding( text.substring( index, index + 1 ) );
 };
 
 /**
@@ -39,7 +48,7 @@ var invalidateOnCapital = function( text, positions, i ) {
 	var firstChar = text.substring( positions[ i ] + 1, positions[ i ] + 2 );
 
 	// If a sentence starts with a number or a whitespace, it shouldn't invalidate
-	if ( firstChar === firstChar.toLocaleLowerCase() && isNaN( parseInt( firstChar, 10 ) ) && firstChar.match( sentenceEndingRegex ) === null ) {
+	if ( firstChar === firstChar.toLocaleLowerCase() && isNaN( parseInt( firstChar, 10 ) ) && !isInvalidSentenceEnding( firstChar ) ) {
 		return true;
 	}
 };
@@ -52,10 +61,11 @@ var invalidateOnCapital = function( text, positions, i ) {
  */
 var filterPositions = function( text, positions ) {
 	return filter( positions, function( position, index ) {
-		if ( !isUndefined( positions[ index + 1 ] ) ) {
-			if ( invalidateOnCharacter( text, positions[ index ] ) || invalidateOnCapital( text, positions, index ) ) {
-				return false;
-			}
+		if ( isUndefined( positions[ index + 1 ] ) ) {
+			return true;
+		}
+		if ( invalidateOnCharacter( text, positions[ index ] ) || invalidateOnCapital( text, positions, index ) ) {
+			return false;
 		}
 		return true;
 	} );

--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -20,7 +20,7 @@ var sentenceEndingRegex = /[\s<\)\]\"\']/;
  * @param {number} index The current index to look for.
  * @returns {boolean} True if it doesn't match a whitespace.
  */
-var invalidateOnCharacter = function(text, index ) {
+var invalidateOnCharacter = function( text, index ) {
 	return text.substring( index, index + 1 ).match( sentenceEndingRegex ) === null;
 };
 

--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -10,15 +10,18 @@ var getSubheadings = require( "./getSubheadings.js" ).getSubheadings;
 // All characters that indicate a sentence delimiter.
 var sentenceDelimiters = ".?!:;";
 
+// If a sentence delimiter is followed by one of these characters, it is a valid ending.
+var sentenceEndingRegex = /[\s<\)\]\"\']/;
+
 /**
- * Checks if the period is followed with a whitespace. If not, it is no ending of a sentence.
+ * Checks if the period is followed with a character that is a valid sentence ending. If not, it is no ending of a sentence.
  *
  * @param {string} text The text to split in sentences.
  * @param {number} index The current index to look for.
  * @returns {boolean} True if it doesn't match a whitespace.
  */
-var invalidateOnWhiteSpace = function( text, index ) {
-	return text.substring( index, index + 1 ).match( /\s/ ) === null;
+var invalidateOnCharacter = function(text, index ) {
+	return text.substring( index, index + 1 ).match( sentenceEndingRegex ) === null;
 };
 
 /**
@@ -36,7 +39,7 @@ var invalidateOnCapital = function( text, positions, i ) {
 	var firstChar = text.substring( positions[ i ] + 1, positions[ i ] + 2 );
 
 	// If a sentence starts with a number or a whitespace, it shouldn't invalidate
-	if ( firstChar === firstChar.toLocaleLowerCase() && isNaN( parseInt( firstChar, 10 ) ) && firstChar.match( /[\s<]/ ) === null ) {
+	if ( firstChar === firstChar.toLocaleLowerCase() && isNaN( parseInt( firstChar, 10 ) ) && firstChar.match( sentenceEndingRegex ) === null ) {
 		return true;
 	}
 };
@@ -50,7 +53,7 @@ var invalidateOnCapital = function( text, positions, i ) {
 var filterPositions = function( text, positions ) {
 	return filter( positions, function( position, index ) {
 		if ( !isUndefined( positions[ index + 1 ] ) ) {
-			if ( invalidateOnWhiteSpace( text, positions[ index ] ) || invalidateOnCapital( text, positions, index ) ) {
+			if ( invalidateOnCharacter( text, positions[ index ] ) || invalidateOnCapital( text, positions, index ) ) {
 				return false;
 			}
 		}

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -30,5 +30,18 @@ describe("Get sentences from text", function(){
 			"<h2>Positive feedback</h2>" +
 			"First, the positive feedback. ";
 		expect( getSentences( text ) ).toEqual( ["<h2>Four types of comments</h2>","The comments people leave on blogs can be divided into four types:","<h2>Positive feedback</h2>","First, the positive feedback. "] );
+	});
+
+	it( "returns sentences with a text with a bracket", function() {
+		var text = "This is a sentence.)With a bracket on the end";
+		expect( getSentences( text ) ).toEqual( ["This is a sentence.", ")With a bracket on the end" ] );
+	});
+	it( "returns sentences with a text with a bracket", function() {
+		var text = "This is a sentence.]With a bracket on the end";
+		expect( getSentences( text ) ).toEqual( ["This is a sentence.", "]With a bracket on the end" ] );
+	})
+	it( "returns sentences with a text with a quote", function() {
+		var text = "This is a sentence.'With a bracket on the end";
+		expect( getSentences( text ) ).toEqual( ["This is a sentence.", "'With a bracket on the end" ] );
 	})
 });


### PR DESCRIPTION
Fixes #582 

This adds a number of characters that should validate as sentence endings. 

If a period is directly followed by a whitespace, `' " < ) or ]` it should validate as a sentence ending. 

For testing. End a sentence with `.)`, it should validate the period as an ending. 