### PR TITLE
Changes subheadings assessments and scoring

### DIFF
--- a/js/assessments/fleschReadingEaseAssessment.js
+++ b/js/assessments/fleschReadingEaseAssessment.js
@@ -26,7 +26,7 @@ var calculateFleschReadingResult = function( fleschReadingScore, i18n ) {
 
 	if ( inRange( fleschReadingScore, 70, 80 ) ) {
 		return {
-			score: 8,
+			score: 9,
 			resultText: i18n.dgettext( "js-text-analysis", "fairly easy" ),
 			note: ""
 		};
@@ -34,7 +34,7 @@ var calculateFleschReadingResult = function( fleschReadingScore, i18n ) {
 
 	if ( inRange( fleschReadingScore, 60, 70 ) ) {
 		return {
-			score: 8,
+			score: 9,
 			resultText: i18n.dgettext( "js-text-analysis", "ok" ),
 			note: ""
 		};
@@ -50,7 +50,7 @@ var calculateFleschReadingResult = function( fleschReadingScore, i18n ) {
 
 	if ( inRange( fleschReadingScore, 30, 50 ) ) {
 		return {
-			score: 5,
+			score: 3,
 			resultText: i18n.dgettext( "js-text-analysis", "difficult" ),
 			note: i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." )
 		};
@@ -58,7 +58,7 @@ var calculateFleschReadingResult = function( fleschReadingScore, i18n ) {
 
 	if ( fleschReadingScore < 30 ) {
 		return {
-			score: 4,
+			score: 3,
 			resultText: i18n.dgettext( "js-text-analysis", "very difficult" ),
 			note: i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." )
 		};

--- a/js/assessments/subheadingDistributionTooLongAssessment.js
+++ b/js/assessments/subheadingDistributionTooLongAssessment.js
@@ -31,9 +31,15 @@ var getTooLongSubheadingTexts = function( subheadingTextsLength ) {
 var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, i18n ) {
 	var score;
 
-	// Return empty result if there are no subheadings
 	if ( subheadingTextsLength.length === 0 ) {
-		return {};
+		// Red indicator, use '2' so we can differentiate in external analysis.
+		return {
+			score: 2,
+			text: i18n.dgettext(
+				"js-text-analysis",
+				"The text does not contain any subheadings. Add at least one subheading."
+			)
+		};
 	}
 
 	var longestSubheadingTextLength = subheadingTextsLength[ 0 ].wordCount;

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -20,17 +20,17 @@ var calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 	var hasMarks   = ( percentage > 0 );
 	var transitionWordsURL = "<a href='https://yoa.st/transition-words' target='_blank'>";
 
-	if ( percentage < 35 ) {
+	if ( percentage < 20 ) {
 		// Red indicator.
 		score = 3;
 	}
 
-	if ( inRange( percentage, 35, 45 ) ) {
+	if ( inRange( percentage, 20, 30 ) ) {
 		// Orange indicator.
 		score = 6;
 	}
 
-	if ( percentage >= 45 ) {
+	if ( percentage >= 30 ) {
 		// Green indicator.
 		score = 9;
 	}

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -36,7 +36,7 @@ var calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 	}
 
 	if ( score < 7 ) {
-		var recommendedMinimum = 45;
+		var recommendedMinimum = 30;
 		return {
 			score: formatNumber( score ),
 			hasMarks: hasMarks,

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -57,7 +57,7 @@ require( "util" ).inherits( ContentAssessor, Assessor );
  *
  * @returns {number} The total negative points for the results.
  */
-ContentAssessor.prototype.calculateNegativePoints = function() {
+ContentAssessor.prototype.calculatePenaltyPoints = function() {
 	var results = this.getValidResults();
 
 	var negativePoints = map( results, function( result ) {
@@ -88,19 +88,19 @@ ContentAssessor.prototype.calculateNegativePoints = function() {
 /**
  * Rates the negative points
  *
- * @param {number} totalNegativePoints The amount of negative points.
+ * @param {number} totalPenaltyPoints The amount of negative points.
  * @returns {number} The score based on the amount of negative points.
  *
  * @private
  */
-ContentAssessor.prototype._rateNegativePoints = function( totalNegativePoints ) {
+ContentAssessor.prototype._ratePenaltyPoints = function(totalPenaltyPoints ) {
 	// Determine the total score based on the total negative points.
-	if ( totalNegativePoints > 6 ) {
+	if ( totalPenaltyPoints > 6 ) {
 		// A red indicator.
 		return 30;
 	}
 
-	if ( totalNegativePoints > 4 ) {
+	if ( totalPenaltyPoints > 4 ) {
 		// An orange indicator.
 		return 60;
 	}
@@ -122,9 +122,9 @@ ContentAssessor.prototype.calculateOverallScore = function() {
 		return 30;
 	}
 
-	var totalNegativePoints = this.calculateNegativePoints();
+	var totalPenaltyPoints = this.calculatePenaltyPoints();
 
-	return this._rateNegativePoints( totalNegativePoints );
+	return this._ratePenaltyPoints( totalPenaltyPoints );
 };
 
 module.exports = ContentAssessor;

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -3,9 +3,9 @@ var Assessor = require( "./assessor.js" );
 var fleschReadingEase = require( "./assessments/fleschReadingEaseAssessment.js" );
 var paragraphTooLong = require( "./assessments/paragraphTooLongAssessment.js" );
 var sentenceLengthInText = require( "./assessments/sentenceLengthInTextAssessment.js" );
-var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
+//var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
 var subheadingDistributionTooLong = require( "./assessments/subheadingDistributionTooLongAssessment.js" );
-var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
+//var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
 var transitionWords = require( "./assessments/transitionWordsAssessment.js" );
 var passiveVoice = require( "./assessments/passiveVoiceAssessment.js" );
 // var sentenceVariation = require( "./assessments/sentenceVariationAssessment.js" );
@@ -34,9 +34,9 @@ var ContentAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		fleschReadingEase,
-		getSubheadingPresence,
+		//getSubheadingPresence,
 		subheadingDistributionTooLong,
-		subHeadingLength,
+		//subHeadingLength,
 		paragraphTooLong,
 		sentenceLengthInText,
 		transitionWords,
@@ -66,11 +66,11 @@ ContentAssessor.prototype.calculateNegativePoints = function() {
 		// Convert the ratings to negative 'points'.
 		switch ( rating ) {
 			case "bad":
-				weight = 1;
+				weight = 3;
 				break;
 
 			case "ok":
-				weight = 1 / 2;
+				weight = 2;
 				break;
 
 			default:
@@ -95,18 +95,18 @@ ContentAssessor.prototype.calculateNegativePoints = function() {
  */
 ContentAssessor.prototype._rateNegativePoints = function( totalNegativePoints ) {
 	// Determine the total score based on the total negative points.
-	if ( totalNegativePoints < 2 ) {
-		// A green indicator.
-		return 90;
+	if ( totalNegativePoints > 6 ) {
+		// A red indicator.
+		return 30;
 	}
 
-	if ( totalNegativePoints < 4 ) {
+	if ( totalNegativePoints > 4 ) {
 		// An orange indicator.
 		return 60;
 	}
 
-	// A red indicator.
-	return 30;
+	// A green indicator.
+	return 90;
 };
 
 /**

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -93,7 +93,7 @@ ContentAssessor.prototype.calculatePenaltyPoints = function() {
  *
  * @private
  */
-ContentAssessor.prototype._ratePenaltyPoints = function(totalPenaltyPoints ) {
+ContentAssessor.prototype._ratePenaltyPoints = function( totalPenaltyPoints ) {
 	// Determine the total score based on the total negative points.
 	if ( totalPenaltyPoints > 6 ) {
 		// A red indicator.

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -1,11 +1,11 @@
-var Assessor = require("./assessor.js");
+var Assessor = require( "./assessor.js" );
 
-var fleschReadingEase = require("./assessments/fleschReadingEaseAssessment.js");
-var paragraphTooLong = require("./assessments/paragraphTooLongAssessment.js");
-var sentenceLengthInText = require("./assessments/sentenceLengthInTextAssessment.js");
-var subheadingDistributionTooLong = require("./assessments/subheadingDistributionTooLongAssessment.js");
-var transitionWords = require("./assessments/transitionWordsAssessment.js");
-var passiveVoice = require("./assessments/passiveVoiceAssessment.js");
+var fleschReadingEase = require( "./assessments/fleschReadingEaseAssessment.js" );
+var paragraphTooLong = require( "./assessments/paragraphTooLongAssessment.js" );
+var sentenceLengthInText = require( "./assessments/sentenceLengthInTextAssessment.js" );
+var subheadingDistributionTooLong = require( "./assessments/subheadingDistributionTooLongAssessment.js" );
+var transitionWords = require( "./assessments/transitionWordsAssessment.js" );
+var passiveVoice = require( "./assessments/passiveVoiceAssessment.js" );
 // var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
 // var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
 // var sentenceVariation = require( "./assessments/sentenceVariationAssessment.js" );
@@ -14,12 +14,12 @@ var passiveVoice = require("./assessments/passiveVoiceAssessment.js");
 // var subheadingDistributionTooShort = require( "./assessments/subheadingDistributionTooShortAssessment.js" );
 // var paragraphTooShort = require( "./assessments/paragraphTooShortAssessment.js" );
 // var sentenceLengthInDescription = require( "./assessments/sentenceLengthInDescriptionAssessment.js" );
-var textPresence = require("./assessments/textPresenceAssessment.js");
+var textPresence = require( "./assessments/textPresenceAssessment.js" );
 
-var scoreToRating = require("./interpreters/scoreToRating");
+var scoreToRating = require( "./interpreters/scoreToRating" );
 
-var map = require("lodash/map");
-var sum = require("lodash/sum");
+var map = require( "lodash/map" );
+var sum = require( "lodash/sum" );
 
 /**
  * Creates the Assessor
@@ -30,27 +30,27 @@ var sum = require("lodash/sum");
  *
  * @constructor
  */
-var ContentAssessor = function (i18n, options) {
-    Assessor.call(this, i18n, options);
+var ContentAssessor = function ( i18n, options ) {
+	Assessor.call( this, i18n, options );
 
-    this._assessments = [
-        fleschReadingEase,
-        subheadingDistributionTooLong,
-        paragraphTooLong,
-        sentenceLengthInText,
-        transitionWords,
-        passiveVoice,
-        textPresence
-        // sentenceVariation,
-        // sentenceBeginnings,
-        // wordComplexity,
-        // subheadingDistributionTooShort,
-        // paragraphTooShort
-        // sentenceLengthInDescription,
-    ];
+	this._assessments = [
+		fleschReadingEase,
+		subheadingDistributionTooLong,
+		paragraphTooLong,
+		sentenceLengthInText,
+		transitionWords,
+		passiveVoice,
+		textPresence
+		// sentenceVariation,
+		// sentenceBeginnings,
+		// wordComplexity,
+		// subheadingDistributionTooShort,
+		// paragraphTooShort
+		// sentenceLengthInDescription,
+	];
 };
 
-require("util").inherits(ContentAssessor, Assessor);
+require( "util" ).inherits( ContentAssessor, Assessor );
 
 /**
  * Calculates the negative points based on the assessment results.
@@ -58,31 +58,31 @@ require("util").inherits(ContentAssessor, Assessor);
  * @returns {number} The total negative points for the results.
  */
 ContentAssessor.prototype.calculatePenaltyPoints = function () {
-    var results = this.getValidResults();
+	var results = this.getValidResults();
 
-    var negativePoints = map(results, function (result) {
-        var weight, rating = scoreToRating(result.getScore());
+	var negativePoints = map( results, function ( result ) {
+		var weight, rating = scoreToRating( result.getScore() );
 
-        // Convert the ratings to negative 'points'.
-        switch (rating) {
-            case "bad":
-                weight = 3;
-                break;
+		// Convert the ratings to negative 'points'.
+		switch ( rating ) {
+			case "bad":
+				weight = 3;
+				break;
 
-            case "ok":
-                weight = 2;
-                break;
+			case "ok":
+				weight = 2;
+				break;
 
-            default:
-            case "good":
-                weight = 0;
-                break;
-        }
+			default:
+			case "good":
+				weight = 0;
+				break;
+		}
 
-        return weight;
-    });
+		return weight;
+	} );
 
-    return sum(negativePoints);
+	return sum( negativePoints );
 };
 
 /**
@@ -93,32 +93,31 @@ ContentAssessor.prototype.calculatePenaltyPoints = function () {
  *
  * @private
  */
-ContentAssessor.prototype._ratePenaltyPoints = function (totalPenaltyPoints) {
-    if (this._lastPaper.getLocale().indexOf("en_") > -1) {
-        // Determine the total score based on the total negative points.
-        if (totalPenaltyPoints > 6) {
-            // A red indicator.
-            return 30;
-        }
+ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
+	if ( this._lastPaper.getLocale().indexOf( "en_" ) > -1 ) {
+		// Determine the total score based on the total negative points.
+		if ( totalPenaltyPoints > 6 ) {
+			// A red indicator.
+			return 30;
+		}
 
-        if (totalPenaltyPoints > 4) {
-            // An orange indicator.
-            return 60;
-        }
-    }
-    else {
-        if (totalPenaltyPoints > 3) {
-            // A red indicator.
-            return 30;
-        }
+		if ( totalPenaltyPoints > 4 ) {
+			// An orange indicator.
+			return 60;
+		}
+	} else {
+		if ( totalPenaltyPoints > 3 ) {
+			// A red indicator.
+			return 30;
+		}
 
-        if (totalPenaltyPoints > 2) {
-            // An orange indicator.
-            return 60;
-        }
-    }
-    // A green indicator.
-    return 90;
+		if ( totalPenaltyPoints > 2 ) {
+			// An orange indicator.
+			return 60;
+		}
+	}
+	// A green indicator.
+	return 90;
 };
 
 /**
@@ -127,16 +126,16 @@ ContentAssessor.prototype._ratePenaltyPoints = function (totalPenaltyPoints) {
  * @returns {number} The overall score.
  */
 ContentAssessor.prototype.calculateOverallScore = function () {
-    var results = this.getValidResults();
+	var results = this.getValidResults();
 
-    // If you have no content, you have a red indicator.
-    if (results.length === 0) {
-        return 30;
-    }
+	// If you have no content, you have a red indicator.
+	if ( results.length === 0 ) {
+		return 30;
+	}
 
-    var totalPenaltyPoints = this.calculatePenaltyPoints();
+	var totalPenaltyPoints = this.calculatePenaltyPoints();
 
-    return this._ratePenaltyPoints(totalPenaltyPoints);
+	return this._ratePenaltyPoints( totalPenaltyPoints );
 };
 
 module.exports = ContentAssessor;

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -94,7 +94,7 @@ ContentAssessor.prototype.calculatePenaltyPoints = function () {
  * @private
  */
 ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
-	if ( this._lastPaper.getLocale().indexOf( "en_" ) > -1 ) {
+	if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
 		// Determine the total score based on the total negative points.
 		if ( totalPenaltyPoints > 6 ) {
 			// A red indicator.

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -3,11 +3,11 @@ var Assessor = require( "./assessor.js" );
 var fleschReadingEase = require( "./assessments/fleschReadingEaseAssessment.js" );
 var paragraphTooLong = require( "./assessments/paragraphTooLongAssessment.js" );
 var sentenceLengthInText = require( "./assessments/sentenceLengthInTextAssessment.js" );
-//var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
 var subheadingDistributionTooLong = require( "./assessments/subheadingDistributionTooLongAssessment.js" );
-//var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
 var transitionWords = require( "./assessments/transitionWordsAssessment.js" );
 var passiveVoice = require( "./assessments/passiveVoiceAssessment.js" );
+// var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
+// var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
 // var sentenceVariation = require( "./assessments/sentenceVariationAssessment.js" );
 // var sentenceBeginnings = require( "./assessments/sentenceBeginningsAssessment.js" );
 // var wordComplexity = require( "./assessments/wordComplexityAssessment.js" );
@@ -34,9 +34,9 @@ var ContentAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		fleschReadingEase,
-		//getSubheadingPresence,
+		// getSubheadingPresence,
 		subheadingDistributionTooLong,
-		//subHeadingLength,
+		// subHeadingLength,
 		paragraphTooLong,
 		sentenceLengthInText,
 		transitionWords,

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -34,13 +34,13 @@ var ContentAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		fleschReadingEase,
-		// getSubheadingPresence,
 		subheadingDistributionTooLong,
-		// subHeadingLength,
 		paragraphTooLong,
 		sentenceLengthInText,
 		transitionWords,
 		passiveVoice
+		// getSubheadingPresence,
+		// subHeadingLength,
 		// sentenceVariation,
 		// sentenceBeginnings,
 		// wordComplexity,

--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -11,29 +11,33 @@ describe( "An assessment for the fleschReading", function(){
 
 		var result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 63.9 ), i18n );
 
-		expect( result.getScore() ).toBe( 8 );
+		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 63.9 in the <a href='https://yoast.com/flesch-reading-ease-score/' target='new'>Flesch Reading Ease</a> test, which is considered ok to read. " );
 
 		paper = new Paper( "A piece of text to calculate scores." );
 
 		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 78.9 ), i18n );
 
-		expect( result.getScore() ).toBe( 8 );
+		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 78.9 in the <a href='https://yoast.com/flesch-reading-ease-score/' target='new'>Flesch Reading Ease</a> test, which is considered fairly easy to read. " );
 
 		paper = new Paper( "aaaaa" );
 
 		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 36.6 ), i18n );
 
-		expect( result.getScore() ).toBe( 5 );
+		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 36.6 in the <a href='https://yoast.com/flesch-reading-ease-score/' target='new'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 
 		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 0 ), i18n );
-		expect( result.getScore() ).toBe( 4 );
+		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoast.com/flesch-reading-ease-score/' target='new'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 
+		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 55.0 ), i18n );
+		expect( result.getScore() ).toBe( 6 );
+		expect( result.getText() ).toBe( "The copy scores 55 in the <a href='https://yoast.com/flesch-reading-ease-score/' target='new'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
+
 		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 60.0 ), i18n );
-		expect( result.getScore() ).toBe( 8 );
+		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 60 in the <a href='https://yoast.com/flesch-reading-ease-score/' target='new'>Flesch Reading Ease</a> test, which is considered ok to read. " );
 
 		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 100.0 ), i18n );

--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -19,7 +19,7 @@ describe( "An assessment for scoring too long sub texts.", function() {
 
 	it ( "returns score 2 for no subheadings", function() {
 		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [] ), i18n );
-		expect( assessment.hasScore() ).toBe( 2 );
+		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe( "The text does not contain any subheadings. Add at least one subheading." );
 	} );
 	it ( "returns a heading that is too long", function() {

--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -17,9 +17,10 @@ describe( "An assessment for scoring too long sub texts.", function() {
 		expect( assessment.getText() ).toBe( "The amount of words following each of your subheadings doesn't exceed the recommended maximum of 300 words, which is great." );
 	} );
 
-	it ( "returns no score, because the string has no subheadings", function() {
+	it ( "returns score 2 for no subheadings", function() {
 		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [] ), i18n );
-		expect( assessment.hasScore() ).toBe( false );
+		expect( assessment.hasScore() ).toBe( 2 );
+		expect( assessment.getText() ).toBe( "The text does not contain any subheadings. Add at least one subheading." );
 	} );
 	it ( "returns a heading that is too long", function() {
 		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 400}, {text: "", wordCount: 300} ] ), i18n );

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -4,32 +4,52 @@ var Factory = require( "../helpers/factory.js" );
 var i18n = Factory.buildJed();
 
 describe( "An assessment for transition word percentage", function(){
+	it( "returns the score for 10.0% of the sentences with transition words", function(){
+		var mockPaper = new Paper();
+		var assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
+			transitionWordSentences: 1 } ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual ( "10% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
+			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+	it( "returns the score for 20.0% of the sentences with transition words", function(){
+		var mockPaper = new Paper();
+		var assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 5,
+			transitionWordSentences: 1 } ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual ( "20% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
+			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
 	it( "returns the score for 25.0% of the sentences with transition words", function(){
 		var mockPaper = new Paper();
 		var assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 4,
 			transitionWordSentences: 1 } ), i18n );
 
-		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( "25% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 45%." );
+			"or phrase, which is less than the recommended minimum of 30%." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 35.0% of the sentences with transition words", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 20,
 			transitionWordSentences: 7 } ), i18n );
-		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual ( "35% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 45%." );
+			"or phrase, which is great." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 40% sentences with transition words", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
 			transitionWordSentences: 4 } ), i18n );
-		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual ( "40% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 45%." );
+			"or phrase, which is great." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 47% sentences with transition words", function(){

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -1,6 +1,7 @@
 var ContentAssessor = require( "../js/contentAssessor.js" );
 var AssessmentResult = require( "../js/values/AssessmentResult.js" );
 var Factory = require( "./helpers/factory.js" );
+var Paper = require("../js/values/Paper.js");
 
 var forEach = require( "lodash/forEach" );
 
@@ -98,6 +99,9 @@ describe( "A content assesor", function() {
 			contentAssessor.calculatePenaltyPoints = function() {
 				return points;
 			};
+			contentAssessor.getPaper = function() {
+				return new Paper;
+			}
 		});
 
 		it( "should default to a bad indicator", function() {

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -13,7 +13,7 @@ describe( "A content assesor", function() {
 		contentAssessor = new ContentAssessor( i18n );
 	});
 
-	describe( "calculateNegativePoints", function() {
+	describe( "calculatePenaltyPoints", function() {
 		var results;
 
 		beforeEach( function() {
@@ -26,7 +26,7 @@ describe( "A content assesor", function() {
 			results = [];
 			var expected = 0;
 
-			var actual = contentAssessor.calculateNegativePoints();
+			var actual = contentAssessor.calculatePenaltyPoints();
 
 			expect( actual ).toBe( expected );
 		});
@@ -41,7 +41,7 @@ describe( "A content assesor", function() {
 			];
 			var expected = 0;
 
-			var actual = contentAssessor.calculateNegativePoints();
+			var actual = contentAssessor.calculatePenaltyPoints();
 
 			expect( actual ).toBe( expected );
 		});
@@ -52,7 +52,7 @@ describe( "A content assesor", function() {
 			];
 			var expected = 3;
 
-			var actual = contentAssessor.calculateNegativePoints();
+			var actual = contentAssessor.calculatePenaltyPoints();
 
 			expect( actual ).toBe( expected );
 		});
@@ -63,7 +63,7 @@ describe( "A content assesor", function() {
 			];
 			var expected = 2;
 
-			var actual = contentAssessor.calculateNegativePoints();
+			var actual = contentAssessor.calculatePenaltyPoints();
 
 			expect( actual ).toBe( expected );
 		});
@@ -82,7 +82,7 @@ describe( "A content assesor", function() {
 			];
 			var expected = 6 + 6;
 
-			var actual = contentAssessor.calculateNegativePoints();
+			var actual = contentAssessor.calculatePenaltyPoints();
 
 			expect( actual ).toBe( expected );
 		});
@@ -95,7 +95,7 @@ describe( "A content assesor", function() {
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
-			contentAssessor.calculateNegativePoints = function() {
+			contentAssessor.calculatePenaltyPoints = function() {
 				return points;
 			};
 		});

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -117,7 +117,7 @@ describe( "A content assesor", function() {
 				{ points: 7, expected: 30 },
 				{ points: 6, expected: 60 },
 				{ points: 9, expected: 30 },
-				{ points: 4, expected: 60 },
+				{ points: 4, expected: 90 },
 				{ points: 2, expected: 90 },
 				{ points: 1.9, expected: 90 },
 				{ points: 1, expected: 90 }

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -46,22 +46,22 @@ describe( "A content assesor", function() {
 			expect( actual ).toBe( expected );
 		});
 
-		it( "should return 1 for a red assessment result", function() {
+		it( "should return 3 for a red assessment result", function() {
 			results = [
 				new AssessmentResult({ score: 3 })
 			];
-			var expected = 1;
+			var expected = 3;
 
 			var actual = contentAssessor.calculateNegativePoints();
 
 			expect( actual ).toBe( expected );
 		});
 
-		it( "should return 1/2 for an orange assessment result", function() {
+		it( "should return 2 for an orange assessment result", function() {
 			results = [
 				new AssessmentResult({ score: 6 })
 			];
-			var expected = 1/2;
+			var expected = 2;
 
 			var actual = contentAssessor.calculateNegativePoints();
 
@@ -80,7 +80,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ text: "A piece of feedback" })
 			];
-			var expected = 3 + 1/2;
+			var expected = 6 + 6;
 
 			var actual = contentAssessor.calculateNegativePoints();
 
@@ -114,10 +114,11 @@ describe( "A content assesor", function() {
 				new AssessmentResult()
 			];
 			var testCases = [
-				{ points: 4, expected: 30 },
-				{ points: 3.9, expected: 60 },
-				{ points: 3, expected: 60 },
-				{ points: 2, expected: 60 },
+				{ points: 7, expected: 30 },
+				{ points: 6, expected: 60 },
+				{ points: 9, expected: 30 },
+				{ points: 4, expected: 60 },
+				{ points: 2, expected: 90 },
 				{ points: 1.9, expected: 90 },
 				{ points: 1, expected: 90 }
 			];


### PR DESCRIPTION
Fixes #692 by disabling two subheadings scores and merging the presence one into the distribution one.

Also: 

- changed scoring to a slightly more balanced method.
- changed `NegativePoints` to `PenaltyPoints`. Because they're positive numbers, because "Penalty" describes what they are a bit better and matches the terminology used in our explainer post.