### PR TITLE
Introduce accessible tooltips for the mark buttons

### DIFF
--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -121,6 +121,11 @@ li.score:after {
 			&-active {
 				background-image: url(svg-icon-eye($color_marker_active));
 				background-color: #a4286a;
+
+				&.yoast-tooltip::before,
+				&.yoast-tooltip::after {
+					display: none;
+				}
 			}
 		}
 

--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -2,6 +2,11 @@
 	position: relative;
 }
 
+button.yoast-tooltip {
+	/* IE 11 needs overflow: visible on buttons. */
+	overflow: visible;
+}
+
 .yoast-tooltip::after {
 	display: none;
 	position: absolute;

--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -38,16 +38,6 @@
 	pointer-events: none;
 }
 
-@-webkit-keyframes yoast-tooltip-appear {
-	from {
-		opacity: 0;
-	}
-
-	to {
-		opacity: 1;
-	}
-}
-
 @keyframes yoast-tooltip-appear {
 	from {
 		opacity: 0;

--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -1,0 +1,224 @@
+.yoast-tooltip {
+	position: relative;
+}
+
+.yoast-tooltip::after {
+	display: none;
+	position: absolute;
+	z-index: 1000000;
+	padding: 5px 8px;
+	border-radius: 3px;
+	opacity: 0;
+	color: #fff;
+	background: rgba(0,0,0,0.8);
+	text-shadow: none;
+	font: normal normal 11px/1.5 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	text-align: center;
+	white-space: pre;
+	text-decoration: none;
+	letter-spacing: normal;
+	text-transform: none;
+	word-wrap: break-word;
+	content: attr(aria-label);
+	pointer-events: none;
+
+	-webkit-font-smoothing: subpixel-antialiased;
+}
+
+.yoast-tooltip::before {
+	display: none;
+	position: absolute;
+	z-index: 1000001;
+	width: 0;
+	height: 0;
+	border: 5px solid transparent;
+	opacity: 0;
+	color: rgba(0,0,0,0.8);
+	content: "\00a0";
+	pointer-events: none;
+}
+
+@-webkit-keyframes yoast-tooltip-appear {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes yoast-tooltip-appear {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+.yoast-tooltip:hover::before,
+.yoast-tooltip:hover::after,
+.yoast-tooltip:active::before,
+.yoast-tooltip:active::after,
+.yoast-tooltip:focus::before,
+.yoast-tooltip:focus::after {
+	display: inline-block;
+	text-decoration: none;
+	animation-name: yoast-tooltip-appear;
+	animation-duration: 0.1s;
+	animation-timing-function: ease-in;
+	animation-delay: 0.4s;
+
+	animation-fill-mode: forwards;
+}
+
+.yoast-tooltip-no-delay:hover::before,
+.yoast-tooltip-no-delay:hover::after,
+.yoast-tooltip-no-delay:active::before,
+.yoast-tooltip-no-delay:active::after,
+.yoast-tooltip-no-delay:focus::before,
+.yoast-tooltip-no-delay:focus::after {
+	opacity: 1;
+	animation: none;
+}
+
+.yoast-tooltip-multiline:hover::after,
+.yoast-tooltip-multiline:active::after,
+.yoast-tooltip-multiline:focus::after {
+	display: table-cell;
+}
+
+.yoast-tooltip-s::after,
+.yoast-tooltip-se::after,
+.yoast-tooltip-sw::after {
+	top: 100%;
+	right: 50%;
+	margin-top: 5px;
+}
+
+.yoast-tooltip-s::before,
+.yoast-tooltip-se::before,
+.yoast-tooltip-sw::before {
+	top: auto;
+	right: 50%;
+	bottom: -5px;
+	margin-right: -5px;
+	border-bottom-color: rgba(0,0,0,0.8);
+}
+
+.yoast-tooltip-se::after {
+	right: auto;
+	left: 50%;
+	margin-left: -15px;
+}
+
+.yoast-tooltip-sw::after {
+	margin-right: -15px;
+}
+
+.yoast-tooltip-n::after,
+.yoast-tooltip-ne::after,
+.yoast-tooltip-nw::after {
+	right: 50%;
+	bottom: 100%;
+	margin-bottom: 5px;
+}
+
+.yoast-tooltip-n::before,
+.yoast-tooltip-ne::before,
+.yoast-tooltip-nw::before {
+	top: -5px;
+	right: 50%;
+	bottom: auto;
+	margin-right: -5px;
+	border-top-color: rgba(0,0,0,0.8);
+}
+
+.yoast-tooltip-ne::after {
+	right: auto;
+	left: 50%;
+	margin-left: -15px;
+}
+
+.yoast-tooltip-nw::after {
+	margin-right: -15px;
+}
+
+.yoast-tooltip-s::after,
+.yoast-tooltip-n::after {
+	transform: translateX(50%);
+}
+
+.yoast-tooltip-w::after {
+	right: 100%;
+	bottom: 50%;
+	margin-right: 5px;
+	transform: translateY(50%);
+}
+
+.yoast-tooltip-w::before {
+	top: 50%;
+	bottom: 50%;
+	left: -5px;
+	margin-top: -5px;
+	border-left-color: rgba(0,0,0,0.8);
+}
+
+.yoast-tooltip-e::after {
+	bottom: 50%;
+	left: 100%;
+	margin-left: 5px;
+	transform: translateY(50%);
+}
+
+.yoast-tooltip-e::before {
+	top: 50%;
+	right: -5px;
+	bottom: 50%;
+	margin-top: -5px;
+	border-right-color: rgba(0,0,0,0.8);
+}
+
+.yoast-tooltip-multiline::after {
+	width: max-content;
+	max-width: 250px;
+	border-collapse: separate;
+	white-space: pre-line;
+	word-wrap: normal;
+	word-break: break-word;
+}
+
+.yoast-tooltip-multiline.yoast-tooltip-s::after,
+.yoast-tooltip-multiline.yoast-tooltip-n::after {
+	right: auto;
+	left: 50%;
+	transform: translateX(-50%);
+}
+
+.yoast-tooltip-multiline.yoast-tooltip-w::after,
+.yoast-tooltip-multiline.yoast-tooltip-e::after {
+	right: 100%;
+}
+
+@media screen and (min-width: 0\0) {
+	.yoast-tooltip-multiline::after {
+		width: 250px;
+	}
+}
+
+.yoast-tooltip-sticky::before,
+.yoast-tooltip-sticky::after {
+	display: inline-block;
+}
+
+.yoast-tooltip-sticky.yoast-tooltip-multiline::after {
+	display: table-cell;
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-moz-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+	.yoast-tooltip-w::after {
+		margin-right: 4.5px;
+	}
+}

--- a/css/analyzer.scss
+++ b/css/analyzer.scss
@@ -3,3 +3,4 @@
 @import "colors";
 @import "analysis";
 @import "loading-dialog";
+@import "tooltips";

--- a/js/templates.js
+++ b/js/templates.js
@@ -1,17 +1,34 @@
 ;(function() {
   var undefined;
 
-  var freeExports = typeof exports == 'object' && exports;
+  var objectTypes = {
+    'function': true,
+    'object': true
+  };
 
-  var freeModule = freeExports && typeof module == 'object' && module;
+  var freeExports = (objectTypes[typeof exports] && exports && !exports.nodeType)
+    ? exports
+    : undefined;
 
-  var freeGlobal = checkGlobal(typeof global == 'object' && global);
+  var freeModule = (objectTypes[typeof module] && module && !module.nodeType)
+    ? module
+    : undefined;
 
-  var freeSelf = checkGlobal(typeof self == 'object' && self);
+  var moduleExports = (freeModule && freeModule.exports === freeExports)
+    ? freeExports
+    : undefined;
 
-  var thisGlobal = checkGlobal(typeof this == 'object' && this);
+  var freeGlobal = checkGlobal(freeExports && freeModule && typeof global == 'object' && global);
 
-  var root = freeGlobal || freeSelf || thisGlobal || Function('return this')();
+  var freeSelf = checkGlobal(objectTypes[typeof self] && self);
+
+  var freeWindow = checkGlobal(objectTypes[typeof window] && window);
+
+  var thisGlobal = checkGlobal(objectTypes[typeof this] && this);
+
+  var root = freeGlobal ||
+    ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) ||
+      freeSelf || thisGlobal || Function('return this')();
 
   function checkGlobal(value) {
     return (value && value.Object === Object) ? value : null;
@@ -21,7 +38,7 @@
   var undefined;
 
   /** Used as the semantic version number. */
-  var VERSION = '4.13.0';
+  var VERSION = '4.11.2';
 
   /** Used as references for various `Number` constants. */
   var INFINITY = 1 / 0;
@@ -43,17 +60,43 @@
     '`': '&#96;'
   };
 
+  /** Used to determine if values are of the language type `Object`. */
+  var objectTypes = {
+    'function': true,
+    'object': true
+  };
+
+  /** Detect free variable `exports`. */
+  var freeExports = (objectTypes[typeof exports] && exports && !exports.nodeType)
+    ? exports
+    : undefined;
+
+  /** Detect free variable `module`. */
+  var freeModule = (objectTypes[typeof module] && module && !module.nodeType)
+    ? module
+    : undefined;
+
   /** Detect free variable `global` from Node.js. */
-  var freeGlobal = checkGlobal(typeof global == 'object' && global);
+  var freeGlobal = checkGlobal(freeExports && freeModule && typeof global == 'object' && global);
 
   /** Detect free variable `self`. */
-  var freeSelf = checkGlobal(typeof self == 'object' && self);
+  var freeSelf = checkGlobal(objectTypes[typeof self] && self);
+
+  /** Detect free variable `window`. */
+  var freeWindow = checkGlobal(objectTypes[typeof window] && window);
 
   /** Detect `this` as the global object. */
-  var thisGlobal = checkGlobal(typeof this == 'object' && this);
+  var thisGlobal = checkGlobal(objectTypes[typeof this] && this);
 
-  /** Used as a reference to the global object. */
-  var root = freeGlobal || freeSelf || thisGlobal || Function('return this')();
+  /**
+   * Used as a reference to the global object.
+   *
+   * The `this` value is used if it's the global object to avoid Greasemonkey's
+   * restricted `window` object, otherwise the `window` object is used.
+   */
+  var root = freeGlobal ||
+    ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) ||
+      freeSelf || thisGlobal || Function('return this')();
 
   /*--------------------------------------------------------------------------*/
 
@@ -244,6 +287,8 @@
       : string;
   }
 
+  /*--------------------------------------------------------------------------*/
+
   var _ = { 'escape': escape };
 
   /*----------------------------------------------------------------------------*/
@@ -263,9 +308,11 @@
      for (var i in scores) {
     __p += '\n        <li class="score">\n            <span class="assessment-results__mark-container">\n                ';
      if ( scores[ i ].marker ) {
-    __p += '\n                    <button type="button" class="assessment-results__mark icon-eye-inactive js-assessment-results__mark-' +
+    __p += '\n                    <button type="button" aria-label="' +
+    ((__t = ( i18n.markInText )) == null ? '' : __t) +
+    '" class="assessment-results__mark icon-eye-inactive js-assessment-results__mark-' +
     ((__t = ( scores[ i ].identifier )) == null ? '' : __t) +
-    '"><span class="screen-reader-text">' +
+    ' yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text">' +
     ((__t = ( i18n.markInText )) == null ? '' : __t) +
     '</span></button>\n                ';
      }
@@ -362,8 +409,10 @@
 
   /*----------------------------------------------------------------------------*/
 
-  if (freeModule) {
-    (freeModule.exports = templates).templates = templates;
+  if (freeExports && freeModule) {
+    if (moduleExports) {
+      (freeModule.exports = templates).templates = templates;
+    }
     freeExports.templates = templates;
   }
   else {

--- a/templates/assessmentPresenterResult.jst
+++ b/templates/assessmentPresenterResult.jst
@@ -3,7 +3,7 @@
         <li class="score">
             <span class="assessment-results__mark-container">
                 <% if ( scores[ i ].marker ) { %>
-                    <button type="button" class="assessment-results__mark icon-eye-inactive js-assessment-results__mark-<%= scores[ i ].identifier %>"><span class="screen-reader-text"><%= i18n.markInText %></span></button>
+                    <button type="button" aria-label="<%= i18n.markInText %>" class="assessment-results__mark icon-eye-inactive js-assessment-results__mark-<%= scores[ i ].identifier %> yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text"><%= i18n.markInText %></span></button>
                 <% } %>
             </span>
             <span class="wpseo-score-icon <%- scores[ i ].className %>"></span>


### PR DESCRIPTION
Moving here the tooltips initially implemented in https://github.com/Yoast/wordpress-seo/pull/4813. First time handling Sass files here on YoastSEO.js please let me know if I'm doing something wrong :)

Tooltips implemented just on the mark buttons for now, and in the "South" position. Example inside the metabox:

<img width="943" alt="screen shot 2016-06-09 at 14 34 32" src="https://cloud.githubusercontent.com/assets/1682452/15930430/2ee2bc6e-2e53-11e6-95fb-7eaa898976af.png">

Fixes #623 
