### PR TITLE
Fixes passive detection

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -314,7 +314,6 @@ module.exports = function( paper ) {
 			passive = determinePassives( subSentence );
 			if ( passive === true ) {
 				passiveSentences.push( sentence );
-				passive = false;
 			}
 		} );
 	} );

--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -102,6 +102,7 @@ var getVerbsEndingInIng = function( sentence ) {
  * @returns {Array} The array with valid indices to use for determining subsentences.
  */
 var getSentenceBreakers = function( sentence ) {
+	sentence = sentence.toLocaleLowerCase();
 	var auxiliaryIndices = matchArray( sentence, auxiliaries );
 
 	var stopwordIndices = matchArray( sentence, stopwords );
@@ -311,11 +312,11 @@ module.exports = function( paper ) {
 		var passive = false;
 		forEach( subSentences, function( subSentence ) {
 			passive = determinePassives( subSentence );
+			if ( passive === true ) {
+				passiveSentences.push( sentence );
+				passive = false;
+			}
 		} );
-		if ( passive === true ) {
-			passiveSentences.push( sentence );
-			passive = false;
-		}
 	} );
 
 	return {

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -214,58 +214,63 @@ describe( "detecting passive voice in sentences", function() {
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	} );
 
-	it( "returns passive voice ( text between having and verb )", function(){
+	it( "returns passive voice ( text between having and verb )", function() {
 		paper = new Paper( "He is having the house painted" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
-	it( "returns active voice ( no text between having and verb )", function(){
+	it( "returns active voice ( no text between having and verb )", function() {
 		paper = new Paper( "He is most notable, having contributed a lot" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	});
 
-	it( "returns active voice ( combination with left )", function(){
+	it( "returns active voice ( combination with left )", function() {
 		paper = new Paper( "The right way is to the left" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	});
 
-	it( "returns passive voice ( combination with left )", function(){
+	it( "returns passive voice ( combination with left )", function() {
 		paper = new Paper( "She was left at home" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
-	it( "returns passive voice ( combination with left )", function(){
+	it( "returns passive voice ( combination with left )", function() {
 		paper = new Paper( "He was hit on the left leg" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
-	it( "returns active voice ( combination with fit )", function(){
+	it( "returns active voice ( combination with fit )", function() {
 		paper = new Paper( "It was the right fit" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	});
 
-	it( "returns passive voice ( combination with fit )", function(){
+	it( "returns passive voice ( combination with fit )", function() {
 		paper = new Paper( "He was fit with hearing aids" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
-	it( "returns active voice ( combination with ing-verbs )", function(){
+	it( "returns active voice ( combination with ing-verbs )", function() {
 		paper = new Paper( "They had apps that are constantly improving, with regular updates based on customer feedback." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	});
 
-	it( "returns passive voice ( combination with cling )", function(){
+	it( "returns passive voice ( combination with cling )", function() {
 		paper = new Paper( "They had apps that get constantly cling wrapped" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
-	it( "returns passive voice ( combination with cling  )", function(){
+	it( "returns passive voice ( combination with cling  )", function() {
 		paper = new Paper( "They had apps that are constantly cling wrapped." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
-	it( "returns passive voice with quotation marks", function(){
+	it( "returns passive voice with quotation marks", function() {
 		paper = new Paper( "As a result of that, a lot of blog posts will 'get lost' in a structure that is too flat." );
+		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
+	});
+
+	it( "returns passive voice with multiple subsentence, where the passive is not in the last part", function() {
+		paper = new Paper( "As a result of that, a lot of blog posts will get lost in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 } );

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -273,4 +273,9 @@ describe( "detecting passive voice in sentences", function() {
 		paper = new Paper( "As a result of that, a lot of blog posts will get lost in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
+
+	it( "returns passive voice in a sentence where the indicator is in caps.", function() {
+		paper = new Paper( "As a result of that, a lot of blog posts will GET LOST in a structure that is too flat." );
+		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
+	});
 } );

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -263,4 +263,9 @@ describe( "detecting passive voice in sentences", function() {
 		paper = new Paper( "They had apps that are constantly cling wrapped." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
+
+	it( "returns passive voice with quotation marks", function(){
+		paper = new Paper( "As a result of that, a lot of blog posts will 'get lost' in a structure that is too flat." );
+		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
+	});
 } );


### PR DESCRIPTION
This pull fixes the passive detection. Only the last subsentence was pushed into an array with passives in stead of all of them, so a sentence was only passive if it was the last part. 

Includes another fix where the index is determined on a lowercased sentence.

For testing: See the added specs for an example of passive sentences. 

Fixes #605 (the issue wasn't the quotation marks).