### PR TITLE
Reintroduce and improve sentence variation

### DIFF
--- a/js/assessments/sentenceLengthInTextAssessment.js
+++ b/js/assessments/sentenceLengthInTextAssessment.js
@@ -36,7 +36,7 @@ var tooLongSentencesTotal = function( sentences, recommendedValue ) {
 /**
  * Calculates sentence length score.
  *
- * @param {Object} sentences The object containing sentences and its length.
+ * @param {Object} sentences The object containing sentences and their lengths.
  * @param {Object} i18n The object used for translations.
  * @returns {Object} Object containing score and text.
  */
@@ -50,7 +50,7 @@ var calculateSentenceLengthResult = function( sentences, i18n ) {
 	}
 
 	if ( percentage <= 25 ) {
-		// Red indicator.
+		// Green indicator.
 		score = 9;
 	}
 

--- a/js/assessments/sentenceVariationAssessment.js
+++ b/js/assessments/sentenceVariationAssessment.js
@@ -1,5 +1,7 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 
+var getSentences = require( "../stringProcessing/getSentences.js" );
+
 /**
  * Calculates the score based on the given deviation.
  *
@@ -62,9 +64,15 @@ var getStandardDeviationResult = function( standardDeviation, i18n ) {
  */
 var getSentenceVariation = function( paper, researcher, i18n ) {
 	var standardDeviation = researcher.getResearch( "sentenceVariation" );
-	var sentenceDeviationResult =  getStandardDeviationResult( standardDeviation, i18n );
 
+	var numberOfSentences = getSentences( paper.getText() ).length;
 	var assessmentResult = new AssessmentResult();
+
+	if ( numberOfSentences <= 1 ) {
+		return assessmentResult;
+	}
+
+	var sentenceDeviationResult =  getStandardDeviationResult( standardDeviation, i18n );
 
 	assessmentResult.setScore( sentenceDeviationResult.score );
 	assessmentResult.setText( sentenceDeviationResult.text );

--- a/js/assessments/sentenceVariationAssessment.js
+++ b/js/assessments/sentenceVariationAssessment.js
@@ -1,40 +1,48 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 
 var getSentences = require( "../stringProcessing/getSentences.js" );
+var inRange = require( "../helpers/inRange.js" ).inRangeStartInclusive;
 
 /**
- * Calculates the score based on the given deviation.
+ * Get the sentence length variation result based on the score.
  *
- * @param {number} standardDeviation The deviation to calculate the score for.
- * @returns {number} The calculated score.
+ * @param {number} standardDeviation The standard deviation to calculate the score for.
+ * @param {Object} i18n The object used for translations.
+ * @returns {Object} The object containing score and text.
  */
-var calculateScore = function( standardDeviation ) {
-	return 3 + Math.max( Math.min( ( 6 ) * ( standardDeviation - 2.33 ), 6 ), 0 );
-};
 
-/**
- * Get the result based on the score. When score is 7 or more, the result is good. Below 7 should be improved.
- *
- * @param {number} standardDeviation The deviation to calculate the score for.
- * @param {object} i18n The object used for translations.
- * @returns {{score: number, text: *}} The calculated result.
- */
 var getStandardDeviationResult = function( standardDeviation, i18n ) {
-	var score = calculateScore( standardDeviation );
+	var score = 0;
 	var recommendedMinimumDeviation = 3;
 	var sentenceVariationURL = "<a href='https://yoa.st/mix-it-up' target='_blank'>";
+
+	if ( standardDeviation >= 3 ) {
+		// Green indicator.
+		score = 9;
+	}
+
+	if ( inRange( standardDeviation, 2.5, 3 ) ) {
+		// Orange indicator.
+		score = 6;
+	}
+
+	if ( standardDeviation < 2.5 ) {
+		// Red indicator.
+		score = 3;
+	}
+
 	if ( score >= 7 ) {
 		return {
 			score: score,
 			text: i18n.sprintf(
 				i18n.dgettext(
 					"js-text-analysis",
-				// Translators: %1$s expands to a link on yoast.com, %2$s expands to the calculated score,
-				// %3$d expands to the anchor end tag, %4$s expands to the recommended minimum score.
+					// Translators: %1$s expands to a link on yoast.com, %2$s expands to the calculated score,
+					// %3$d expands to the anchor end tag, %4$s expands to the recommended minimum score.
 					"The %1$ssentence length variation%2$s score is %3$s, " +
 					"which is more than or equal to the recommended minimum of %4$d. " +
 					"The text contains a nice combination of long and short sentences."
-				 ), sentenceVariationURL, "</a>", standardDeviation, recommendedMinimumDeviation
+				), sentenceVariationURL, "</a>", standardDeviation, recommendedMinimumDeviation
 			)
 		};
 	}

--- a/js/assessments/sentenceVariationAssessment.js
+++ b/js/assessments/sentenceVariationAssessment.js
@@ -65,13 +65,7 @@ var getStandardDeviationResult = function( standardDeviation, i18n ) {
 var getSentenceVariation = function( paper, researcher, i18n ) {
 	var standardDeviation = researcher.getResearch( "sentenceVariation" );
 
-	var numberOfSentences = getSentences( paper.getText() ).length;
 	var assessmentResult = new AssessmentResult();
-
-	if ( numberOfSentences <= 1 ) {
-		return assessmentResult;
-	}
-
 	var sentenceDeviationResult =  getStandardDeviationResult( standardDeviation, i18n );
 
 	assessmentResult.setScore( sentenceDeviationResult.score );
@@ -84,7 +78,8 @@ module.exports = {
 	identifier: "textSentenceLengthVariation",
 	getResult: getSentenceVariation,
 	isApplicable: function( paper ) {
-		return paper.hasText();
+		var numberOfSentences = getSentences( paper.getText() ).length;
+		return paper.hasText() && numberOfSentences > 1;
 	}
 };
 

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -8,7 +8,7 @@ var transitionWords = require( "./assessments/transitionWordsAssessment.js" );
 var passiveVoice = require( "./assessments/passiveVoiceAssessment.js" );
 // var subHeadingLength = require( "./assessments/getSubheadingLengthAssessment.js" );
 // var getSubheadingPresence = require( "./assessments/subheadingPresenceAssessment.js" );
-// var sentenceVariation = require( "./assessments/sentenceVariationAssessment.js" );
+var sentenceVariation = require( "./assessments/sentenceVariationAssessment.js" );
 // var sentenceBeginnings = require( "./assessments/sentenceBeginningsAssessment.js" );
 // var wordComplexity = require( "./assessments/wordComplexityAssessment.js" );
 // var subheadingDistributionTooShort = require( "./assessments/subheadingDistributionTooShortAssessment.js" );
@@ -41,8 +41,8 @@ var ContentAssessor = function ( i18n, options ) {
 		sentenceLengthInText,
 		transitionWords,
 		passiveVoice,
-		textPresence
-		// sentenceVariation,
+		textPresence,
+		sentenceVariation
 		// sentenceBeginnings,
 		// wordComplexity,
 		// subheadingDistributionTooShort,

--- a/spec/assessments/sentenceVariationSpec.js
+++ b/spec/assessments/sentenceVariationSpec.js
@@ -3,9 +3,12 @@ var Paper = require( "../../js/values/Paper.js" );
 var Factory = require( "../helpers/factory.js" );
 var i18n = Factory.buildJed();
 
-describe( "An assessment for sentence variation", function(){
+describe( "An assessment for sentence variation", function() {
+
+	//Add 2 sentences to the paper, so the assessment will return a valid result.
+	var mockPaper = new Paper( "Sentence. Sentence." );
+
 	it( "returns the score when deviation 4 ", function() {
-		var mockPaper = new Paper();
 		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 4 ), i18n );
 
 		expect( assessment.hasScore()).toBe( true );
@@ -15,7 +18,6 @@ describe( "An assessment for sentence variation", function(){
 	} );
 
 	it( "returns the score when deviation is 2 ", function() {
-		var mockPaper = new Paper();
 		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 2 ), i18n );
 
 		expect( assessment.hasScore()).toBe( true );
@@ -25,7 +27,6 @@ describe( "An assessment for sentence variation", function(){
 	} );
 
 	it( "returns the score when deviation is zero ", function() {
-		var mockPaper = new Paper();
 		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.hasScore()).toBe( true );
@@ -35,7 +36,6 @@ describe( "An assessment for sentence variation", function(){
 	} );
 
 	it( "returns the score when deviation is 20 ", function() {
-		var mockPaper = new Paper();
 		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.hasScore()).toBe( true );
@@ -44,4 +44,9 @@ describe( "An assessment for sentence variation", function(){
 			"which is more than or equal to the recommended minimum of 3. The text contains a nice combination of long and short sentences." );
 	} );
 
+	it( "returns no score when there is only 1 sentence", function() {
+		mockPaper = new Paper( "" );
+		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
+		expect( assessment.hasScore() ).toBe( false );
+	} );
 } );

--- a/spec/assessments/sentenceVariationSpec.js
+++ b/spec/assessments/sentenceVariationSpec.js
@@ -45,7 +45,19 @@ describe( "An assessment for sentence variation", function() {
 	} );
 
 	it( "returns no score when there is only 1 sentence", function() {
-		mockPaper = new Paper( "" );
+		mockPaper = new Paper( "This is one sentence." );
+		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
+		expect( assessment.hasScore() ).toBe( false );
+	} );
+
+	it( "returns no score when there is only HTMLtags ", function() {
+		mockPaper = new Paper( "<iframe src='framesource'>" );
+		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
+		expect( assessment.hasScore() ).toBe( false );
+	} );
+
+	it( "returns no score when there is only HTMLtags and 1 sentence", function() {
+		mockPaper = new Paper( "<iframe src='framesource'> One sentence." );
 		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 		expect( assessment.hasScore() ).toBe( false );
 	} );

--- a/spec/assessments/sentenceVariationSpec.js
+++ b/spec/assessments/sentenceVariationSpec.js
@@ -26,6 +26,33 @@ describe( "An assessment for sentence variation", function() {
 			"which is less than the recommended minimum of 3. Try to alternate more between long and short sentences." );
 	} );
 
+	it( "returns the score when deviation is 2.5 ", function() {
+		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 2.5 ), i18n );
+
+		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual ( "The <a href='https://yoa.st/mix-it-up' target='_blank'>sentence length variation</a> score is 2.5, " +
+			"which is less than the recommended minimum of 3. Try to alternate more between long and short sentences." );
+	} );
+
+	it( "returns the score when deviation is 2.7 ", function() {
+		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 2.7 ), i18n );
+
+		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual ( "The <a href='https://yoa.st/mix-it-up' target='_blank'>sentence length variation</a> score is 2.7, " +
+			"which is less than the recommended minimum of 3. Try to alternate more between long and short sentences." );
+	} );
+
+	it( "returns the score when deviation is 3 ", function() {
+		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 3 ), i18n );
+
+		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual ( "The <a href='https://yoa.st/mix-it-up' target='_blank'>sentence length variation</a> score is 3, " +
+			"which is more than or equal to the recommended minimum of 3. The text contains a nice combination of long and short sentences." );
+	} );
+
 	it( "returns the score when deviation is zero ", function() {
 		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 

--- a/spec/assessments/sentenceVariationSpec.js
+++ b/spec/assessments/sentenceVariationSpec.js
@@ -46,19 +46,16 @@ describe( "An assessment for sentence variation", function() {
 
 	it( "returns no score when there is only 1 sentence", function() {
 		mockPaper = new Paper( "This is one sentence." );
-		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
-		expect( assessment.hasScore() ).toBe( false );
+		expect( sentenceVariationAssessment.isApplicable( mockPaper ) ).toBe( false );
 	} );
 
 	it( "returns no score when there is only HTMLtags ", function() {
 		mockPaper = new Paper( "<iframe src='framesource'>" );
-		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
-		expect( assessment.hasScore() ).toBe( false );
+		expect( sentenceVariationAssessment.isApplicable( mockPaper ) ).toBe( false );
 	} );
 
 	it( "returns no score when there is only HTMLtags and 1 sentence", function() {
 		mockPaper = new Paper( "<iframe src='framesource'> One sentence." );
-		var assessment = sentenceVariationAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
-		expect( assessment.hasScore() ).toBe( false );
+		expect( sentenceVariationAssessment.isApplicable( mockPaper ) ).toBe( false );
 	} );
 } );

--- a/spec/researches/sentenceVariationSpec.js
+++ b/spec/researches/sentenceVariationSpec.js
@@ -2,13 +2,12 @@ var sentenceVariation = require( "../../js/researches/sentenceVariation" );
 var Paper = require( "../../js/values/Paper.js" );
 
 describe( "the sentence length variation research", function() {
-	/*
 	it( "should calculate the standard deviation of a text containing one line", function() {
 		var paper = new Paper( "this is a oneliner." );
 		var result = sentenceVariation( paper );
 		expect( result ).toBe( 0 );
 	} );
-*/
+
 	it( "should calculate the standard deviation of a two liner", function() {
 		var paper = new Paper(
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam suscipit convallis " +
@@ -17,7 +16,7 @@ describe( "the sentence length variation research", function() {
 		var result = sentenceVariation( paper );
 		expect( result ).toBe( 1.4 );
 	} );
-/*
+
 	it( "should calculate the standard deviation short and long sentences", function() {
 		var paper = new Paper(
 			"Lorem. Ipsum dolor sit amet, consectetur adipiscing elit. Nam suscipit convallis urna at " +
@@ -27,7 +26,7 @@ describe( "the sentence length variation research", function() {
 		);
 
 		var result = sentenceVariation( paper );
-		expect( result ).toBe( 3.34 );
+		expect( result ).toBe( 3.3 );
 	} );
 
 	it( "should calculate the standard deviation of a text containing six lines", function() {
@@ -39,6 +38,6 @@ describe( "the sentence length variation research", function() {
 		);
 
 		var result = sentenceVariation( paper );
-		expect( result ).toBe( 2.19 );
-	} );*/
+		expect( result ).toBe( 2.2 );
+	} );
 });


### PR DESCRIPTION
Fixes #729 

Reintroduces the sentence variation assessment. Includes a check if there is 1 sentence or less, it doesn't run the assessment, since a variation on only 1 sentence doesn't make sense. 

@IreneStr can you improve this PR with an updated formula for calculating the score?