### PR TITLE
Simplify assessment to ranges

### DIFF
--- a/js/assessments/getSubheadingLengthAssessment.js
+++ b/js/assessments/getSubheadingLengthAssessment.js
@@ -3,6 +3,7 @@ var formatNumber = require( "../helpers/formatNumber.js" );
 var getSubheadings = require( "../stringProcessing/getSubheadings.js" ).getSubheadings;
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
+var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
 
 var filter = require( "lodash/filter" );
 var map = require( "lodash/map" );
@@ -71,9 +72,20 @@ var getSubheadingLength = function( paper, researcher, i18n ) {
 				tooLong++;
 			}
 
-			// 6 is the number of scorepoints between 3, minscore and 9, maxscore. For scoring we use 20 steps, each step is 0.3.
-			// Up to 43.4 is for scoring a 9, higher numbers give lower scores.
-			scores.push( 9 - Math.max( Math.min( ( 0.3 ) * ( length - 43.4 ), 6 ), 0 ) );
+			if ( length <= 50 ) {
+				// Green indicator.
+				scores.push( 9 );
+			}
+
+			if ( inRange( length, 50, 60 ) ) {
+				// Orange indicator.
+				scores.push( 6 );
+			}
+
+			if ( length > 60 ) {
+				// Red indicator.
+				scores.push( 3 );
+			}
 		} );
 
 		lowestScore = scores.sort(

--- a/js/assessments/paragraphTooLongAssessment.js
+++ b/js/assessments/paragraphTooLongAssessment.js
@@ -1,8 +1,8 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var formatNumber = require( "../helpers/formatNumber.js" );
 var isParagraphTooLong = require( "../helpers/isValueTooLong" );
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
+var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
 
 var filter = require( "lodash/filter" );
 var map = require( "lodash/map" );
@@ -29,14 +29,29 @@ var getTooLongParagraphs = function( paragraphsLength  ) {
  * @returns {{score: number, text: string }} the assessmentResult.
  */
 var calculateParagraphLengthResult = function( paragraphsLength, tooLongParagraphs, i18n ) {
+	var score;
+
 	if ( paragraphsLength.length === 0 ) {
 		return {};
 	}
-	// 6 is the number of scorepoints between 3, minscore and 9, maxscore. For scoring we use 100 steps, each step is 0.06.
-	// Up to 117 is for scoring a 9, higher numbers give lower scores.
-	// FloatingPointFix because of js rounding errors.
-	var score = 9 - Math.max( Math.min( ( 0.06 ) * ( paragraphsLength[ 0 ].wordCount - 117 ), 6 ), 0 );
-	score = formatNumber( score );
+
+	var longestParagraphLength = paragraphsLength[ 0 ].wordCount;
+
+	if ( longestParagraphLength <= 150 ) {
+		// Green indicator.
+		score = 9;
+	}
+
+	if ( inRange( longestParagraphLength, 150, 200 ) ) {
+		// Orange indicator.
+		score = 6;
+	}
+
+	if ( longestParagraphLength > 200 ) {
+		// Red indicator.
+		score = 3;
+	}
+
 	if ( score >= 7 ) {
 		return {
 			score: score,

--- a/js/assessments/passiveVoiceAssessment.js
+++ b/js/assessments/passiveVoiceAssessment.js
@@ -1,5 +1,6 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
+var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
 
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
@@ -13,17 +14,29 @@ var map = require( "lodash/map" );
  * @returns {{score: number, text}} resultobject with score and text.
  */
 var calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
+	var score;
+
 	var percentage = ( passiveVoice.passives.length / passiveVoice.total ) * 100;
 	percentage = formatNumber( percentage );
 	var recommendedValue = 10;
 	var passiveVoiceURL = "<a href='https://yoa.st/passive-voice' target='_blank'>";
 	var hasMarks = ( percentage > 0 );
 
-	// 6 is the number of scorepoints between 3, minscore and 9, maxscore. For scoring we use 10 steps, each step is 0.6
-	// Up to 6.7% passive sentences scores a 9, higher percentages give lower scores.
-	// FloatingPointFix because of js rounding errors
-	var score = 9 - Math.max( Math.min( ( 0.6 ) * ( percentage - 6.7 ), 6 ), 0 );
-	score = formatNumber( score );
+	if ( percentage <= 10 ) {
+		// Green indicator.
+		score = 9;
+	}
+
+	if ( inRange( percentage, 10, 15 ) ) {
+		// Orange indicator.
+		score = 6;
+	}
+
+	if ( percentage > 15 ) {
+		// Red indicator.
+		score = 3;
+	}
+
 	if ( score >= 7 ) {
 		return {
 			score: score,

--- a/js/assessments/sentenceLengthInTextAssessment.js
+++ b/js/assessments/sentenceLengthInTextAssessment.js
@@ -1,11 +1,10 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var countTooLongSentences = require( "./../assessmentHelpers/checkForTooLongSentences.js" );
-var calculateTooLongSentences = require( "./../assessmentHelpers/sentenceLengthPercentageScore.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
+var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
 
 var Mark = require( "../values/Mark.js" );
 var addMark = require( "../markers/addMark.js" );
-
 
 var map = require( "lodash/map" );
 
@@ -42,13 +41,29 @@ var tooLongSentencesTotal = function( sentences, recommendedValue ) {
  * @returns {Object} Object containing score and text.
  */
 var calculateSentenceLengthResult = function( sentences, i18n ) {
+	var score;
 	var percentage = 0;
 	var tooLongTotal = tooLongSentencesTotal( sentences, recommendedValue );
 
 	if ( sentences.length !== 0 ) {
 		percentage = formatNumber( ( tooLongTotal / sentences.length ) * 100 );
 	}
-	var score = calculateTooLongSentences( percentage );
+
+	if ( percentage <= 25 ) {
+		// Red indicator.
+		score = 9;
+	}
+
+	if ( inRange( percentage, 25, 30 ) ) {
+		// Orange indicator.
+		score = 6;
+	}
+
+	if ( percentage > 30 ) {
+		// Red indicator.
+		score = 3;
+	}
+
 	var hasMarks = ( percentage > 0 );
 	var sentenceLengthURL = "<a href='https://yoa.st/short-sentences' target='_blank'>";
 

--- a/js/assessments/subheadingDistributionTooLongAssessment.js
+++ b/js/assessments/subheadingDistributionTooLongAssessment.js
@@ -5,6 +5,7 @@ var map = require( "lodash/map" );
 
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
+var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
 
 // The maximum recommended value of the subheading text.
 var recommendedValue = 300;
@@ -28,15 +29,29 @@ var getTooLongSubheadingTexts = function( subheadingTextsLength ) {
  * @returns {object} the resultobject containing a score and text if subheadings are present
  */
 var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, i18n ) {
+	var score;
 
 	// Return empty result if there are no subheadings
 	if ( subheadingTextsLength.length === 0 ) {
 		return {};
 	}
 
-	// 6 is the number of scorepoints between 3, minscore and 9, maxscore. For scoring we use 100 steps, each step is 0.06.
-	// Up to 267  is for scoring a 9, higher numbers give lower scores.
-	var score = 9 - Math.max( Math.min( ( 0.06 ) * ( subheadingTextsLength[ 0 ].wordCount - 267 ), 6 ), 0 );
+	var longestSubheadingTextLength = subheadingTextsLength[ 0 ].wordCount;
+
+	if ( longestSubheadingTextLength <= 300 ) {
+		// Green indicator.
+		score = 9;
+	}
+
+	if ( inRange( longestSubheadingTextLength, 300, 350  ) ) {
+		// Orange indicator.
+		score = 6;
+	}
+
+	if ( longestSubheadingTextLength > 350 ) {
+		// Red indicator.
+		score = 3;
+	}
 
 	if ( score >= 7 ) {
 		return {
@@ -48,6 +63,7 @@ var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, i18n 
 				), recommendedValue )
 		};
 	}
+
 	return {
 		score: score,
 		hasMarks: true,

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -1,6 +1,7 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
 var map = require( "lodash/map" );
+var inRange = require( "../helpers/inRange.js" ).inRangeStartInclusive;
 
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
@@ -13,18 +14,27 @@ var marker = require( "../markers/addMark.js" );
  * @returns {object} Object containing score and text.
  */
 var calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
-	var score, unboundedScore;
+	var score;
 	var percentage = ( transitionWordSentences.transitionWordSentences / transitionWordSentences.totalSentences ) * 100;
 	percentage     = formatNumber( percentage );
 	var hasMarks   = ( percentage > 0 );
 	var transitionWordsURL = "<a href='https://yoa.st/transition-words' target='_blank'>";
 
-	// The 20 percentage points from 31.7 to 51.7 are scaled to a range of 6 score points: 6/20 = 0.3.
-	// 51.7 scores 9, 31.7 scores 3.
-	unboundedScore = 3 + ( 0.3  * ( percentage - 31.7 ) );
+	if ( percentage < 35 ) {
+		// Red indicator.
+		score = 3;
+	}
 
-	// Scores exceeding 9 are 9, scores below 3 are 3.
-	score = Math.max( Math.min( unboundedScore, 9 ), 3 );
+	if ( inRange( percentage, 35, 45 ) ) {
+		// Orange indicator.
+		score = 6;
+	}
+
+	if ( percentage >= 45 ) {
+		// Green indicator.
+		score = 9;
+	}
+
 	if ( score < 7 ) {
 		var recommendedMinimum = 45;
 		return {

--- a/js/helpers/inRange.js
+++ b/js/helpers/inRange.js
@@ -1,0 +1,41 @@
+/**
+ * Checks if `n` is between `start` and up to, but not including, `start`.
+ *
+ * @param {number} number The number to check.
+ * @param {number} start The start of the range.
+ * @param {number} end The end of the range.
+ * @returns {boolean} Returns `true` if `number` is in the range, else `false`.
+ */
+function inRangeEndInclusive( number, start, end ) {
+	return number > start && number <= end;
+}
+
+/**
+ * Checks if `n` is between `start` and up to, but not including, `end`.
+ *
+ * @param {number} number The number to check.
+ * @param {number} start The start of the range.
+ * @param {number} end The end of the range.
+ * @returns {boolean} Returns `true` if `number` is in the range, else `false`.
+ */
+function inRangeStartInclusive( number, start, end ) {
+	return number >= start && number < end;
+}
+
+/**
+ * Checks if `n` is between `start` and up to, but not including, `start`.
+ *
+ * @param {number} number The number to check.
+ * @param {number} start The start of the range.
+ * @param {number} end The end of the range.
+ * @returns {boolean} Returns `true` if `number` is in the range, else `false`.
+ */
+function inRange( number, start, end ) {
+	return inRangeEndInclusive( number, start, end );
+}
+
+module.exports = {
+	inRange: inRange,
+	inRangeStartInclusive: inRangeStartInclusive,
+	inRangeEndInclusive: inRangeEndInclusive
+};

--- a/spec/assessments/getSubheadingLengthSpec.js
+++ b/spec/assessments/getSubheadingLengthSpec.js
@@ -13,13 +13,13 @@ describe( "An assessment for finding the length of the subheadings.", function()
 	} );
 	it( "returns headings < 50 chars. ", function() {
 		assessment = subHeadingLengthAssessment.getResult( paper, Factory.buildMockResearcher( [ 5, 5, 46 ] ), i18n );
-		expect( assessment.getScore() ).toBe( 8.2 );
+		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The length of all subheadings is less than or equal to the recommended maximum of 50 characters, which is great." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 	it( "returns headings > 50 chars, 1 too long heading. ", function() {
 		assessment = subHeadingLengthAssessment.getResult( paper, Factory.buildMockResearcher( [ 5, 5, 55 ] ), i18n );
-		expect( assessment.getScore() ).toBe( 5.5 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "You have 1 subheading containing more than the recommended maximum of 50 characters." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -31,7 +31,7 @@ describe( "An assessment for finding the length of the subheadings.", function()
 	} );
 	it( "returns headings > 50 chars. 2 too long headings. ", function() {
 		assessment = subHeadingLengthAssessment.getResult( paper, Factory.buildMockResearcher( [ 5, 54, 56 ] ), i18n );
-		expect( assessment.getScore() ).toBe( 5.2 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "You have 2 subheadings containing more than the recommended maximum of 50 characters." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );

--- a/spec/assessments/paragraphTooLongSpec.js
+++ b/spec/assessments/paragraphTooLongSpec.js
@@ -13,7 +13,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 	} );
 	it( "scores 1 slightly too long paragraph", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 160, paragraph: "" } ] ), i18n );
-		expect( assessment.getScore() ).toBe( 6.4 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "1 of the paragraphs contains more than the recommended maximum of 150 words. " +
 			"Are you sure all information is about the same topic, and therefore belongs in one single paragraph?" );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -33,14 +33,14 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 	} );
 	it( "scores 3 paragraphs, one of which is too long", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, paragraph: "" }, { wordCount: 71, paragraph: "" }, { wordCount: 183, paragraph: "" } ] ), i18n );
-		expect( assessment.getScore() ).toBe( 5.0 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "1 of the paragraphs contains more than the recommended maximum of 150 words. " +
 			"Are you sure all information is about the same topic, and therefore belongs in one single paragraph?" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "scores 3 paragraphs, two of which are too long", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, paragraph: "" }, { wordCount: 191, paragraph: "" }, { wordCount: 183, paragraph: "" } ] ), i18n );
-		expect( assessment.getScore() ).toBe( 4.6 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "2 of the paragraphs contain more than the recommended maximum of 150 words. Are you sure " +
 			"all information within each of these paragraphs is about the same topic, and therefore belongs in a single paragraph?" );
 		expect( assessment.hasMarks() ).toBe( true );

--- a/spec/assessments/passiveVoiceAssessmentSpec.js
+++ b/spec/assessments/passiveVoiceAssessmentSpec.js
@@ -15,7 +15,7 @@ describe( "An assessment for scoring passive voice.", function() {
 
 	it( "scores 2 passive sentences - 10%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( {total: 20, passives: [ 1, 2 ] } ), i18n );
-		expect( assessment.getScore() ).toBe( 7 );
+		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "10% of the sentences contain a <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
 			"which is less than or equal to the recommended maximum of 10%." );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -37,9 +37,9 @@ describe( "An assessment for scoring passive voice.", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "scores 5 passive sentences - 33%", function() {
+	it( "scores 5 passive sentences - 13.3%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( {total: 30, passives: [ 1, 2, 3, 4 ] } ), i18n );
-		expect( assessment.getScore() ).toBe( 5 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "13.3% of the sentences contain a <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
 			"which is more than the recommended maximum of 10%. Try to use their active counterparts." );
 		expect( assessment.hasMarks() ).toBe( true );

--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -57,7 +57,7 @@ describe( "An assessment for sentence length", function(){
 		] ), i18n );
 
 		expect( assessment.hasScore()).toBe( true );
-		expect( assessment.getScore() ).toEqual( 7.02 );
+		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual ( "25% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is less than or equal to the recommended maximum of 25%." );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -78,7 +78,7 @@ describe( "An assessment for sentence length", function(){
 		] ), i18n );
 
 		expect( assessment.hasScore()).toBe( true );
-		expect( assessment.getScore() ).toEqual( 4.02 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( "30% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is more than the recommended maximum of 25%.Try to shorten your sentences." )
 		expect( assessment.hasMarks() ).toBe( true );

--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -7,7 +7,7 @@ var paper = new Paper();
 describe( "An assessment for scoring too long sub texts.", function() {
 	it( "scores 3 subheading texts, 0 are too long", function() {
 		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 100}, {text: "", wordCount: 300} ] ), i18n );
-		expect( assessment.getScore() ).toBe( 7.02 );
+		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The amount of words following each of your subheadings doesn't exceed the recommended maximum of 300 words, which is great." );
 	} );
 
@@ -29,7 +29,7 @@ describe( "An assessment for scoring too long sub texts.", function() {
 
 	it ( "returns a heading that is too long", function() {
 		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 310}, {text: "", wordCount: 310}, {text: "", wordCount: 310} ] ), i18n );
-		expect( assessment.getScore() ).toBe( 6.42 );
+		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "3 of the subheadings are followed by more than the recommended maximum of 300 words. Try to insert additional subheadings." );
 	} );
 

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -18,7 +18,7 @@ describe( "An assessment for transition word percentage", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 20,
 			transitionWordSentences: 7 } ), i18n );
-		expect( assessment.getScore() ).toEqual( 4 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( "35% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
 			"or phrase, which is less than the recommended minimum of 45%." );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -27,7 +27,7 @@ describe( "An assessment for transition word percentage", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
 			transitionWordSentences: 4 } ), i18n );
-		expect( assessment.getScore() ).toEqual( 5.5 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( "40% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
 			"or phrase, which is less than the recommended minimum of 45%." );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -36,7 +36,7 @@ describe( "An assessment for transition word percentage", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 100,
 			transitionWordSentences: 47 } ), i18n );
-		expect( assessment.getScore() ).toEqual( 7.6 );
+		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual ( "47% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
 			"or phrase, which is great.");
 		expect( assessment.hasMarks() ).toBe( true );


### PR DESCRIPTION
This removes the scores inside the ranges but in the end the only thing that matters is a `green`, `orange` or `red` indicator.