### PR TITLE
Alignment of the icon

### DIFF
--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -137,7 +137,7 @@ li.score:after {
 		padding: 4px;
 		border-radius: 100%;
 		outline: none;
-		background: url(svg-icon-eye-slash($color_marker_inactive)) no-repeat center;
+		background: url(svg-icon-eye-slash($color_marker_inactive)) no-repeat 3px center;
 		background-size: 16px;
 		cursor: pointer;
 		margin-top: -16px;


### PR DESCRIPTION
Align the background 3pixels from the left instead of in the center.

Fixes https://github.com/Yoast/wordpress-seo/issues/4795