### PR TITLE
Change feedback string from keyword density assessment

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -59,7 +59,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		score = 4;
 
 		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is a bit low;" +
+		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is too low;" +
 			" the focus keyword was found %2$d times." );
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );

--- a/spec/assessments/keywordDensitySpec.js
+++ b/spec/assessments/keywordDensitySpec.js
@@ -10,7 +10,7 @@ describe( "An assessment for the keywordDensity", function(){
 		var paper = new Paper( "string without the key", {keyword: "keyword"} );
 		var result = keywordDensityAssessment.getResult( paper, Factory.buildMockResearcher( 0.0 ), i18n );
 		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "The keyword density is 0%, which is a bit low; the focus keyword was found 0 times.");
+		expect( result.getText() ).toBe( "The keyword density is 0%, which is too low; the focus keyword was found 0 times.");
 
 		paper = new Paper( "string with the keyword", {keyword: "keyword"} );
 		result = keywordDensityAssessment.getResult( paper, Factory.buildMockResearcher( 10.0 ), i18n );


### PR DESCRIPTION
Change keyword density feedback string from 
`The keyword density is %1$s, which is a bit low.`
to
`The keyword density is %1$s, which is too low.`

This results in a less sarcastic comment in case of a 0% keyword density.

Fixes #751 