### PR TITLE
Mark complex words in their sentence

### DIFF
--- a/js/assessments/wordComplexityAssessment.js
+++ b/js/assessments/wordComplexityAssessment.js
@@ -84,6 +84,41 @@ var calculateComplexity = function( wordCount, wordComplexity, i18n ) {
 };
 
 /**
+ * Marks complex words in a sentence.
+ * @param {string} sentence The sentence to mark complex words in.
+ * @param {Array} complexWords The array with complex words.
+ * @returns {Array} All marked complex words.
+ */
+var markComplexWordsInSentence = function( sentence, complexWords ) {
+	var splitWords = sentence.split( /\s+/ );
+
+	forEach( complexWords, function( complexWord ) {
+		var wordIndex = complexWord.wordIndex;
+
+		if ( complexWord.word === splitWords[ wordIndex ]
+			|| complexWord.word === removeSentenceTerminators( splitWords[ wordIndex ] ) ) {
+			splitWords[ wordIndex ] = splitWords[ wordIndex ].replace( complexWord.word, addMark( complexWord.word ) );
+		}
+	} );
+	return splitWords;
+};
+
+/**
+ * Splits sentence on whitespace
+ * @param {string} sentence The sentence to split.
+ * @returns {Array} All words from sentence. .
+ */
+var splitSentenceOnWhitespace = function( sentence ) {
+	var whitespace = sentence.split( /\S+/ );
+
+	// Drop first and last elements.
+	whitespace.pop();
+	whitespace.shift();
+
+	return whitespace;
+};
+
+/**
  * Creates markers of words that are complex.
  *
  * @param {Paper} paper The Paper object to assess.
@@ -91,11 +126,11 @@ var calculateComplexity = function( wordCount, wordComplexity, i18n ) {
  * @returns {Array} A list with markers
  */
 var wordComplexityMarker = function( paper, researcher ) {
-	var sentences = researcher.getResearch( "wordComplexity" );
+	var wordComplexityResults = researcher.getResearch( "wordComplexity" );
 
-	return flatMap( sentences, function( sentence ) {
-		var words = sentence.words;
-		sentence = sentence.sentence;
+	return flatMap( wordComplexityResults, function( result ) {
+		var words = result.words;
+		var sentence = result.sentence;
 
 		var complexWords = filterComplexity( words );
 
@@ -103,21 +138,9 @@ var wordComplexityMarker = function( paper, researcher ) {
 			return [];
 		}
 
-		var splitWords = sentence.split( /\s+/ );
-		var whitespace = sentence.split( /\S+/ );
+		var splitWords = markComplexWordsInSentence( sentence, complexWords );
 
-		forEach( complexWords, function( complexWord ) {
-			var wordIndex = complexWord.wordIndex;
-
-			if ( complexWord.word === splitWords[ wordIndex ]
-				|| complexWord.word === removeSentenceTerminators( splitWords[ wordIndex ] ) ) {
-				splitWords[ wordIndex ] = splitWords[ wordIndex ].replace( complexWord.word, addMark( complexWord.word ) );
-			}
-		} );
-
-		// Drop first and last elements.
-		whitespace.pop();
-		whitespace.shift();
+		var whitespace = splitSentenceOnWhitespace( sentence );
 
 		// Rebuild the sentence with the marked words.
 		var markedSentence = zip( splitWords, whitespace );

--- a/js/researches/getWordComplexity.js
+++ b/js/researches/getWordComplexity.js
@@ -3,6 +3,27 @@ var countSyllables = require( "../stringProcessing/countSyllables.js" );
 var getSentences = require( "../stringProcessing/getSentences.js" );
 
 var map = require( "lodash/map" );
+var forEach = require( "lodash/forEach" );
+
+/**
+ * Gets the complexity per word, along with the index for the sentence.
+ * @param {string} sentence The sentence to get wordComplexity from.
+ * @returns {Array} A list with words, the index and the complexity per word.
+ */
+var getWordComplexityForSentence = function( sentence ) {
+	var words = getWords( sentence );
+	var results = [];
+
+	forEach( words, function( word, i ) {
+		results.push( {
+			word: word,
+			wordIndex: i,
+			complexity: countSyllables( word )
+		} );
+	} );
+
+	return results;
+};
 
 /**
  * Calculates the complexity of words in a text, returns each words with their complexity.
@@ -13,17 +34,9 @@ module.exports = function( paper ) {
 	var sentences = getSentences( paper.getText() );
 
 	return map( sentences, function( sentence ) {
-		var words = getWords( sentence );
-
 		return {
 			sentence: sentence,
-			words: words.map( function( word, i ) {
-				return {
-					word: word,
-					wordIndex: i,
-					complexity: countSyllables( word )
-				};
-			} )
+			words: getWordComplexityForSentence( sentence )
 		};
 	} );
 };

--- a/js/researches/getWordComplexity.js
+++ b/js/researches/getWordComplexity.js
@@ -1,5 +1,8 @@
 var getWords = require( "../stringProcessing/getWords.js" );
 var countSyllables = require( "../stringProcessing/countSyllables.js" );
+var getSentences = require( "../stringProcessing/getSentences.js" );
+
+var map = require( "lodash/map" );
 
 /**
  * Calculates the complexity of words in a text, returns each words with their complexity.
@@ -7,11 +10,21 @@ var countSyllables = require( "../stringProcessing/countSyllables.js" );
  * @returns {Object} The words found in the text with the number of syllables.
  */
 module.exports = function( paper ) {
-	var words = getWords( paper.getText() );
-	var wordComplexity = [];
-	words.map( function( word ) {
-		wordComplexity.push( { word: word, complexity: countSyllables( word ) } );
+	var sentences = getSentences( paper.getText() );
+
+	return map( sentences, function( sentence ) {
+		var words = getWords( sentence );
+
+		return {
+			sentence: sentence,
+			words: words.map( function( word, i ) {
+				return {
+					word: word,
+					wordIndex: i,
+					complexity: countSyllables( word )
+				};
+			} )
+		};
 	} );
-	return wordComplexity;
 };
 

--- a/spec/assessments/complexWordsSpec.js
+++ b/spec/assessments/complexWordsSpec.js
@@ -6,18 +6,22 @@ var i18n = factory.buildJed();
 describe( "an assessment returning complex words", function() {
 	it( "runs a test with 30% too many syllables", function(){
 		var mockPaper = new Paper( "" );
-		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 4 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 4 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 10 } ]
+		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher(
+			[ { sentence: "", words: [
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 4 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 4 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 10 } ]
+			} ]
 		), i18n );
+
+
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "30% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
 			"which is more than the recommended maximum of 5%." );
@@ -27,25 +31,27 @@ describe( "an assessment returning complex words", function() {
 	it( "runs a test with exactly 5.3% too many syllables", function(){
 		var mockPaper = new Paper( "" );
 		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 10 } ]
+			{ sentence: "", words: [
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 10 }
+			] } ]
 		), i18n );
 		expect( result.getScore() ).toBe( 6.8 );
 		expect( result.getText() ).toBe( "5.3% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
@@ -56,26 +62,28 @@ describe( "an assessment returning complex words", function() {
 	it( "runs a test with exactly 5% too many syllables", function(){
 		var mockPaper = new Paper( "" );
 		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 10 } ]
+			{ sentence: "", words: [
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 10 } ] }
+			]
 		), i18n );
 		expect( result.getScore() ).toBe( 7 );
 		expect( result.getText() ).toBe( "5% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
@@ -86,40 +94,42 @@ describe( "an assessment returning complex words", function() {
 	it( "runs a test with 2.94% too many syllables", function(){
 		var mockPaper = new Paper( "" );
 		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 10 } ]
+			{ sentence: "", words: [
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 10 } ]
+			} ]
 		), i18n );
 		expect( result.getScore() ).toBe( 8.3 );
 		expect( result.getText() ).toBe( "2.9% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
@@ -130,16 +140,19 @@ describe( "an assessment returning complex words", function() {
 	it( "runs a test with 0% too many syllables", function(){
 		var mockPaper = new Paper( "" );
 		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 3 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 2 },
-			{ word: "", complexity: 1 },
-			{ word: "", complexity: 1 } ] ), i18n );
+			{ sentence: "", words: [
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 3 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 2 },
+				{ word: "", complexity: 1 },
+				{ word: "", complexity: 1 } ]
+			} ]
+			), i18n );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "0% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
 			"which is less than or equal to the recommended maximum of 5%." );

