### PR TITLE
Disable 'got' in passive voice irregular list

### DIFF
--- a/js/assessments/passiveVoiceAssessment.js
+++ b/js/assessments/passiveVoiceAssessment.js
@@ -32,7 +32,7 @@ var calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 					i18n.dgettext(
 						"js-text-analysis",
 
-						// translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
+						// Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
 						// %3$s expands to the anchor end tag, %4$s expands to the recommended value.
 						"%1$s of the sentences contain a %2$spassive voice%3$s, " +
 						"which is less than or equal to the recommended maximum of %4$s." ),
@@ -50,7 +50,7 @@ var calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 			i18n.dgettext(
 				"js-text-analysis",
 
-				// translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
+				// Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
 				// %3$s expands to the anchor end tag, %4$s expands to the recommended value.
 				"%1$s of the sentences contain a %2$spassive voice%3$s, " +
 				"which is more than the recommended maximum of %4$s. Try to use their active counterparts."

--- a/js/researches/passivevoice-english/irregulars.js
+++ b/js/researches/passivevoice-english/irregulars.js
@@ -103,7 +103,7 @@ module.exports = function() {
 		"given",
 		"gone",
 		"undergone",
-		"got",
+//		"got",
 		"gotten",
 		"ground",
 		"reground",

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -10,18 +10,20 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice (Simple Present)", function () {
+		// passive: is cleaned
 		paper = new Paper("Once a week, the house is cleaned by Tom.");
-		expect(passiveVoice( paper ).passives.length).toBe(1);
+		expect(passiveVoice( paper ).passives.length).toBe( 1 );
 	});
 
 	it( "returns active voice (Present Continuous)", function () {
 		paper = new Paper("Right now, Sarah is writing the letter.");
-		expect(passiveVoice( paper ).passives.length).toBe(0);
+		expect(passiveVoice( paper ).passives.length).toBe( 0 );
 	});
 
 	it( "returns passive voice (Present Continuous)", function () {
+		// passive: (is) being written
 		paper = new Paper("Right now, the letter is being written by Sarah.");
-		expect(passiveVoice( paper ).passives.length).toBe(1);
+		expect(passiveVoice( paper ).passives.length).toBe( 1 );
 	});
 
 	it( "returns active voice (Simple Past)", function() {
@@ -30,6 +32,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Simple Past)", function() {
+		// passive: was repaired
 		paper = new Paper( "The car was repaired by Sam." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -40,6 +43,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Past Continuous)", function() {
+		// passive: (was) being helped
 		paper = new Paper( "The customer was being helped by the salesman when the thief came into the store." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -50,6 +54,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Present Perfect)", function() {
+		// passive: (has) been visited
 		paper = new Paper( "That castle has been visited by many tourists." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -60,6 +65,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Present Perfect Continuous)", function() {
+		// passive: (has been) being done
 		paper = new Paper( "Recently, the work has been being done by John." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -70,6 +76,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Past Perfect)", function() {
+		// passive: (had) been repaired
 		paper = new Paper( "Many cars had been repaired by George before he received his mechanic's license." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -80,6 +87,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Past Perfect Continuous)", function() {
+		// passive: (had been) being prepared
 		paper = new Paper( "The restaurant's fantastic dinners had been being prepared by Chef Jones for two years before he moved to Paris." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -90,6 +98,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Simple Future - will)", function() {
+		// passive: (will) be finished
 		paper = new Paper( "The work will be finished by 5:00 PM." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -100,6 +109,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Simple Future - be going to)", function() {
+		// passive: (to) be made
 		paper = new Paper( "A beautiful dinner is going to be made by Sally tonight." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -110,6 +120,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Continuous - will)", function() {
+		// passive: (will be) being washed
 		paper = new Paper( "At 8:00 PM tonight, the dishes will be being washed by John." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -120,6 +131,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Continuous - be going to)", function() {
+		// passive: (to be) being washed
 		paper = new Paper( "At 8:00 PM tonight, the dishes are going to be being washed by John." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -130,6 +142,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect - will)", function() {
+		// passive: (will have) been completed
 		paper = new Paper( "The project will have been completed before the deadline." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -140,6 +153,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect - be going to)", function() {
+		// passive:  (have) been completed
 		paper = new Paper( "The project is going to have been completed before the deadline." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -150,6 +164,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect Continuous- will)", function() {
+		// passive: (will have been) being painted
 		paper = new Paper( "The mural will have been being painted by the famous artist for over six months." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -160,6 +175,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect Continuous- be going to)", function() {
+		// passive: (have been) being painted
 		paper = new Paper( "The mural is going to have been being painted by the famous artist for over six months." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -170,6 +186,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Used to)", function() {
+		// passive: (to) be paid
 		paper = new Paper( "The bills used to be paid by Jerry." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -180,6 +197,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Would Always)", function() {
+		// passive: (would) be made
 		paper = new Paper( "The pies would always be made by my mother." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 
@@ -190,6 +208,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future in the Past - would)", function() {
+		// passive: (would) be finished
 		paper = new Paper( "I knew the work would be finished by 5:00 PM." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -200,6 +219,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future in the Past - was going to)", function() {
+		// passive: (to) be made
 		paper = new Paper( "I thought a beautiful dinner was going to be made by Sally tonight." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -215,6 +235,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice ( text between having and verb )", function() {
+		// passive: having painted
 		paper = new Paper( "He is having the house painted" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
@@ -230,11 +251,13 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice ( combination with left )", function() {
+		// passive: was left
 		paper = new Paper( "She was left at home" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice ( combination with left )", function() {
+		// passive: was hit
 		paper = new Paper( "He was hit on the left leg" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
@@ -245,6 +268,7 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice ( combination with fit )", function() {
+		// passive: was fit
 		paper = new Paper( "He was fit with hearing aids" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
@@ -255,36 +279,43 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice ( combination with cling )", function() {
+		// passive: get (cling) wrapped
 		paper = new Paper( "They had apps that get constantly cling wrapped" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice ( combination with cling  )", function() {
+		// passive: are (cling) wrapped
 		paper = new Paper( "They had apps that are constantly cling wrapped." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice with quotation marks", function() {
+		// passive: get lost
 		paper = new Paper( "As a result of that, a lot of blog posts will 'get lost' in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice with multiple subsentence, where the passive is not in the last part", function() {
+		// passive: get lost
 		paper = new Paper( "As a result of that, a lot of blog posts will get lost in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice in a sentence where the indicator is in caps.", function() {
+		// passive: get lost
 		paper = new Paper( "As a result of that, a lot of blog posts will GET LOST in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 	
 	it( "returns the passive sentences with multiple passive subsentences", function () {
+		// passive: is cleaned, is cleaned (2 times)
 		paper = new Paper("Once a week, the house is cleaned by Tom where the house is cleaned by Jane.");
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns the passive sentences with more subsentences and only the first subsentence is passive", function () {
+		// passive: is cleaned
 		paper = new Paper("Once a week, the house is cleaned by Tom where the house is Jane.");
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -10,7 +10,7 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice (Simple Present)", function () {
-		// passive: is cleaned
+		// Passive: is cleaned.
 		paper = new Paper("Once a week, the house is cleaned by Tom.");
 		expect(passiveVoice( paper ).passives.length).toBe( 1 );
 	});
@@ -21,7 +21,7 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice (Present Continuous)", function () {
-		// passive: (is) being written
+		// Passive: (is) being written.
 		paper = new Paper("Right now, the letter is being written by Sarah.");
 		expect(passiveVoice( paper ).passives.length).toBe( 1 );
 	});
@@ -32,7 +32,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Simple Past)", function() {
-		// passive: was repaired
+		// Passive: was repaired.
 		paper = new Paper( "The car was repaired by Sam." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -43,7 +43,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Past Continuous)", function() {
-		// passive: (was) being helped
+		// Passive: (was) being helped.
 		paper = new Paper( "The customer was being helped by the salesman when the thief came into the store." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -54,7 +54,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Present Perfect)", function() {
-		// passive: (has) been visited
+		// Passive: (has) been visited.
 		paper = new Paper( "That castle has been visited by many tourists." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -65,7 +65,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Present Perfect Continuous)", function() {
-		// passive: (has been) being done
+		// Passive: (has been) being done.
 		paper = new Paper( "Recently, the work has been being done by John." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -76,7 +76,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Past Perfect)", function() {
-		// passive: (had) been repaired
+		// Passive: (had) been repaired.
 		paper = new Paper( "Many cars had been repaired by George before he received his mechanic's license." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -87,7 +87,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Past Perfect Continuous)", function() {
-		// passive: (had been) being prepared
+		// Passive: (had been) being prepared.
 		paper = new Paper( "The restaurant's fantastic dinners had been being prepared by Chef Jones for two years before he moved to Paris." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -98,7 +98,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Simple Future - will)", function() {
-		// passive: (will) be finished
+		// Passive: (will) be finished.
 		paper = new Paper( "The work will be finished by 5:00 PM." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -109,7 +109,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Simple Future - be going to)", function() {
-		// passive: (to) be made
+		// Passive: (to) be made.
 		paper = new Paper( "A beautiful dinner is going to be made by Sally tonight." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -120,7 +120,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Continuous - will)", function() {
-		// passive: (will be) being washed
+		// Passive: (will be) being washed.
 		paper = new Paper( "At 8:00 PM tonight, the dishes will be being washed by John." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -131,7 +131,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Continuous - be going to)", function() {
-		// passive: (to be) being washed
+		// Passive: (to be) being washed.
 		paper = new Paper( "At 8:00 PM tonight, the dishes are going to be being washed by John." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -142,7 +142,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect - will)", function() {
-		// passive: (will have) been completed
+		// Passive: (will have) been completed.
 		paper = new Paper( "The project will have been completed before the deadline." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -153,7 +153,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect - be going to)", function() {
-		// passive:  (have) been completed
+		// Passive:  (have) been completed.
 		paper = new Paper( "The project is going to have been completed before the deadline." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -164,7 +164,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect Continuous- will)", function() {
-		// passive: (will have been) being painted
+		// Passive: (will have been) being painted.
 		paper = new Paper( "The mural will have been being painted by the famous artist for over six months." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -175,7 +175,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future Perfect Continuous- be going to)", function() {
-		// passive: (have been) being painted
+		// Passive: (have been) being painted.
 		paper = new Paper( "The mural is going to have been being painted by the famous artist for over six months." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -186,7 +186,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Used to)", function() {
-		// passive: (to) be paid
+		// Passive: (to) be paid.
 		paper = new Paper( "The bills used to be paid by Jerry." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -197,7 +197,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Would Always)", function() {
-		// passive: (would) be made
+		// Passive: (would) be made.
 		paper = new Paper( "The pies would always be made by my mother." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 
@@ -208,7 +208,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future in the Past - would)", function() {
-		// passive: (would) be finished
+		// Passive: (would) be finished.
 		paper = new Paper( "I knew the work would be finished by 5:00 PM." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -219,7 +219,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice (Future in the Past - was going to)", function() {
-		// passive: (to) be made
+		// Passive: (to) be made.
 		paper = new Paper( "I thought a beautiful dinner was going to be made by Sally tonight." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	} );
@@ -235,7 +235,7 @@ describe( "detecting passive voice in sentences", function() {
 	} );
 
 	it( "returns passive voice ( text between having and verb )", function() {
-		// passive: having painted
+		// Passive: having painted.
 		paper = new Paper( "He is having the house painted" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
@@ -251,13 +251,13 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice ( combination with left )", function() {
-		// passive: was left
+		// Passive: was left.
 		paper = new Paper( "She was left at home" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice ( combination with left )", function() {
-		// passive: was hit
+		// Passive: was hit.
 		paper = new Paper( "He was hit on the left leg" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
@@ -268,7 +268,7 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice ( combination with fit )", function() {
-		// passive: was fit
+		// Passive: was fit.
 		paper = new Paper( "He was fit with hearing aids" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
@@ -279,43 +279,43 @@ describe( "detecting passive voice in sentences", function() {
 	});
 
 	it( "returns passive voice ( combination with cling )", function() {
-		// passive: get (cling) wrapped
+		// Passive: get (cling) wrapped.
 		paper = new Paper( "They had apps that get constantly cling wrapped" );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice ( combination with cling  )", function() {
-		// passive: are (cling) wrapped
+		// Passive: are (cling) wrapped.
 		paper = new Paper( "They had apps that are constantly cling wrapped." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice with quotation marks", function() {
-		// passive: get lost
+		// Passive: get lost.
 		paper = new Paper( "As a result of that, a lot of blog posts will 'get lost' in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice with multiple subsentence, where the passive is not in the last part", function() {
-		// passive: get lost
+		// Passive: get lost.
 		paper = new Paper( "As a result of that, a lot of blog posts will get lost in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns passive voice in a sentence where the indicator is in caps.", function() {
-		// passive: get lost
+		// Passive: get lost.
 		paper = new Paper( "As a result of that, a lot of blog posts will GET LOST in a structure that is too flat." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 	
 	it( "returns the passive sentences with multiple passive subsentences", function () {
-		// passive: is cleaned, is cleaned (2 times)
+		// Passive: is cleaned, is cleaned (2 times).
 		paper = new Paper("Once a week, the house is cleaned by Tom where the house is cleaned by Jane.");
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});
 
 	it( "returns the passive sentences with more subsentences and only the first subsentence is passive", function () {
-		// passive: is cleaned
+		// Passive: is cleaned.
 		paper = new Paper("Once a week, the house is cleaned by Tom where the house is Jane.");
 		expect( passiveVoice( paper ).passives.length ).toBe( 1 );
 	});


### PR DESCRIPTION
Disables 'got' in the passive voice irregular list.

Also adds uppercase to translator comments, and adds comments to passive voice spec indicating what is the passive part of the sentences.

Fixes #678