### PR TITLE
Persist active marker on analysis refresh

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -479,12 +479,10 @@ App.prototype.runAnalyzer = function() {
 
 	this.seoAssessorPresenter.setKeyword( this.paper.getKeyword() );
 	this.seoAssessorPresenter.render();
-	this.seoAssessorPresenter.displayRemoveAllMarkersButton( this.seoAssessor.hasMarkers() );
 	this.callbacks.saveScores( this.seoAssessor.calculateOverallScore(), this.seoAssessorPresenter );
 
 	if ( !isUndefined( this.contentAssessorPresenter ) ) {
 		this.contentAssessorPresenter.renderIndividualRatings();
-		this.contentAssessorPresenter.displayRemoveAllMarkersButton( this.contentAssessor.hasMarkers() );
 		this.callbacks.saveContentScore( this.contentAssessor.calculateOverallScore(), this.contentAssessorPresenter );
 	}
 
@@ -638,6 +636,17 @@ App.prototype.registerTest = function() {
  */
 App.prototype.registerAssessment = function( name, assessment, pluginName ) {
 	return this.pluggable._registerAssessment( this.seoAssessor, name, assessment, pluginName );
+};
+
+/**
+ * Disables markers visually in the UI
+ */
+App.prototype.disableMarkers = function() {
+	this.seoAssessorPresenter.disableMarker();
+
+	if ( !isUndefined( this.contentAssessorPresenter ) ) {
+		this.contentAssessorPresenter.disableMarker();
+	}
 };
 
 // Deprecated functions

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -287,8 +287,7 @@ AssessorPresenter.prototype.renderIndividualRatings = function() {
 		scores: scores,
 		i18n: {
 			markInText: this.i18n.dgettext( "js-text-analysis", "Mark this result in the text" ),
-			removeMarksInText: this.i18n.dgettext( "js-text-analysis", "Remove marks in the text" ),
-			removeMarks: this.i18n.dgettext( "js-text-analysis", "Remove all marks from the text" )
+			removeMarksInText: this.i18n.dgettext( "js-text-analysis", "Remove marks in the text" )
 		},
 		activeMarker: this._activeMarker
 	} );

--- a/templates/assessmentPresenterResult.jst
+++ b/templates/assessmentPresenterResult.jst
@@ -3,7 +3,9 @@
         <li class="score">
             <span class="assessment-results__mark-container">
                 <% if ( scores[ i ].marker ) { %>
-                    <button type="button" aria-label="<%= i18n.markInText %>" class="assessment-results__mark icon-eye-inactive js-assessment-results__mark-<%= scores[ i ].identifier %> yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text"><%= i18n.markInText %></span></button>
+                    <button type="button"
+                        aria-label="<%= i18n.markInText %>"
+                        class="assessment-results__mark <% if ( scores[ i ].identifier === activeMarker ) { %>icon-eye-active<% } else { %>icon-eye-inactive<% } %> js-assessment-results__mark-<%= scores[ i ].identifier %> yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text"><% if ( scores[ i ].identifier === activeMarker ) { %><%= i18n.removeMarksInText %><% } else { %><%= i18n.markInText %><% } %></span></button>
                 <% } %>
             </span>
             <span class="wpseo-score-icon <%- scores[ i ].className %>"></span>
@@ -12,4 +14,3 @@
         </li>
     <% } %>
 </ul>
-<button type="button" class="assessment-results__remove-marks js-assessment-results__remove-marks"><%= i18n.removeMarks %></button>


### PR DESCRIPTION
I have:

* Removed the "Remove all marks" button.
* Made the mark buttons actual toggles.
* Persisted markers across analysis refreshes.

To test this: Make sure it all works as you expected in the standalone version.