### PR TITLE
Increases negative point treshold for contentscore

### DIFF
--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -66,7 +66,7 @@ ContentAssessor.prototype.calculatePenaltyPoints = function () {
 		// Convert the ratings to negative 'points'.
 		switch ( rating ) {
 			case "bad":
-				weight = 3;
+				weight = 4;
 				break;
 
 			case "ok":
@@ -101,7 +101,7 @@ ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
 
 	if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
 		// Determine the total score based on the total negative points.
-		if ( totalPenaltyPoints > 6 ) {
+		if ( totalPenaltyPoints > 8 ) {
 			// A red indicator.
 			return 30;
 		}
@@ -111,7 +111,7 @@ ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
 			return 60;
 		}
 	} else {
-		if ( totalPenaltyPoints > 3 ) {
+		if ( totalPenaltyPoints > 4 ) {
 			// A red indicator.
 			return 30;
 		}

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -81,6 +81,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ text: "A piece of feedback" })
 			];
+			// Total 14. score = 3 gets 4 penalty points, score = 6 gets 2 penaltypoints.
 			var expected = 2 + 4 + 2 + 4 + 2;
 
 			var actual = contentAssessor.calculatePenaltyPoints();

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -51,7 +51,7 @@ describe( "A content assesor", function() {
 			results = [
 				new AssessmentResult({ score: 3 })
 			];
-			var expected = 3;
+			var expected = 4;
 
 			var actual = contentAssessor.calculatePenaltyPoints();
 
@@ -81,7 +81,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ text: "A piece of feedback" })
 			];
-			var expected = 6 + 6;
+			var expected = 2 + 4 + 2 + 4 + 2;
 
 			var actual = contentAssessor.calculatePenaltyPoints();
 
@@ -119,7 +119,8 @@ describe( "A content assesor", function() {
 				new AssessmentResult()
 			];
 			var testCases = [
-				{ points: 7, expected: 30 },
+				{ points: 8.5, expected: 30 },
+				{ points: 7, expected: 60 },
 				{ points: 6, expected: 60 },
 				{ points: 9, expected: 30 },
 				{ points: 4, expected: 90 },


### PR DESCRIPTION
To make sure we don't give too many penalty points when only a few tests are run, this PR increases the treshold a bit on bad scores. 

With 3 scores; 
1 bad score and 1 ok score should result in a red bullet.
1 bad score and 2 good scores should result in an orange bullet.
2 ok scores and a good score should result in an orange bullet.
1 ok score and 2 good scores should result in a green bullet. 

I increased the penalty from a bad score from 3 to 4, and increased the total allowed penaltypoints so with 2 ok scores you have 4 penaltypoints, which scores an orange bullet, in stead of a red bullet. 

For testing: Make sure to test this with a non-english locale