### PR TITLE
Increases negative point treshold for contentscore 

### DIFF
--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -66,7 +66,7 @@ ContentAssessor.prototype.calculatePenaltyPoints = function () {
 		// Convert the ratings to negative 'points'.
 		switch ( rating ) {
 			case "bad":
-				weight = 3;
+				weight = 4;
 				break;
 
 			case "ok":
@@ -101,7 +101,7 @@ ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
 
 	if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
 		// Determine the total score based on the total negative points.
-		if ( totalPenaltyPoints > 6 ) {
+		if ( totalPenaltyPoints > 8 ) {
 			// A red indicator.
 			return 30;
 		}
@@ -111,7 +111,7 @@ ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
 			return 60;
 		}
 	} else {
-		if ( totalPenaltyPoints > 3 ) {
+		if ( totalPenaltyPoints > 4 ) {
 			// A red indicator.
 			return 30;
 		}

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -55,6 +55,7 @@ require( "util" ).inherits( ContentAssessor, Assessor );
 
 /**
  * Calculates the weighted rating for English languages based on a given rating.
+ *
  * @param {number} rating The rating to be weighted.
  * @returns {number} The weighted rating.
  */
@@ -72,6 +73,7 @@ ContentAssessor.prototype.calculateNegativePointsEnglish = function( rating ) {
 
 /**
  * Calculates the weighted rating for non-English languages based on a given rating.
+ *
  * @param {number} rating The rating to be weighted.
  * @returns {number} The weighted rating.
  */

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -96,16 +96,16 @@ ContentAssessor.prototype.calculateNegativePointsNonEnglish = function( rating )
  */
 ContentAssessor.prototype.calculatePenaltyPoints = function () {
 	var results = this.getValidResults();
-	var self = this;
+
 	var negativePoints = map( results, function ( result ) {
 		var rating = scoreToRating( result.getScore() );
 
-		if ( self.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
-			return self.calculateNegativePointsEnglish( rating );
+		if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
+			return this.calculateNegativePointsEnglish( rating );
 		}
 
-		return self.calculateNegativePointsNonEnglish( rating );
-	} );
+		return this.calculateNegativePointsNonEnglish( rating );
+	}.bind( this ) );
 
 	return sum( negativePoints );
 };

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -100,9 +100,9 @@ ContentAssessor.prototype.calculatePenaltyPoints = function () {
 
 		if ( self.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
 			return self.calculateNegativePointsEnglish( rating );
-		} else {
-			return self.calculateNegativePointsNonEnglish( rating );
 		}
+
+		return self.calculateNegativePointsNonEnglish( rating );
 	} );
 
 	return sum( negativePoints );

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -59,7 +59,7 @@ require( "util" ).inherits( ContentAssessor, Assessor );
  * @param {number} rating The rating to be weighted.
  * @returns {number} The weighted rating.
  */
-ContentAssessor.prototype.calculateNegativePointsEnglish = function( rating ) {
+ContentAssessor.prototype.calculatePenaltyPointsEnglish = function( rating ) {
 	switch ( rating ) {
 		case "bad":
 			return 3;
@@ -77,7 +77,7 @@ ContentAssessor.prototype.calculateNegativePointsEnglish = function( rating ) {
  * @param {number} rating The rating to be weighted.
  * @returns {number} The weighted rating.
  */
-ContentAssessor.prototype.calculateNegativePointsNonEnglish = function( rating ) {
+ContentAssessor.prototype.calculatePenaltyPointsNonEnglish = function( rating ) {
 	switch ( rating ) {
 		case "bad":
 			return 4;
@@ -90,31 +90,31 @@ ContentAssessor.prototype.calculateNegativePointsNonEnglish = function( rating )
 };
 
 /**
- * Calculates the negative points based on the assessment results.
+ * Calculates the penalty points based on the assessment results.
  *
- * @returns {number} The total negative points for the results.
+ * @returns {number} The total penalty points for the results.
  */
 ContentAssessor.prototype.calculatePenaltyPoints = function () {
 	var results = this.getValidResults();
 
-	var negativePoints = map( results, function ( result ) {
+	var penaltyPoints = map( results, function ( result ) {
 		var rating = scoreToRating( result.getScore() );
 
 		if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
-			return this.calculateNegativePointsEnglish( rating );
+			return this.calculatePenaltyPointsEnglish( rating );
 		}
 
-		return this.calculateNegativePointsNonEnglish( rating );
+		return this.calculatePenaltyPointsNonEnglish( rating );
 	}.bind( this ) );
 
-	return sum( negativePoints );
+	return sum( penaltyPoints );
 };
 
 /**
- * Rates the negative points
+ * Rates the penalty points
  *
- * @param {number} totalPenaltyPoints The amount of negative points.
- * @returns {number} The score based on the amount of negative points.
+ * @param {number} totalPenaltyPoints The amount of penalty points.
+ * @returns {number} The score based on the amount of penalty points.
  *
  * @private
  */
@@ -125,7 +125,7 @@ ContentAssessor.prototype._ratePenaltyPoints = function ( totalPenaltyPoints ) {
 	}
 
 	if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
-		// Determine the total score based on the total negative points.
+		// Determine the total score based on the total penalty points.
 		if ( totalPenaltyPoints > 6 ) {
 			// A red indicator.
 			return 30;

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -81,6 +81,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ text: "A piece of feedback" })
 			];
+			// Total 14. score = 3 gets 4 penalty points, score = 6 gets 2 penaltypoints.
 			var expected = 2 + 4 + 2 + 4 + 2;
 
 			var actual = contentAssessor.calculatePenaltyPoints();

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -51,7 +51,7 @@ describe( "A content assesor", function() {
 			results = [
 				new AssessmentResult({ score: 3 })
 			];
-			var expected = 3;
+			var expected = 4;
 
 			var actual = contentAssessor.calculatePenaltyPoints();
 
@@ -81,7 +81,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ text: "A piece of feedback" })
 			];
-			var expected = 6 + 6;
+			var expected = 2 + 4 + 2 + 4 + 2;
 
 			var actual = contentAssessor.calculatePenaltyPoints();
 
@@ -119,7 +119,8 @@ describe( "A content assesor", function() {
 				new AssessmentResult()
 			];
 			var testCases = [
-				{ points: 7, expected: 30 },
+				{ points: 8.5, expected: 30 },
+				{ points: 7, expected: 60 },
 				{ points: 6, expected: 60 },
 				{ points: 9, expected: 30 },
 				{ points: 4, expected: 90 },

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -16,11 +16,14 @@ describe( "A content assesor", function() {
 
 	describe( "calculatePenaltyPoints", function() {
 		var results;
-
+		var paper = new Paper();
 		beforeEach( function() {
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
+			contentAssessor.getPaper = function() {
+				return paper;
+			}
 		});
 
 		it( "should have no points for an empty result set", function() {
@@ -51,7 +54,7 @@ describe( "A content assesor", function() {
 			results = [
 				new AssessmentResult({ score: 3 })
 			];
-			var expected = 4;
+			var expected = 3;
 
 			var actual = contentAssessor.calculatePenaltyPoints();
 
@@ -81,8 +84,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ text: "A piece of feedback" })
 			];
-			// Total 14. score = 3 gets 4 penalty points, score = 6 gets 2 penaltypoints.
-			var expected = 2 + 4 + 2 + 4 + 2;
+			var expected = 6 + 6;
 
 			var actual = contentAssessor.calculatePenaltyPoints();
 
@@ -120,8 +122,7 @@ describe( "A content assesor", function() {
 				new AssessmentResult()
 			];
 			var testCases = [
-				{ points: 8.5, expected: 30 },
-				{ points: 7, expected: 60 },
+				{ points: 7, expected: 30 },
 				{ points: 6, expected: 60 },
 				{ points: 9, expected: 30 },
 				{ points: 4, expected: 90 },
@@ -137,6 +138,43 @@ describe( "A content assesor", function() {
 
 				expect( actual ).toBe( testCase.expected );
 			} );
+		});
+
+		describe( "calculateOverallScore for non English", function() {
+			var points, results;
+
+			beforeEach( function() {
+				contentAssessor.getValidResults = function() {
+					return results;
+				};
+				contentAssessor.calculatePenaltyPoints = function() {
+					return points;
+				};
+				contentAssessor.getPaper = function() {
+					return new Paper( "", { locale: "nl_NL" } );
+				}
+			});
+
+			it( "should give worse results based on the negative points", function() {
+				results = [
+					new AssessmentResult(),
+					new AssessmentResult()
+				];
+				var testCases = [
+					{ points: 6, expected: 30 },
+					{ points: 4, expected: 60 },
+					{ points: 3, expected: 60 },
+					{ points: 2, expected: 90 }
+				];
+
+				forEach( testCases, function( testCase ) {
+					points = testCase.points;
+
+					var actual = contentAssessor.calculateOverallScore();
+
+					expect( actual ).toBe( testCase.expected );
+				} );
+			});
 		});
 	});
 });


### PR DESCRIPTION
To make sure we don't give too many penalty points when only a few tests are run, this PR increases the treshold a bit on bad scores. 

With 3 scores; 
1 bad score and 1 ok score should result in a red bullet.
1 bad score and 2 good scores should result in an orange bullet.
2 ok scores and a good score should result in an orange bullet.
1 ok score and 2 good scores should result in a green bullet. 

I increased the penalty from a bad score from 3 to 4, and increased the total allowed penaltypoints so with 2 ok scores you have 4 penaltypoints, which scores an orange bullet, in stead of a red bullet. 

For testing: Make sure to test this with a non-english locale

Fixes #https://github.com/Yoast/wordpress-seo/issues/4957

- update, created a seperate score for non-english, so the english scoring will remain completely unchanged. 