### PR TITLE
Updates strings for text-length

### DIFF
--- a/js/assessments/taxonomyTextLengthAssessment.js
+++ b/js/assessments/taxonomyTextLengthAssessment.js
@@ -99,8 +99,8 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 			) + " " + i18n.dngettext(
 				"js-text-analysis",
 				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is far below the recommended minimum of %2$d word. Increase the word count with content that is relevant for the topic.",
-				"This is far below the recommended minimum of %2$d words. Increase the word count with content that is relevant for the topic.",
+				"This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
+				"This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
 				recommendedMinimum
 			)
 		};

--- a/js/assessments/textLengthAssessment.js
+++ b/js/assessments/textLengthAssessment.js
@@ -97,8 +97,8 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 			) + " " + i18n.dngettext(
 				"js-text-analysis",
 				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is far below the recommended minimum of %2$d word. Increase the word count with content that is relevant for the topic.",
-				"This is far below the recommended minimum of %2$d words. Increase the word count with content that is relevant for the topic.",
+				"This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
+				"This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
 				recommendedMinimum
 			)
 		};

--- a/spec/assessments/taxonomyTextLengthSpec.js
+++ b/spec/assessments/taxonomyTextLengthSpec.js
@@ -10,7 +10,7 @@ describe( "A word count assessment", function(){
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual ( 'The text contains 1 word. This is far below the recommended minimum of 150 words. ' +
-			'Increase the word count with content that is relevant for the topic.' );
+			'Add more content that is relevant for the topic.' );
 	} );
 
 	it( "assesses a low word count", function(){
@@ -19,7 +19,7 @@ describe( "A word count assessment", function(){
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual ( 'The text contains 5 words. This is far below the recommended minimum of 150 words. ' +
-			'Increase the word count with content that is relevant for the topic.' );
+			'Add more content that is relevant for the topic.' );
 	} );
 
 	it( "assesses a medium word count", function(){

--- a/spec/assessments/textLengthSpec.js
+++ b/spec/assessments/textLengthSpec.js
@@ -11,7 +11,7 @@ describe( "A word count assessment", function(){
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual ( 'The text contains 1 word. This is far below the recommended minimum of 300 words. ' +
-			'Increase the word count with content that is relevant for the topic.' );
+			'Add more content that is relevant for the topic.' );
 	} );
 
 	it( "assesses a low word count", function(){
@@ -20,7 +20,7 @@ describe( "A word count assessment", function(){
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual ( 'The text contains 5 words. This is far below the recommended minimum of 300 words. ' +
-			'Increase the word count with content that is relevant for the topic.' );
+			'Add more content that is relevant for the topic.' );
 	} );
 
 	it( "assesses a medium word count", function(){


### PR DESCRIPTION
Fixes #714 

This changes the text used in the text lenght and taxonomy length assessments. Now we use 'Add more content that is relevant for this topic' in every feedback string to make it uniform and consistent. 
Increasing the word count isn't what we want the user to do, we want them to add more content. 

For testing: Create a text with a few words ( < 100 ) and check the feedback. 