### PR TITLE
Fixes content assessorspec

### DIFF
--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -115,6 +115,7 @@ describe( "A content assesor", function() {
 
 		it( "should give worse results based on the negative points", function() {
 			results = [
+				new AssessmentResult(),
 				new AssessmentResult()
 			];
 			var testCases = [


### PR DESCRIPTION
The assessorspec was failing, because it always returns a score of 30 if there is only 1 assessment result. 
This adds another assessment result to the array, so it will calculate penalty points. 

For testing: run jasmine and see tests don't fail