### PR TITLE
Adds markers for subheadingtexts

### DIFF
--- a/js/assessments/subheadingDistributionTooLongAssessment.js
+++ b/js/assessments/subheadingDistributionTooLongAssessment.js
@@ -1,27 +1,33 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var isTextTooLong = require( "../helpers/isValueTooLong" );
 var filter = require( "lodash/filter" );
+var map = require( "lodash/map" );
+
+var Mark = require( "../values/Mark.js" );
+var marker = require( "../markers/addMark.js" );
+
+// The maximum recommended value of the subheading text.
+var recommendedValue = 300;
 
 /**
  * Counts the number of subheading texts that are too long.
  * @param {Array} subheadingTextsLength Array with subheading text lengths.
- * @param {number} recommendedValue The recommended maximum value of the subheading text length
  * @returns {number} The number of subheading texts that are too long.
  */
-var getTooLongSubheadingTexts = function( subheadingTextsLength, recommendedValue ) {
-	var tooLongTexts = filter( subheadingTextsLength, isTextTooLong.bind( null, recommendedValue ) );
-	return tooLongTexts.length;
+var getTooLongSubheadingTexts = function( subheadingTextsLength ) {
+	return filter( subheadingTextsLength, function( subheading ) {
+		return isTextTooLong( recommendedValue, subheading.wordCount );
+	} );
 };
 
 /**
  * Calculates the score based on the subheading texts length.
  * @param {Array} subheadingTextsLength Array with subheading text lengths.
  * @param {number} tooLongTexts The number of subheading texts that are too long.
- * @param {number} recommendedValue The recommended maximum value of the subheading text length
  * @param {object} i18n The object used for translations.
  * @returns {object} the resultobject containing a score and text if subheadings are present
  */
-var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, recommendedValue, i18n ) {
+var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, i18n ) {
 
 	// Return empty result if there are no subheadings
 	if ( subheadingTextsLength.length === 0 ) {
@@ -30,7 +36,7 @@ var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, recom
 
 	// 6 is the number of scorepoints between 3, minscore and 9, maxscore. For scoring we use 100 steps, each step is 0.06.
 	// Up to 267  is for scoring a 9, higher numbers give lower scores.
-	var score = 9 - Math.max( Math.min( ( 0.06 ) * ( subheadingTextsLength[ 0 ] - 267 ), 6 ), 0 );
+	var score = 9 - Math.max( Math.min( ( 0.06 ) * ( subheadingTextsLength[ 0 ].wordCount - 267 ), 6 ), 0 );
 
 	if ( score >= 7 ) {
 		return {
@@ -44,6 +50,7 @@ var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, recom
 	}
 	return {
 		score: score,
+		hasMarks: true,
 
 		// translators: %1$d expands to the number of subheadings, %2$d expands to the recommended value
 		text: i18n.sprintf(
@@ -58,6 +65,25 @@ var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, recom
 };
 
 /**
+ * Creates a marker for each text following a subheading that is too long.
+ * @param {Paper} paper The paper to use for the assessment.
+ * @param {object} researcher The researcher used for calling research.
+ * @returns {Array} All markers for the current text.
+ */
+var subheadingsMarker = function( paper, researcher ) {
+	var subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
+	var tooLongTexts = getTooLongSubheadingTexts( subheadingTextsLength );
+
+	return map( tooLongTexts, function( tooLongText ) {
+		var marked = marker( tooLongText.text );
+		return new Mark( {
+			original: tooLongText.text,
+			marked: marked
+		} );
+	} );
+};
+
+/**
  * Runs the getSubheadingLength research and checks scores based on length.
  *
  * @param {Paper} paper The paper to use for the assessment.
@@ -69,17 +95,17 @@ var getSubheadingsTextLength = function( paper, researcher, i18n ) {
 	var subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
 	subheadingTextsLength = subheadingTextsLength.sort(
 		function( a, b ) {
-			return b - a;
+			return b.wordCount - a.wordCount;
 		}
 	);
-	var recommendedValue = 300;
-	var tooLongTexts = getTooLongSubheadingTexts( subheadingTextsLength, recommendedValue );
-	var subheadingsTextLengthresult = subheadingsTextLength( subheadingTextsLength, tooLongTexts, recommendedValue, i18n );
+	var tooLongTexts = getTooLongSubheadingTexts( subheadingTextsLength ).length;
+	var subheadingsTextLengthresult = subheadingsTextLength( subheadingTextsLength, tooLongTexts, i18n );
 
 	var assessmentResult = new AssessmentResult();
 
 	assessmentResult.setScore( subheadingsTextLengthresult.score );
 	assessmentResult.setText( subheadingsTextLengthresult.text );
+	assessmentResult.setHasMarks( subheadingsTextLengthresult.hasMarks );
 
 	return assessmentResult;
 };
@@ -89,5 +115,6 @@ module.exports = {
 	getResult: getSubheadingsTextLength,
 	isApplicable: function( paper ) {
 		return paper.hasText();
-	}
+	},
+	getMarks: subheadingsMarker
 };

--- a/js/assessments/subheadingDistributionTooShortAssessment.js
+++ b/js/assessments/subheadingDistributionTooShortAssessment.js
@@ -1,27 +1,33 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var isTextTooShort = require( "../helpers/isValueTooShort" );
 var filter = require( "lodash/filter" );
+var map = require( "lodash/map" );
+
+var Mark = require( "../values/Mark.js" );
+var marker = require( "../markers/addMark.js" );
+
+// The minimum recommended value.
+var recommendedValue = 40;
 
 /**
  * Counts the number of subheading texts that are too short.
  * @param {Array} subheadingTextsLength Array with subheading text lengths.
- * @param {number} recommendedValue The recommended minimum value of the subheading text length
  * @returns {number} The number of subheading texts that are too short.
  */
-var getTooShortSubheadingTexts = function( subheadingTextsLength, recommendedValue ) {
-	var tooShortTexts = filter( subheadingTextsLength, isTextTooShort.bind( null, recommendedValue ) );
-	return tooShortTexts.length;
+var getTooShortSubheadingTexts = function( subheadingTextsLength ) {
+	return filter( subheadingTextsLength, function( subheading ) {
+		return isTextTooShort( recommendedValue, subheading.wordCount );
+	} );
 };
 
 /**
  * Calculates the score based on the subheading texts length.
  * @param {Array} subheadingTextsLength Array with subheading text lengths.
  * @param {number} tooShortTexts The number of subheading texts that are too long.
- * @param {number} recommendedValue The recommended minimum value of the subheading text length
  * @param {object} i18n The object used for translations.
  * @returns {object} the resultobject containing a score and text if subheadings are present
  */
-var subheadingsTextLength = function( subheadingTextsLength, tooShortTexts, recommendedValue, i18n ) {
+var subheadingsTextLength = function( subheadingTextsLength, tooShortTexts, i18n ) {
 
 	// Return empty result if there are no subheadings
 	if ( subheadingTextsLength.length === 0 ) {
@@ -30,7 +36,7 @@ var subheadingsTextLength = function( subheadingTextsLength, tooShortTexts, reco
 
 	// 6 is the number of scorepoints between 3, minscore and 9, maxscore. For scoring we use 40 steps, each step is 0.15.
 	// Up to 267  is for scoring a 9, higher numbers give lower scores.
-	var score = 3 + Math.max( Math.min( ( 6 / 40 ) * ( subheadingTextsLength[ 0 ] - 13 ), 6 ), 0 );
+	var score = 3 + Math.max( Math.min( ( 6 / 40 ) * ( subheadingTextsLength[ 0 ].wordCount - 13 ), 6 ), 0 );
 
 	if ( score >= 7 ) {
 		return {
@@ -45,6 +51,7 @@ var subheadingsTextLength = function( subheadingTextsLength, tooShortTexts, reco
 	}
 	return {
 		score: score,
+		hasMarks: true,
 
 		// translators: %1$d expands to the number of subheadings, %2$d expands to the recommended value
 		text: i18n.sprintf(
@@ -61,6 +68,25 @@ var subheadingsTextLength = function( subheadingTextsLength, tooShortTexts, reco
 };
 
 /**
+ * Creates a marker for each text following a subheading that is too short.
+ * @param {Paper} paper The paper to use for the assessment.
+ * @param {object} researcher The researcher used for calling research.
+ * @returns {Array} All markers for the current text.
+ */
+var subheadingsMarker = function( paper, researcher ) {
+	var subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
+	var tooShortTexts = getTooShortSubheadingTexts( subheadingTextsLength );
+
+	return map( tooShortTexts, function( tooShortText ) {
+		var marked = marker( tooShortText.text );
+		return new Mark( {
+			original: tooShortText.text,
+			marked: marked
+		} );
+	} );
+};
+
+/**
  * Runs the getSubheadingLength research and checks scores based on length.
  *
  * @param {Paper} paper The paper to use for the assessment.
@@ -72,16 +98,18 @@ var getSubheadingsTextLength = function( paper, researcher, i18n ) {
 	var subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
 	subheadingTextsLength = subheadingTextsLength.sort(
 		function( a, b ) {
-			return a - b;
+			return a.wordCount - b.wordCount;
 		}
 	);
-	var recommendedValue = 40;
-	var tooShortTexts = getTooShortSubheadingTexts( subheadingTextsLength, recommendedValue );
-	var subheadingsTextLengthresult = subheadingsTextLength( subheadingTextsLength, tooShortTexts, recommendedValue, i18n );
+
+	var tooShortTexts = getTooShortSubheadingTexts( subheadingTextsLength ).length;
+	var subheadingsTextLengthresult = subheadingsTextLength( subheadingTextsLength, tooShortTexts, i18n );
 
 	var assessmentResult = new AssessmentResult();
 	assessmentResult.setScore( subheadingsTextLengthresult.score );
 	assessmentResult.setText( subheadingsTextLengthresult.text );
+	assessmentResult.setHasMarks( subheadingsTextLengthresult.hasMarks );
+
 	return assessmentResult;
 };
 
@@ -90,5 +118,6 @@ module.exports = {
 	getResult: getSubheadingsTextLength,
 	isApplicable: function( paper ) {
 		return paper.hasText();
-	}
+	},
+	getMarks: subheadingsMarker
 };

--- a/js/researches/getSubheadingTextLengths.js
+++ b/js/researches/getSubheadingTextLengths.js
@@ -15,7 +15,10 @@ module.exports = function( paper ) {
 	var subHeadingTexts = [];
 	forEach( matches, function( subHeading ) {
 
-		subHeadingTexts.push( countWords( subHeading ) );
+		subHeadingTexts.push( {
+			text: subHeading,
+			wordCount: countWords( subHeading )
+		} );
 	} );
 	return subHeadingTexts;
 };

--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -6,13 +6,13 @@ var i18n = Factory.buildJed();
 var paper = new Paper();
 describe( "An assessment for scoring too long sub texts.", function() {
 	it( "scores 3 subheading texts, 0 are too long", function() {
-		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ 60,  100, 300 ] ), i18n );
+		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 100}, {text: "", wordCount: 300} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 7.02 );
 		expect( assessment.getText() ).toBe( "The amount of words following each of your subheadings doesn't exceed the recommended maximum of 300 words, which is great." );
 	} );
 
 	it( "scores 3 subheading texts, 0 are too long", function() {
-		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ 60,  100, 200 ] ), i18n );
+		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 100}, {text: "", wordCount: 200} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The amount of words following each of your subheadings doesn't exceed the recommended maximum of 300 words, which is great." );
 	} );
@@ -22,13 +22,13 @@ describe( "An assessment for scoring too long sub texts.", function() {
 		expect( assessment.hasScore() ).toBe( false );
 	} );
 	it ( "returns a heading that is too long", function() {
-		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ 60,  400, 300 ] ), i18n );
+		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 400}, {text: "", wordCount: 300} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "1 of the subheadings is followed by more than the recommended maximum of 300 words. Try to insert another subheading." );
 	} );
 
 	it ( "returns a heading that is too long", function() {
-		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ 60,  310, 310, 310 ] ), i18n );
+		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 310}, {text: "", wordCount: 310}, {text: "", wordCount: 310} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 6.42 );
 		expect( assessment.getText() ).toBe( "3 of the subheadings are followed by more than the recommended maximum of 300 words. Try to insert additional subheadings." );
 	} );

--- a/spec/assessments/subheadingDistributionTooShortSpec.js
+++ b/spec/assessments/subheadingDistributionTooShortSpec.js
@@ -6,13 +6,13 @@ var i18n = Factory.buildJed();
 var paper = new Paper();
 describe( "An assessment for scoring too long sub texts.", function() {
 	it( "scores 3 subheading texts, 0 are too long", function() {
-		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ 40,  100, 300 ] ), i18n );
+		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 40},{text: "", wordCount: 100},{text: "", wordCount: 300} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 7.05 );
 		expect( assessment.getText() ).toBe( "The number of words following each of your subheadings exceeds the recommended minimum of 40 words, which is great." );
 	} );
 
 	it( "scores 3 subheading texts, 0 are too short", function() {
-		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ 53,  100, 200 ] ), i18n );
+		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 53},{text: "", wordCount: 100},{text: "", wordCount: 200} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The number of words following each of your subheadings exceeds the recommended minimum of 40 words, which is great." );
 	} );
@@ -23,13 +23,14 @@ describe( "An assessment for scoring too long sub texts.", function() {
 	} );
 
 	it ( "returns a heading that is too short", function() {
-		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ 10,  200, 300 ] ), i18n );
+		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [{text: "", wordCount: 10},{text: "", wordCount: 200},{text: "", wordCount: 300} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "The number of words following 1 of your subheadings is less than or equal to the recommended minimum of 40 words. Consider deleting that particular subheading, or the following subheading." );
 	} );
 
 	it ( "returns 3 headings that are too short", function() {
-		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ 10,  20, 30, 310 ] ), i18n );
+		var assessment = subheadingDistributionTooShort.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 10},{text: "", wordCount: 20},{text: "", wordCount: 30},{text: "", wordCount: 310}
+		 ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "The number of words following 3 of your subheadings is less than or equal to the recommended minimum of 40 words. Consider deleting those particular subheadings, or the subheading following each of them." );
 	} );

--- a/spec/researches/getSubheadingTextLengthSpec.js
+++ b/spec/researches/getSubheadingTextLengthSpec.js
@@ -4,7 +4,7 @@ var Paper = require( "../../js/values/Paper.js" );
 describe( "gets the length of subheadings", function() {
 	it( "returns an array with lengths", function() {
 		var mockPaper = new Paper( "<h1>test</h1>one two three" );
-		expect( subHeadingTextLength( mockPaper ) ).toContain( 3 );
+		expect( subHeadingTextLength( mockPaper )[ 0 ].wordCount ).toBe( 3 );
 	} );
 
 	it( "returns an empty array", function() {
@@ -14,15 +14,15 @@ describe( "gets the length of subheadings", function() {
 
 	it( "returns an array with 2 entries", function() {
 		var mockPaper = new Paper( "<h2>one</h2> two three<h3>four</h3>this is a text string with a number of words" );
-		expect( subHeadingTextLength( mockPaper) ).toContain( 2 );
-		expect( subHeadingTextLength( mockPaper) ).toContain( 10 );
+		expect( subHeadingTextLength( mockPaper)[ 0 ].wordCount ).toBe( 2 );
+		expect( subHeadingTextLength( mockPaper)[ 1 ].wordCount ).toBe( 10 );
 		expect( subHeadingTextLength( mockPaper).length ).toBe( 2 );
 	} );
 
 	it( "returns an array with 2 entries", function() {
 		var mockPaper = new Paper( "some text<h2>one</h2> two three<h3>four</h3>this is a text string with a number of words" );
-		expect( subHeadingTextLength( mockPaper) ).toContain( 2 );
-		expect( subHeadingTextLength( mockPaper) ).toContain( 10 );
+		expect( subHeadingTextLength( mockPaper)[ 0 ].wordCount ).toBe( 2 );
+		expect( subHeadingTextLength( mockPaper)[ 1 ].wordCount ).toBe( 10 );
 		expect( subHeadingTextLength( mockPaper).length ).toBe( 2 );
 	} );
 } );


### PR DESCRIPTION
Creates a marker for the subheading text too long assessment and the subheading text too short assessment. 

For testing: Make a `<h2>` followed by a few words ( < 150 ) to trigger the too short assessment, and a `<h2>`  with a whole bunch of words ( > 150 ) for the too long assessment.