### PR TITLE
Fix sentence beginning assessment. 

### DIFF
--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -9,7 +9,7 @@ var passiveVoice = require( "./assessments/passiveVoiceAssessment.js" );
 // var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
 // var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
 // var sentenceVariation = require( "./assessments/sentenceVariationAssessment.js" );
-// var sentenceBeginnings = require( "./assessments/sentenceBeginningsAssessment.js" );
+var sentenceBeginnings = require( "./assessments/sentenceBeginningsAssessment.js" );
 // var wordComplexity = require( "./assessments/wordComplexityAssessment.js" );
 // var subheadingDistributionTooShort = require( "./assessments/subheadingDistributionTooShortAssessment.js" );
 // var paragraphTooShort = require( "./assessments/paragraphTooShortAssessment.js" );
@@ -40,9 +40,10 @@ var ContentAssessor = function ( i18n, options ) {
 		sentenceLengthInText,
 		transitionWords,
 		passiveVoice,
-		textPresence
+		textPresence,
+		sentenceBeginnings
 		// sentenceVariation,
-		// sentenceBeginnings,
+		//
 		// wordComplexity,
 		// subheadingDistributionTooShort,
 		// paragraphTooShort

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -43,7 +43,6 @@ var ContentAssessor = function ( i18n, options ) {
 		textPresence,
 		sentenceBeginnings
 		// sentenceVariation,
-		//
 		// wordComplexity,
 		// subheadingDistributionTooShort,
 		// paragraphTooShort

--- a/js/language/en/firstWordExceptions.js
+++ b/js/language/en/firstWordExceptions.js
@@ -3,5 +3,5 @@
  * @returns {Array} The array filled with exceptions.
  */
 module.exports = function() {
-	return [ "A", "An", "The", "This", "That", "These", "Those", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten" ];
+	return [ "a", "an", "the", "this", "that", "these", "those", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten" ];
 };

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -6,6 +6,7 @@ var firstWordExceptions = require ( "../language/en/firstWordExceptions.js" )();
 
 var isEmpty = require( "lodash/isEmpty" );
 var forEach = require( "lodash/forEach" );
+
 /**
  * Compares the first word of each sentence with the first word of the following sentence.
  *
@@ -13,8 +14,8 @@ var forEach = require( "lodash/forEach" );
  * @param {string} nextSentenceBeginning The first word of the next sentence.
  * @returns {boolean} Returns true if sentence beginnings match.
  */
-var hasSameBeginWord = function( currentSentenceBeginning, nextSentenceBeginning ) {
-	if( !isEmpty( currentSentenceBeginning ) && currentSentenceBeginning === nextSentenceBeginning ) {
+var startsWithSameWord = function( currentSentenceBeginning, nextSentenceBeginning ) {
+	if ( !isEmpty( currentSentenceBeginning ) && currentSentenceBeginning === nextSentenceBeginning ) {
 		return true;
 	}
 	return false;
@@ -36,7 +37,7 @@ var compareFirstWords = function ( sentenceBeginnings, sentences ) {
 		var nextSentenceBeginning = sentenceBeginnings[ i + 1 ];
 		foundSentences.push( sentences );
 
-		if( hasSameBeginWord( currentSentenceBeginning, nextSentenceBeginning ) ) {
+		if ( startsWithSameWord( currentSentenceBeginning, nextSentenceBeginning ) ) {
 			sameBeginnings++;
 		} else {
 			consecutiveFirstWords.push( { word: currentSentenceBeginning, count: sameBeginnings, sentences: foundSentences } );

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -11,7 +11,7 @@ var firstWordExceptions = require ( "../language/en/firstWordExceptions.js" )();
  * @returns {boolean} Returns true if sentence beginnings match.
  */
 var matchSentenceBeginnings = function( sentenceBeginnings, i ) {
-	if ( sentenceBeginnings[ i ] === sentenceBeginnings[ i + 1 ] ) {
+	if ( sentenceBeginnings[ i ] !== "" && sentenceBeginnings[ i ] === sentenceBeginnings[ i + 1 ] ) {
 		return true;
 	}
 	return false;
@@ -53,7 +53,7 @@ module.exports = function( paper ) {
 		if( words.length === 0 ) {
 			return "";
 		}
-		var firstWord = removeNonWordCharacters( words[ 0 ] );
+		var firstWord = removeNonWordCharacters( words[ 0 ] ).toLocaleLowerCase();
 		if ( firstWordExceptions.indexOf( firstWord ) > -1 ) {
 			firstWord += " " + removeNonWordCharacters( words[ 1 ] );
 		}

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -35,13 +35,14 @@ var compareFirstWords = function ( sentenceBeginnings, sentences ) {
 	forEach( sentenceBeginnings, function( beginning, i ) {
 		var currentSentenceBeginning = beginning;
 		var nextSentenceBeginning = sentenceBeginnings[ i + 1 ];
-		foundSentences.push( sentences );
+		foundSentences.push( sentences[ i ] );
 
 		if ( startsWithSameWord( currentSentenceBeginning, nextSentenceBeginning ) ) {
 			sameBeginnings++;
 		} else {
 			consecutiveFirstWords.push( { word: currentSentenceBeginning, count: sameBeginnings, sentences: foundSentences } );
 			sameBeginnings = 1;
+			foundSentences = [];
 		}
 	} );
 

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -4,14 +4,17 @@ var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 var removeNonWordCharacters = require( "../stringProcessing/removeNonWordCharacters.js" );
 var firstWordExceptions = require ( "../language/en/firstWordExceptions.js" )();
 
+var isEmpty = require( "lodash/isEmpty" );
+var forEach = require( "lodash/forEach" );
 /**
  * Compares the first word of each sentence with the first word of the following sentence.
- * @param {array} sentenceBeginnings The array containing the first word of each sentence.
- * @param {number} i The iterator for the sentenceBeginning array.
+ *
+ * @param {string} currentSentenceBeginning The first word of the current sentence.
+ * @param {string} nextSentenceBeginning The first word of the next sentence.
  * @returns {boolean} Returns true if sentence beginnings match.
  */
-var matchSentenceBeginnings = function( sentenceBeginnings, i ) {
-	if ( sentenceBeginnings[ i ] !== "" && sentenceBeginnings[ i ] === sentenceBeginnings[ i + 1 ] ) {
+var hasSameBeginWord = function( currentSentenceBeginning, nextSentenceBeginning ) {
+	if( !isEmpty( currentSentenceBeginning ) && currentSentenceBeginning === nextSentenceBeginning ) {
 		return true;
 	}
 	return false;
@@ -24,21 +27,24 @@ var matchSentenceBeginnings = function( sentenceBeginnings, i ) {
  * @returns {array} The array containing the objects containing the first words and the corresponding counts.
  */
 var compareFirstWords = function ( sentenceBeginnings, sentences ) {
-	var counts = [];
+	var consecutiveFirstWords = [];
 	var foundSentences = [];
-	var count = 1;
-	for ( var i = 0; i < sentenceBeginnings.length; i++ ) {
-		if ( matchSentenceBeginnings( sentenceBeginnings, i ) ) {
-			foundSentences.push( sentences[ i ] );
-			count++;
+	var sameBeginnings = 1;
+
+	forEach( sentenceBeginnings, function( beginning, i ) {
+		var currentSentenceBeginning = beginning;
+		var nextSentenceBeginning = sentenceBeginnings[ i + 1 ];
+		foundSentences.push( sentences );
+
+		if( hasSameBeginWord( currentSentenceBeginning, nextSentenceBeginning ) ) {
+			sameBeginnings++;
 		} else {
-			foundSentences.push( sentences[ i ] );
-			counts.push( { word: sentenceBeginnings[ i ], count: count, sentences: foundSentences } );
-			foundSentences = [];
-			count = 1;
+			consecutiveFirstWords.push( { word: currentSentenceBeginning, count: sameBeginnings, sentences: foundSentences } );
+			sameBeginnings = 1;
 		}
-	}
-	return counts;
+	} );
+
+	return consecutiveFirstWords;
 };
 
 /**

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -4,37 +4,56 @@ var Paper = require( "../../js/values/Paper.js" );
 describe( "gets the sentence beginnings and the count of consecutive duplicates.", function() {
 	it( "returns an object with sentence beginnings and counts for two sentences starting with different words.", function() {
 		var mockPaper = new Paper( "How are you? Bye!" );
-		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "How" );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "how" );
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 1 );
-		expect( sentenceBeginnings( mockPaper )[1].word ).toBe( "Bye" );
+		expect( sentenceBeginnings( mockPaper )[1].word ).toBe( "bye" );
 		expect( sentenceBeginnings( mockPaper )[1].count ).toBe( 1 );
 	} );
 	it( "returns an object with sentence beginnings and counts for two sentences starting with the same word.", function() {
 		var mockPaper = new Paper( "Hey, hey! Hey." );
-		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "Hey" );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "hey" );
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 2 );
 	} );
 	it( "returns an object with sentence beginnings and counts for four sentences, the first two starting with the same word. The fourth is starting with the same word as the first two. " +
 		"The count for this word should be reset.", function() {
 		var mockPaper = new Paper( "Hey, hey! Hey. Bye. Hey." );
-		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "Hey" );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "hey" );
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 2 );
-		expect( sentenceBeginnings( mockPaper )[1].word ).toBe( "Bye" );
+		expect( sentenceBeginnings( mockPaper )[1].word ).toBe( "bye" );
 		expect( sentenceBeginnings( mockPaper )[1].count ).toBe( 1 );
-		expect( sentenceBeginnings( mockPaper )[2].word ).toBe( "Hey" );
+		expect( sentenceBeginnings( mockPaper )[2].word ).toBe( "hey" );
 		expect( sentenceBeginnings( mockPaper )[2].count ).toBe( 1 );
 	} );
 	it( "returns an object with sentence beginnings and counts for three sentences all starting with one of the exception words.", function() {
 		var mockPaper = new Paper( "The boy, hey! The boy. The boy." );
-		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "The boy" );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "the boy" );
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 3 );
 	} );
 	it( "returns an object with sentence beginnings and counts for three sentences all starting with one of the exception words. The second word of all sentences is also in the list " +
 		"of exception words, which should not matter.", function() {
 		var mockPaper = new Paper( "One, two, three. One, two, three. One, two, three." );
-		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "One two" );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "one two" );
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 3 );
 	} );
+
+	it( "returns an object with sentence beginnings in lists", function() {
+		var mockPaper = new Paper( "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].word ).toBe( "item" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].count ).toBe( 4 );
+	});
+
+	it( "returns an object with sentence beginnings in tables", function() {
+		var mockPaper = new Paper( "<table><td><tr>Sentence 1.</tr><tr>Sentence 2 that is longer.</tr><tr>Sentence 3 is shorter.</tr><tr>Sentence 4.</tr></td></table>" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].word ).toBe( "sentence" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].count ).toBe( 4 );
+	});
+
+	it( "returns an object with sentence beginnings in different capitalizations", function() {
+		var mockPaper = new Paper( "Sentence 1. SENTENCE 2. Sentence 3." );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].word ).toBe( "sentence" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].count ).toBe( 3 );
+	});
+
 	it( "returns an empty string if only enters or whitespaces in a string", function() {
 		var mockPaper = new Paper( "   \n</div>" );
 		expect( sentenceBeginnings( mockPaper ) ).toEqual( [] );

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -48,6 +48,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( sentenceBeginnings( mockPaper )[ 0 ].count ).toBe( 4 );
 	});
 
+	it( "returns an object with sentence beginnings with paragraph tags - it should match over paragraphs", function() {
+		var mockPaper = new Paper( "<p>Sentence 1. Sentence 2.</p><p>Sentence 3.</p>" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].word ).toBe( "sentence" );
+		expect( sentenceBeginnings( mockPaper )[ 0 ].count ).toBe( 3 );
+	});
+
 	it( "returns an object with sentence beginnings in different capitalizations", function() {
 		var mockPaper = new Paper( "Sentence 1. SENTENCE 2. Sentence 3." );
 		expect( sentenceBeginnings( mockPaper )[ 0 ].word ).toBe( "sentence" );


### PR DESCRIPTION
Fixes #727
Fixes #619 

This PR reintroduces the sentence begining assessment and adds enhancements for detection. 
Added tests for matching first sentences with different capitalization and with different tags. 

Now converts all words to lowercase, this makes sure we can match the exception words, regardless of their casing. The converted words are only used for this check, so the markings work like expected. 

For testing:
Test the assessment in the standalone example, and test with different tags to make sure these work.