--- a/spec/researches/getWordComplexitySpec.js
+++ b/spec/researches/getWordComplexitySpec.js
@@ -4,13 +4,14 @@ var Paper = require( "../../js/values/Paper" );
 describe( "A function for getting the syllables per word",  function(){
 	it( "returns an array with the number of syllables per word", function(){
 		var mockPaper = new Paper( "word" );
-		expect( wordComplexity( mockPaper )[ 0 ][ 0 ].complexity ).toBe( 1 );
+
+		expect( wordComplexity( mockPaper )[ 0 ].words[ 0 ].complexity ).toBe( 1 );
 
 		mockPaper = new Paper( "double" );
-		expect( wordComplexity( mockPaper )[ 0 ][ 0 ].complexity ).toBe( 2 );
+		expect( wordComplexity( mockPaper )[ 0 ].words[ 0 ].complexity ).toBe( 2 );
 
 		mockPaper = new Paper( "strawberry cake" );
-		expect( wordComplexity( mockPaper )[ 0 ][ 0 ].complexity ).toBe( 3 );
-		expect( wordComplexity( mockPaper )[ 0 ][ 1 ].complexity ).toBe( 1 );
+		expect( wordComplexity( mockPaper )[ 0 ].words[ 0 ].complexity ).toBe( 3 );
+		expect( wordComplexity( mockPaper )[ 0 ].words[ 1 ].complexity ).toBe( 1 );
 	} );
 } );

--- a/spec/researches/getWordComplexitySpec.js
+++ b/spec/researches/getWordComplexitySpec.js
@@ -4,13 +4,13 @@ var Paper = require( "../../js/values/Paper" );
 describe( "A function for getting the syllables per word",  function(){
 	it( "returns an array with the number of syllables per word", function(){
 		var mockPaper = new Paper( "word" );
-		expect( wordComplexity( mockPaper )[ 0 ].complexity ).toBe( 1 );
+		expect( wordComplexity( mockPaper )[ 0 ][ 0 ].complexity ).toBe( 1 );
 
 		mockPaper = new Paper( "double" );
-		expect( wordComplexity( mockPaper )[ 0 ].complexity ).toBe( 2 );
+		expect( wordComplexity( mockPaper )[ 0 ][ 0 ].complexity ).toBe( 2 );
 
 		mockPaper = new Paper( "strawberry cake" );
-		expect( wordComplexity( mockPaper )[ 0 ].complexity ).toBe( 3 );
-		expect( wordComplexity( mockPaper )[ 1 ].complexity ).toBe( 1 );
+		expect( wordComplexity( mockPaper )[ 0 ][ 0 ].complexity ).toBe( 3 );
+		expect( wordComplexity( mockPaper )[ 0 ][ 1 ].complexity ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
This makes sure we aren't replacing complex words inside HTML tags.

Fixes https://github.com/Yoast/wordpress-seo/issues/4799