### PR TITLE
Fix case-insensitive require for js/values/Paper

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
 	Researcher: require( "./js/researcher" ),
 	SnippetPreview: require( "./js/snippetPreview.js" ),
 
-	Paper: require( "./js/values/paper" ),
+	Paper: require( "./js/values/Paper" ),
 	AssessmentResult: require( "./js/values/AssessmentResult" ),
 
 	bundledPlugins: plugins,


### PR DESCRIPTION
Running this plugin on Ubuntu (via Jenkins) I ran into an issue with case sensitivity with this import line (transpiled with babel6):

`import { Paper, SEOAssessor } from 'yoastseo';`

Before fix gives this error:

18:22:17 Error: Cannot find module './js/values/paper'
18:22:17     at Function.Module._resolveFilename (module.js:339:15)
18:22:17     at Function.Module._load (module.js:290:25)
18:22:17     at Module.require (module.js:367:17)
18:22:17     at require (internal/module.js:16:19)