### PR TITLE
RW/add nomarker option

### DIFF
--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -100,7 +100,7 @@ li.score:after {
 
 	&__mark {
 		&.icon-eye {
-			&-inactive, &-active {
+			&-inactive, &-active, &-disabled {
 				float: left;
 				border: 0;
 				width: 28px;
@@ -127,6 +127,11 @@ li.score:after {
 					display: none;
 				}
 			}
+
+			&-disabled {
+				background-image: url(svg-icon-eye($color_marker_disabled));
+			}
+
 		}
 
 		&:focus {

--- a/css/_colors.scss
+++ b/css/_colors.scss
@@ -21,3 +21,4 @@ $color_buttons: #555555;
 
 $color_marker_inactive: #555555;
 $color_marker_active: #ffffff;
+$color_marker_disabled: #e6e6e6;

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -30,6 +30,8 @@ var AssessorPresenter = function( args ) {
 	this.overall = args.targets.overall || "overallScore";
 	this.presenterConfig = createConfig( args.i18n );
 
+	this._disableMarkerButtons = false;
+
 	this._activeMarker = false;
 };
 
@@ -233,6 +235,22 @@ AssessorPresenter.prototype.disableMarker = function() {
 };
 
 /**
+ * Disables the marker buttons.
+ */
+AssessorPresenter.prototype.disableMarkerButtons = function() {
+	this._disableMarkerButtons = true;
+	this.render();
+};
+
+/**
+ * Enables the marker buttons.
+ */
+AssessorPresenter.prototype.enableMarkerButtons = function() {
+	this._disableMarkerButtons = false;
+	this.render();
+};
+
+/**
  * Adds an event listener for the marker button
  *
  * @param {string} identifier The identifier for the assessment the marker belongs to.
@@ -289,7 +307,8 @@ AssessorPresenter.prototype.renderIndividualRatings = function() {
 			markInText: this.i18n.dgettext( "js-text-analysis", "Mark this result in the text" ),
 			removeMarksInText: this.i18n.dgettext( "js-text-analysis", "Remove marks in the text" )
 		},
-		activeMarker: this._activeMarker
+		activeMarker: this._activeMarker,
+		markerButtonsDisabled: this._disableMarkerButtons
 	} );
 
 	this.bindMarkButtons( scores );

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -304,7 +304,7 @@ AssessorPresenter.prototype.renderIndividualRatings = function() {
 	outputTarget.innerHTML = template( {
 		scores: scores,
 		i18n: {
-			disabledMarkText : this.i18n.dgettext( "js-text-analysis", "Marks are disabled in current view" ),
+			disabledMarkText: this.i18n.dgettext( "js-text-analysis", "Marks are disabled in current view" ),
 			markInText: this.i18n.dgettext( "js-text-analysis", "Mark this result in the text" ),
 			removeMarksInText: this.i18n.dgettext( "js-text-analysis", "Remove marks in the text" )
 		},

--- a/js/renderers/AssessorPresenter.js
+++ b/js/renderers/AssessorPresenter.js
@@ -304,6 +304,7 @@ AssessorPresenter.prototype.renderIndividualRatings = function() {
 	outputTarget.innerHTML = template( {
 		scores: scores,
 		i18n: {
+			disabledMarkText : this.i18n.dgettext( "js-text-analysis", "Marks are disabled in current view" ),
 			markInText: this.i18n.dgettext( "js-text-analysis", "Mark this result in the text" ),
 			removeMarksInText: this.i18n.dgettext( "js-text-analysis", "Remove marks in the text" )
 		},

--- a/js/templates.js
+++ b/js/templates.js
@@ -21,7 +21,7 @@
   var undefined;
 
   /** Used as the semantic version number. */
-  var VERSION = '4.13.0';
+  var VERSION = '4.13.1';
 
   /** Used as references for various `Number` constants. */
   var INFINITY = 1 / 0;
@@ -263,7 +263,11 @@
      for (var i in scores) {
     __p += '\n        <li class="score">\n            <span class="assessment-results__mark-container">\n                ';
      if ( scores[ i ].marker ) {
-    __p += '\n                    <button type="button"\n                        aria-label="' +
+    __p += '\n                    <button type="button" ';
+     if ( markerButtonsDisabled ) {
+    __p += ' disabled="disabled" ';
+     }
+    __p += '\n                        aria-label="' +
     ((__t = ( i18n.markInText )) == null ? '' : __t) +
     '"\n                        class="assessment-results__mark ';
      if ( scores[ i ].identifier === activeMarker ) {

--- a/js/templates.js
+++ b/js/templates.js
@@ -267,25 +267,46 @@
      if ( markerButtonsDisabled ) {
     __p += ' disabled="disabled" ';
      }
-    __p += '\n                        aria-label="' +
-    ((__t = ( i18n.markInText )) == null ? '' : __t) +
-    '"\n                        class="assessment-results__mark ';
-     if ( scores[ i ].identifier === activeMarker ) {
-    __p += 'icon-eye-active';
-     } else {
-    __p += 'icon-eye-inactive';
+    __p += '\n                        aria-label="';
+     if ( markerButtonsDisabled ) {
+    __p +=
+    ((__t = ( i18n.disabledMarkText )) == null ? '' : __t);
      }
-    __p += ' js-assessment-results__mark-' +
-    ((__t = ( scores[ i ].identifier )) == null ? '' : __t) +
-    ' yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text">';
-     if ( scores[ i ].identifier === activeMarker ) {
+                                else if ( scores[ i ].identifier === activeMarker ) {
     __p +=
     ((__t = ( i18n.removeMarksInText )) == null ? '' : __t);
-     } else {
+     }
+                                else {
     __p +=
     ((__t = ( i18n.markInText )) == null ? '' : __t);
      }
-    __p += '</span></button>\n                ';
+    __p += '"\n                        class="assessment-results__mark ';
+
+                            if ( markerButtonsDisabled ) {
+    __p += ' icon-eye-disabled ';
+     }
+                            else if ( scores[ i ].identifier === activeMarker ) {
+    __p += '\n                            icon-eye-active\n                        ';
+     }
+                            else {
+    __p += '\n                            icon-eye-inactive\n                        ';
+     }
+    __p += '\n                        js-assessment-results__mark-' +
+    ((__t = ( scores[ i ].identifier )) == null ? '' : __t) +
+    ' yoast-tooltip yoast-tooltip-s">\n                        <span class="screen-reader-text">';
+     if ( markerButtonsDisabled ) {
+    __p +=
+    ((__t = ( i18n.disabledMarkText )) == null ? '' : __t);
+     }
+                                else if ( scores[ i ].identifier === activeMarker ) {
+    __p +=
+    ((__t = ( i18n.removeMarksInText )) == null ? '' : __t);
+     }
+                                else {
+    __p +=
+    ((__t = ( i18n.markInText )) == null ? '' : __t);
+     }
+    __p += '\n                        </span></button>\n                ';
      }
     __p += '\n            </span>\n            <span class="wpseo-score-icon ' +
     __e( scores[ i ].className ) +

--- a/js/values/AssessmentResult.js
+++ b/js/values/AssessmentResult.js
@@ -132,7 +132,7 @@ AssessmentResult.prototype.hasMarker = function() {
 };
 
 /**
- * Gets the marker, a pure function that an return the marks for a given Paper
+ * Gets the marker, a pure function that can return the marks for a given Paper
  *
  * @returns {Function} The marker.
  */

--- a/languages/yoast-seo.pot
+++ b/languages/yoast-seo.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: yoastseo 1.2.2\n"
+"Project-Id-Version: yoastseo 1.3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-10 15:14+0200\n"
+"POT-Creation-Date: 2016-06-15 13:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,14 +65,14 @@ msgid ""
 msgstr ""
 
 #. Translators: %1$d expands to the recommended maximum number of characters.
-#: js/assessments/getSubheadingLengthAssessment.js:32
+#: js/assessments/getSubheadingLengthAssessment.js:33
 msgid ""
 "The length of all subheadings is less than or equal to the recommended "
 "maximum of %1$d characters, which is great."
 msgstr ""
 
 #. Translators: %1$d expands to the number of subheadings. %2$d expands to the recommended maximum number of characters.
-#: js/assessments/getSubheadingLengthAssessment.js:45
+#: js/assessments/getSubheadingLengthAssessment.js:46
 msgid ""
 "You have %1$d subheading containing more than the recommended maximum of "
 "%2$d characters."
@@ -110,29 +110,23 @@ msgid ""
 "focus keyword was found %2$d times."
 msgstr ""
 
-#. Translators: This is the maximum keyword density, localize the number for your language (e.g. 2,5)
-#: js/assessments/keywordDensityAssessment.js:30
-#: js/assessments/keywordDensityAssessment.js:45
-msgid "2.5"
-msgstr ""
-
 #. Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
 #. %3$s expands to the maximum keyword density percentage.
-#: js/assessments/keywordDensityAssessment.js:40
+#: js/assessments/keywordDensityAssessment.js:39
 msgid ""
 "The keyword density is %1$s, which is over the advised %3$s maximum; the "
 "focus keyword was found %2$d times."
 msgstr ""
 
 #. Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count.
-#: js/assessments/keywordDensityAssessment.js:54
+#: js/assessments/keywordDensityAssessment.js:52
 msgid ""
 "The keyword density is %1$s, which is great; the focus keyword was found "
 "%2$d times."
 msgstr ""
 
 #. Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count.
-#: js/assessments/keywordDensityAssessment.js:64
+#: js/assessments/keywordDensityAssessment.js:62
 msgid ""
 "The keyword density is %1$s, which is a bit low; the focus keyword was found "
 "%2$d times."
@@ -183,12 +177,12 @@ msgid ""
 "competition? Could it be made more appealing?"
 msgstr ""
 
-#: js/assessments/paragraphTooLongAssessment.js:44
+#: js/assessments/paragraphTooLongAssessment.js:59
 msgid "None of your paragraphs are too long, which is great."
 msgstr ""
 
 #. Translators: %1$d expands to the number of paragraphs, %2$d expands to the recommended value
-#: js/assessments/paragraphTooLongAssessment.js:52
+#: js/assessments/paragraphTooLongAssessment.js:67
 msgid ""
 "%1$d of the paragraphs contains more than the recommended maximum of %2$d "
 "words. Are you sure all information is about the same topic, and therefore "
@@ -219,7 +213,7 @@ msgstr[1] ""
 
 #. Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
 #. %3$s expands to the anchor end tag, %4$s expands to the recommended value.
-#: js/assessments/passiveVoiceAssessment.js:37
+#: js/assessments/passiveVoiceAssessment.js:50
 msgid ""
 "%1$s of the sentences contain a %2$spassive voice%3$s, which is less than or "
 "equal to the recommended maximum of %4$s."
@@ -227,7 +221,7 @@ msgstr ""
 
 #. Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
 #. %3$s expands to the anchor end tag, %4$s expands to the recommended value.
-#: js/assessments/passiveVoiceAssessment.js:55
+#: js/assessments/passiveVoiceAssessment.js:68
 msgid ""
 "%1$s of the sentences contain a %2$spassive voice%3$s, which is more than "
 "the recommended maximum of %4$s. Try to use their active counterparts."
@@ -267,7 +261,7 @@ msgstr[1] ""
 #. Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
 #. %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
 #. %5$s expands to the recommended maximum percentage.
-#: js/assessments/sentenceLengthInTextAssessment.js:63
+#: js/assessments/sentenceLengthInTextAssessment.js:78
 msgid ""
 "%1$s of the sentences contain %2$smore than %3$s words%4$s, which is less "
 "than or equal to the recommended maximum of %5$s."
@@ -276,7 +270,7 @@ msgstr ""
 #. Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
 #. %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
 #. %5$s expands to the recommended maximum percentage.
-#: js/assessments/sentenceLengthInTextAssessment.js:80
+#: js/assessments/sentenceLengthInTextAssessment.js:95
 msgid ""
 "%1$s of the sentences contain %2$smore than %3$s words%4$s, which is more "
 "than the recommended maximum of %5$s.Try to shorten your sentences."
@@ -300,13 +294,18 @@ msgid ""
 "sentences."
 msgstr ""
 
-#: js/assessments/subheadingDistributionTooLongAssessment.js:47
+#: js/assessments/subheadingDistributionTooLongAssessment.js:40
+#: js/assessments/subheadingPresenceAssessment.js:28
+msgid "The text does not contain any subheadings. Add at least one subheading."
+msgstr ""
+
+#: js/assessments/subheadingDistributionTooLongAssessment.js:68
 msgid ""
 "The amount of words following each of your subheadings doesn't exceed the "
 "recommended maximum of %1$d words, which is great."
 msgstr ""
 
-#: js/assessments/subheadingDistributionTooLongAssessment.js:59
+#: js/assessments/subheadingDistributionTooLongAssessment.js:81
 msgid ""
 "%1$d of the subheadings is followed by more than the recommended maximum of "
 "%2$d words. Try to insert another subheading."
@@ -339,10 +338,6 @@ msgid "The text contains %1$d subheading, which is great."
 msgid_plural "The text contains %1$d subheadings, which is great."
 msgstr[0] ""
 msgstr[1] ""
-
-#: js/assessments/subheadingPresenceAssessment.js:28
-msgid "The text does not contain any subheadings. Add at least one subheading."
-msgstr ""
 
 #: js/assessments/subheadingsKeywordAssessment.js:14
 msgid ""
@@ -489,6 +484,12 @@ msgstr ""
 msgid "This page has %1$s outbound link(s)."
 msgstr ""
 
+#: js/assessments/textPresenceAssessment.js:18
+msgid ""
+"You have far too little content, please add some content to enable a good "
+"analysis."
+msgstr ""
+
 #: js/assessments/titleKeywordAssessment.js:16
 msgid "The focus keyword '%1$s' does not appear in the SEO title."
 msgstr ""
@@ -546,7 +547,7 @@ msgstr ""
 
 #. Translators: %1$s expands to the number of sentences containing transition words, %2$s expands to a link on yoast.com,
 #. %3$s expands to the anchor end tag, %4$s expands to the recommended value.
-#: js/assessments/transitionWordsAssessment.js:38
+#: js/assessments/transitionWordsAssessment.js:48
 msgid ""
 "%1$s of the sentences contain a %2$stransition word%3$s or phrase, which is "
 "less than the recommended minimum of %4$s."
@@ -554,7 +555,7 @@ msgstr ""
 
 #. Translators: %1$s expands to the number of sentences containing transition words, %2$s expands to a link on yoast.com,
 #. %3$s expands to the anchor end tag.
-#: js/assessments/transitionWordsAssessment.js:51
+#: js/assessments/transitionWordsAssessment.js:61
 msgid ""
 "%1$s of the sentences contain a %2$stransition word%3$s or phrase, which is "
 "great."
@@ -663,12 +664,16 @@ msgstr ""
 msgid "Content Analysis: Good SEO score"
 msgstr ""
 
-#: js/renderers/AssessorPresenter.js:304
+#: js/renderers/AssessorPresenter.js:307
+msgid "Marks are disabled in current view."
+msgstr ""
+
+#: js/renderers/AssessorPresenter.js:308
 msgid "Mark this result in the text"
 msgstr ""
 
-#: js/renderers/AssessorPresenter.js:305
-msgid "Remove all marks from the text"
+#: js/renderers/AssessorPresenter.js:309
+msgid "Remove marks in the text"
 msgstr ""
 
 #: js/snippetPreview.js:362
@@ -696,7 +701,7 @@ msgid "Snippet preview"
 msgstr ""
 
 #: js/snippetPreview.js:368
-msgid "Seo title preview:"
+msgid "SEO title preview:"
 msgstr ""
 
 #: js/snippetPreview.js:369
@@ -712,10 +717,10 @@ msgid ""
 "You can click on each element in the preview to jump to the Snippet Editor."
 msgstr ""
 
-#: js/snippetPreview.js:570
+#: js/snippetPreview.js:565
 msgid "Please provide an SEO title by editing the snippet below."
 msgstr ""
 
-#: js/snippetPreview.js:646
+#: js/snippetPreview.js:641
 msgid "Please provide a meta description by editing the snippet below."
 msgstr ""

--- a/templates/assessmentPresenterResult.jst
+++ b/templates/assessmentPresenterResult.jst
@@ -3,7 +3,7 @@
         <li class="score">
             <span class="assessment-results__mark-container">
                 <% if ( scores[ i ].marker ) { %>
-                    <button type="button"
+                    <button type="button" <% if ( markerButtonsDisabled ) { %> disabled="disabled" <% } %>
                         aria-label="<%= i18n.markInText %>"
                         class="assessment-results__mark <% if ( scores[ i ].identifier === activeMarker ) { %>icon-eye-active<% } else { %>icon-eye-inactive<% } %> js-assessment-results__mark-<%= scores[ i ].identifier %> yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text"><% if ( scores[ i ].identifier === activeMarker ) { %><%= i18n.removeMarksInText %><% } else { %><%= i18n.markInText %><% } %></span></button>
                 <% } %>

--- a/templates/assessmentPresenterResult.jst
+++ b/templates/assessmentPresenterResult.jst
@@ -4,8 +4,22 @@
             <span class="assessment-results__mark-container">
                 <% if ( scores[ i ].marker ) { %>
                     <button type="button" <% if ( markerButtonsDisabled ) { %> disabled="disabled" <% } %>
-                        aria-label="<%= i18n.markInText %>"
-                        class="assessment-results__mark <% if ( scores[ i ].identifier === activeMarker ) { %>icon-eye-active<% } else { %>icon-eye-inactive<% } %> js-assessment-results__mark-<%= scores[ i ].identifier %> yoast-tooltip yoast-tooltip-s"><span class="screen-reader-text"><% if ( scores[ i ].identifier === activeMarker ) { %><%= i18n.removeMarksInText %><% } else { %><%= i18n.markInText %><% } %></span></button>
+                        aria-label="<% if ( markerButtonsDisabled ) { %><%= i18n.disabledMarkText %><% }
+                            else if ( scores[ i ].identifier === activeMarker ) { %><%= i18n.removeMarksInText %><% }
+                            else { %><%= i18n.markInText %><% } %>"
+                        class="assessment-results__mark <%
+                        if ( markerButtonsDisabled ) { %> icon-eye-disabled <% }
+                        else if ( scores[ i ].identifier === activeMarker ) { %>
+                            icon-eye-active
+                        <% }
+                        else { %>
+                            icon-eye-inactive
+                        <% } %>
+                        js-assessment-results__mark-<%= scores[ i ].identifier %> yoast-tooltip yoast-tooltip-s">
+                        <span class="screen-reader-text"><% if ( markerButtonsDisabled ) { %><%= i18n.disabledMarkText %><% }
+                            else if ( scores[ i ].identifier === activeMarker ) { %><%= i18n.removeMarksInText %><% }
+                            else { %><%= i18n.markInText %><% } %>
+                        </span></button>
                 <% } %>
             </span>
             <span class="wpseo-score-icon <%- scores[ i ].className %>"></span>


### PR DESCRIPTION
Fixes https://github.com/Yoast/wordpress-seo/issues/4807
Requires: https://github.com/Yoast/wordpress-seo/pull/4902

Testing:
1. Create a post and write some text so some marker buttons show up.
2. Test if the marker buttons are disabled in text editor and enabled in visual editor.
3. Also test if the marker buttons are disabled when you refresh the page, with the text editor enabled. They also need to re-enable when you again switch to the visual editor.
