### PR TITLE
Fixes flesch reading ease score

### DIFF
--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -22,13 +22,15 @@ module.exports = function( paper ) {
 		return 0;
 	}
 
+	var sentenceCount = countSentences( text );
+
 	text = cleanText( text );
 	text = stripHTMLTags( text );
 	var wordCount = countWords( text );
 
 	text = stripNumbers( text );
-	var sentenceCount = countSentences( text );
 	var syllableCount = countSyllables( text );
+
 	var score = 206.835 - ( 1.015 * ( wordCount / sentenceCount ) ) - ( 84.6 * ( syllableCount / wordCount ) );
 
 	return formatNumber( score );

--- a/spec/researches/fleschReadingSpec.js
+++ b/spec/researches/fleschReadingSpec.js
@@ -6,11 +6,11 @@ describe("a test to calculate the fleschReading score", function(){
 
 		var mockPaper = new Paper( "A piece of text to calculate scores." );
 		expect( fleschFunction( mockPaper ) ).toBe( 78.9 );
-/*
+
 // todo This spec is currently disabled, because the fleschreading still runs a cleantext, that removes capitals. This is fixed in #496 of YoastSEO
 		mockPaper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop and people were actually in a bit of trouble" );
-		expect( fleschFunction( mockPaper )).toBe( "63.9" );
-*/
+		expect( fleschFunction( mockPaper )).toBe( 63.9 );
+
 		mockPaper = new Paper( "" );
 		expect( fleschFunction( mockPaper ) ).toBe( 0 );
 	});

--- a/spec/researches/fleschReadingSpec.js
+++ b/spec/researches/fleschReadingSpec.js
@@ -7,7 +7,6 @@ describe("a test to calculate the fleschReading score", function(){
 		var mockPaper = new Paper( "A piece of text to calculate scores." );
 		expect( fleschFunction( mockPaper ) ).toBe( 78.9 );
 
-// todo This spec is currently disabled, because the fleschreading still runs a cleantext, that removes capitals. This is fixed in #496 of YoastSEO
 		mockPaper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop and people were actually in a bit of trouble" );
 		expect( fleschFunction( mockPaper )).toBe( 63.9 );
 


### PR DESCRIPTION
How to test this: The flesch reading ease score should now always be
correct. Especially when testing in combination with the improved
sentence detection.

Fixes #544 
Fixes #542