### PR TITLE
Adapt transition word assessment for French and Spanish.

### DIFF
--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -108,7 +108,7 @@ module.exports = {
 	getResult: transitionWordsAssessment,
 	isApplicable: function( paper ) {
 		var locale = getLanguage( paper.getLocale() );
-		var validLocale = locale === "en" || locale === "de";
+		var validLocale = locale === "en" || locale === "de" || locale === "es" || locale === "fr";
 		return ( validLocale && paper.hasText() );
 	},
 	getMarks: transitionWordsMarker

--- a/js/helpers/getTransitionWords.js
+++ b/js/helpers/getTransitionWords.js
@@ -2,6 +2,10 @@ var transitionWordsEnglish = require( "../researches/english/transitionWords.js"
 var twoPartTransitionWordsEnglish = require( "../researches/english/twoPartTransitionWords.js" );
 var transitionWordsGerman = require( "../researches/german/transitionWords.js" );
 var twoPartTransitionWordsGerman = require( "../researches/german/twoPartTransitionWords.js" );
+var transitionWordsFrench = require( "../researches/french/transitionWords.js" );
+var twoPartTransitionWordsFrench = require( "../researches/french/twoPartTransitionWords.js" );
+var transitionWordsSpanish = require( "../researches/spanish/transitionWords.js" );
+var twoPartTransitionWordsSpanish = require( "../researches/spanish/twoPartTransitionWords.js" );
 
 var getLanguage = require( "./getLanguage.js" );
 
@@ -11,6 +15,16 @@ module.exports = function( locale ) {
 			return {
 				transitionWords: transitionWordsGerman,
 				twoPartTransitionWords: twoPartTransitionWordsGerman
+			};
+		case "es":
+			return {
+				transitionWords: transitionWordsSpanish,
+				twoPartTransitionWords: twoPartTransitionWordsSpanish
+			};
+		case "fr":
+			return {
+				transitionWords: transitionWordsFrench,
+				twoPartTransitionWords: twoPartTransitionWordsFrench
 			};
 		default:
 		case "en":

--- a/js/researches/english/twoPartTransitionWords.js
+++ b/js/researches/english/twoPartTransitionWords.js
@@ -8,4 +8,3 @@ module.exports = function() {
 	return [ [ "both", "and" ], [ "if", "then" ], [ "not only", "but also" ], [ "neither", "nor" ], [ "either", "or" ], [ "not", "but" ],
 		[ "whether", "or" ], [ "no sooner", "than" ] ];
 };
-

--- a/js/researches/french/transitionWords.js
+++ b/js/researches/french/transitionWords.js
@@ -40,4 +40,3 @@ module.exports = function() {
 		"tellement que", "tout bien pesé", "tout compte fait", "tout d'abord", "tout de même", "toutefois", "troisièmement", "vu que"
 	];
 };
-

--- a/js/researches/french/transitionWords.js
+++ b/js/researches/french/transitionWords.js
@@ -1,0 +1,43 @@
+/** @module config/transitionWords */
+
+/**
+ * Returns an array with transition words to be used by the assessments.
+ * @returns {Array} The array filled with transition words.
+ */
+module.exports = function() {
+	return [ 
+		"à cause de", "à ce propos", "à ce sujet", "à condition que", "à l'encontre de", "à l'image de", "à l'inverse",
+		"à l'inverse de", "à mesure que", "à moins que", "à première vue", "à savoir", "à seule fin que", "à supposer que",
+		"à vrai dire", "afin que", "ainsi", "ainsi donc", "ainsi que", "alors", "alors que", "apès réflexion", "après cela",
+		"après que", "après réflexion", "après tout", "attendu que", "au cas où", "au contraire", "au fur et à mesure que",
+		"au lieu de", "au même temps", "au moment où", "au point que", "aussi", "aussi bien que", "aussitôt que", "autant que",
+		"autrement dit", "avant que", "avant tout", "ayant fini", "bien que", "c'est à dire que", "c'est ainsi que",
+		"c'est le cas de", "c'est pourquoi", "c'est qu'en effet", "c'est-à-dire", "ça confirme que", "ça montre que",
+		"ça prouve que", "car", "cela dit", "cela étant", "cependant", "cependant que", "comme l'illustre", "comme le souligne",
+		"comme quoi", "comme si", "conséquemment", "contrairement à", "d'abord", "d'ailleurs", "d'après", "d'autant plus que",
+		"d'autant que", "d'autre part", "d'ici là", "d'un autre côté", "d'un côté", "d'une facon générale ''", "dans ce cas",
+		"dans ces conditions", "dans l'ensemble", "dans l'hypothèse où", "dans la mesure où", "dans le cadre de",
+		"dans le cas où", "dans un autre ordre d'idée", "de crainte que", "de façon à ce que", "de façon que", "de fait",
+		"de l'autre côté", "de la même façon que", "de manière que", "de même", "de même qua", "de même que", "de peur que",
+		"de prime abord", "de sorte que", "de surcroît", "de telle manière que", "de telle sorte que", "de toute façon",
+		"depuis que", "dès lors que", "dès qua", "dès que", "désormais", "deuxièmement", "donc", "dorénavant", "du fait que",
+		"du moment que", "du point de vue de", "du reste", "effectivement", "également", "en admettant que", "en attendant que",
+		"en bref", "en cas que", "en ce domaine", "en cela", "en concequence", "en conclusion", "en conséquence",
+		"en d'autres termes", "en définitive", "en dépit de", "en dernier lieu", "en deuxième lieu", "en effet", "en face de",
+		"en fait", "en fin de compte", "en général", "en guise de conclusion", "en même temps que", "en outre", "en particulier",
+		"en plus", "en premier lieu", "en raison de", "en réalité", "en règle générale", "en résumé", "en revanche", "en second lieu",
+		"en somme", "en sorte que", "en supposant que", "en tant que", "en tout cas", "en troisième lieu", "en un mot", "en vue que",
+		"encore que", "enfin", "ensuite", "entre autres", "et puis", "étant donné qua", "étant donné que", "face à", "finalement",
+		"globalement", "grâce à", "il faut dire aussi que", "jusqu'à ce que", "la preuve c'est que", "la-dessus", "loin que", "lorsque",
+		"mais", "malgré", "malgré cela", "malgré tout", "même si", "mis à part le fait que", "néanmoins", "notamment", "nul doute que",
+		"ou bien", "où que", "par ailleurs", "par conséquent", "par contre", "par example", "par exemple", "par la suite",
+		"par rapport à", "par suite", "par suite de", "parce que", "pareillement", "partant", "partant de ce fait", "pas du tout",
+		"pendant que", "pour ainsi dire", "pour ces raisons", "pour cette raison", "pour conclure", "pour peu que", "pour que", "pour résumé",
+		"pourtant", "pourvu que", "premièrement", "probablement", "puis", "puisque", "pur toutes ces raisons", "quand bien même que",
+		"quand même", "quant à", "quant même", "quel que soit", "qui que", "quoi qu'il en soit", "quoi que", "quoiqu'il en soit",
+		"quoique", "sans doute", "selon", "selon que", "semblablement", "si bien que", "si ce n'est que", "sinon", "sitôt que",
+		"somme toute", "sous prétexte que", "suivant", "suivant que", "supposé que", "tandis que", "tant et si bien que", "tant que",
+		"tellement que", "tout bien pesé", "tout compte fait", "tout d'abord", "tout de même", "toutefois", "troisièmement", "vu que" 
+	];
+};
+

--- a/js/researches/french/transitionWords.js
+++ b/js/researches/french/transitionWords.js
@@ -5,7 +5,7 @@
  * @returns {Array} The array filled with transition words.
  */
 module.exports = function() {
-	return [ 
+	return [
 		"à cause de", "à ce propos", "à ce sujet", "à condition que", "à l'encontre de", "à l'image de", "à l'inverse",
 		"à l'inverse de", "à mesure que", "à moins que", "à première vue", "à savoir", "à seule fin que", "à supposer que",
 		"à vrai dire", "afin que", "ainsi", "ainsi donc", "ainsi que", "alors", "alors que", "apès réflexion", "après cela",
@@ -37,7 +37,7 @@ module.exports = function() {
 		"quand même", "quant à", "quant même", "quel que soit", "qui que", "quoi qu'il en soit", "quoi que", "quoiqu'il en soit",
 		"quoique", "sans doute", "selon", "selon que", "semblablement", "si bien que", "si ce n'est que", "sinon", "sitôt que",
 		"somme toute", "sous prétexte que", "suivant", "suivant que", "supposé que", "tandis que", "tant et si bien que", "tant que",
-		"tellement que", "tout bien pesé", "tout compte fait", "tout d'abord", "tout de même", "toutefois", "troisièmement", "vu que" 
+		"tellement que", "tout bien pesé", "tout compte fait", "tout d'abord", "tout de même", "toutefois", "troisièmement", "vu que"
 	];
 };
 

--- a/js/researches/french/twoPartTransitionWords.js
+++ b/js/researches/french/twoPartTransitionWords.js
@@ -1,0 +1,16 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @returns {Array} The array filled with two-part transition words.
+ */
+module.exports = function() {
+	return [
+		[ "à première vue", "mais à bien considérer les choses" ], [ "à première vue", "mais toute réflexion faite" ], 
+		[ "aussi", "que" ], [ "certes", "mais" ], [ "d'un côté", "de l'autre côté" ], [ "d'un côté", "de l'autre" ], 
+		[ "d'une part", "d'autre part" ], [ "d'une parte", "de l'autre parte" ], [ "non seulement", "mais aussi" ], 
+		[ "non seulement", "mais en outre" ], [ "non seulement", "mais encore" ], [ "quelque", "que" ], [ "si", "que" ], 
+		[ "soit", "soit" ], [ "tantôt", "tantôt" ], [ "tout d'abord", "ensuite" ], [ "tout", "que" ]
+	];
+};
+

--- a/js/researches/french/twoPartTransitionWords.js
+++ b/js/researches/french/twoPartTransitionWords.js
@@ -6,10 +6,10 @@
  */
 module.exports = function() {
 	return [
-		[ "à première vue", "mais à bien considérer les choses" ], [ "à première vue", "mais toute réflexion faite" ], 
-		[ "aussi", "que" ], [ "certes", "mais" ], [ "d'un côté", "de l'autre côté" ], [ "d'un côté", "de l'autre" ], 
-		[ "d'une part", "d'autre part" ], [ "d'une parte", "de l'autre parte" ], [ "non seulement", "mais aussi" ], 
-		[ "non seulement", "mais en outre" ], [ "non seulement", "mais encore" ], [ "quelque", "que" ], [ "si", "que" ], 
+		[ "à première vue", "mais à bien considérer les choses" ], [ "à première vue", "mais toute réflexion faite" ],
+		[ "aussi", "que" ], [ "certes", "mais" ], [ "d'un côté", "de l'autre côté" ], [ "d'un côté", "de l'autre" ],
+		[ "d'une part", "d'autre part" ], [ "d'une parte", "de l'autre parte" ], [ "non seulement", "mais aussi" ],
+		[ "non seulement", "mais en outre" ], [ "non seulement", "mais encore" ], [ "quelque", "que" ], [ "si", "que" ],
 		[ "soit", "soit" ], [ "tantôt", "tantôt" ], [ "tout d'abord", "ensuite" ], [ "tout", "que" ]
 	];
 };

--- a/js/researches/french/twoPartTransitionWords.js
+++ b/js/researches/french/twoPartTransitionWords.js
@@ -13,4 +13,3 @@ module.exports = function() {
 		[ "soit", "soit" ], [ "tantôt", "tantôt" ], [ "tout d'abord", "ensuite" ], [ "tout", "que" ]
 	];
 };
-

--- a/js/researches/german/transitionWords.js
+++ b/js/researches/german/transitionWords.js
@@ -28,4 +28,3 @@ module.exports = function() {
 		"wennschon", "wennzwar", "weshalb", "widrigenfalls", "wiewohl", "wohingegen", "zudem", "zuerst",
 		"zufolge", "zuletzt", "zum beispiel", "zumal", "zuvor", "zwar", "zweitens" ];
 };
-

--- a/js/researches/german/twoPartTransitionWords.js
+++ b/js/researches/german/twoPartTransitionWords.js
@@ -11,4 +11,3 @@ module.exports = function() {
 		[ "sowohl", "wie auch" ], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ], [ "wenn", "auch" ],
 		[ "wenn", "schon" ], [ "nicht weil", "sondern" ]  ];
 };
-

--- a/js/researches/spanish/transitionWords.js
+++ b/js/researches/spanish/transitionWords.js
@@ -36,4 +36,3 @@ module.exports = function() {
 		"sino", "sobre todo", "supongamos", "supuesto que", "tal como", "también", "tan pronto como", "tanto como", "tercero",
 		"una vez", "verbigracia", "vice-versa", "ya", "ya que" ];
 };
-

--- a/js/researches/spanish/transitionWords.js
+++ b/js/researches/spanish/transitionWords.js
@@ -1,0 +1,39 @@
+/** @module config/transitionWords */
+
+/**
+ * Returns an array with transition words to be used by the assessments.
+ * @returns {Array} The array filled with transition words.
+ */
+module.exports = function() {
+	return [ "a causa de", "a continuación", "a diferencia de", "a la inversa", "a la misma vez", "a más de", "a más de esto",
+		"a menos que", "a pesar de", "a pesar de eso", "a pesar de todo", "a peser de", "a propósito", "a saber", "a todo esto",
+		"además", "adicional", "al contrario", "al fin y al cabo", "al final", "al inicio", "al mismo tiempo", "al principio",
+		"ante todo", "antes de", "aparte de", "as asií como", "así", "así como", "así mismo", "así que", "asimismo", "aún así",
+		"aunque", "ciertamente", "claro está que", "claro que", "claro que sí", "como", "como caso típico", "como era de esperarse",
+		"como es de esperarse", "como muestra", "como resultado", "como se ha notado", "como sigue", "comparado con", "con que",
+		"con relación a", "con todo", "conque", "cuando", "dado que", "de ahí", "de cierta manera", "de cualquier manera",
+		"de cualquier modo", "de este modo", "de golpe", "de hecho", "de igual manera", "de igual modo", "de igualmanera",
+		"de la manera siguente", "de la misma forma", "de la misma manera", "de manera semejante", "de mismo modo", "de modo que",
+		"de nuevo", "de otra manera", "de otro modo", "de qualquier manera", "de repente", "de todas formas", "de todas maneras",
+		"de todos modos", "de veras", "debido a", "debido a que", "decididamente", "decisivamente", "del mismo modo",
+		"dentro de poco", "desde entonces", "después", "después de", "después de todo", "diferentemente", "dúbitamente",
+		"efectivamente", "ejemplo de esto", "en cambio", "en cierto modo", "en comparación con", "en conclusión", "en concreto",
+		"en conformidad con", "en consecuencia", "en consiguiente", "en contraste con", "en cuanto", "en cuanto a", "en efecto",
+		"en fin", "en fin de cuentas", "en general", "en lugar de", "en otras palabras", "en particular", "en primer lugar",
+		"en primer término", "en primera instancia", "en realidad", "en relación a", "en relación con", "en representación de",
+		"en resumen", "en segundo lugar", "en síntesis", "en suma", "en todo caso", "en último término", "en verdad", "en vez de",
+		"entonces", "entre ellas figura", "entre ellos figura", "es decir", "es más", "especialmente", "específicamente",
+		"esto indica", "eventualmente", "finalmente", "frecuentemente", "generalmente", "generalmente por ejemplo",
+		"hasta cierto punto", "hay que añadir", "igual que", "igualmente", "la mayor parte del tiempo", "la mayoría del tiempo",
+		"lo que es peor", "lógicamente", "luego", "más tarde", "mientras", "mientras tanto", "mirándolo todo", "no faltaría más",
+		"no obstante", "o sea", "otra vez", "otro aspecto", "par ilustrar", "par terminar", "para concluir", "para conclusión",
+		"para continuar", "para empezar", "para mencionar una cosa", "para que", "para resumir", "pero", "por", "por añadidura",
+		"por consiguiente", "por ejemplo", "por el contrario", "por eso", "por esta razón", "por esto", "por fin", "por la mayor parte",
+		"por lo general", "por lo tanto", "por orto lado", "por otra parte", "por otro lado", "por supuesto", "por tanto",
+		"por último", "por un lado", "por una parte", "porque", "posteriormente", "primero", "primero que nada", "principalmente",
+		"pronto", "próximamente", "pues bien", "puesto que", "rara vez", "raramente", "realmente", "resulta que", "seguidamente",
+		"seguidamente entre tanto", "segundo", "semejantemente", "siempre que", "sigue que", "siguiente", "sin duda", "sin embargo",
+		"sino", "sobre todo", "supongamos", "supuesto que", "tal como", "también", "tan pronto como", "tanto como", "tercero",
+		"una vez", "verbigracia", "vice-versa", "ya", "ya que" ];
+};
+

--- a/js/researches/spanish/twoPartTransitionWords.js
+++ b/js/researches/spanish/twoPartTransitionWords.js
@@ -5,6 +5,6 @@
  * @returns {Array} The array filled with two-part transition words.
  */
 module.exports = function() {
-	return [ [ "de un lado", "de otra parte" ], [ "de un lado", "de otro" ], [ "no", "sino que" ], [ "no", "sino" ], [ "por un lado", "por otro lado" ],
-		[ "por una parte", "por otra parte" ], [ "por una parte", "por otra" ], [ "tanto", "como" ] ];
+	return [ [ "de un lado", "de otra parte" ], [ "de un lado", "de otro" ], [ "no", "sino que" ], [ "no", "sino" ],
+		[ "por un lado", "por otro lado" ], [ "por una parte", "por otra parte" ], [ "por una parte", "por otra" ], [ "tanto", "como" ] ];
 };

--- a/js/researches/spanish/twoPartTransitionWords.js
+++ b/js/researches/spanish/twoPartTransitionWords.js
@@ -5,7 +5,6 @@
  * @returns {Array} The array filled with two-part transition words.
  */
 module.exports = function() {
-	return [ [ "de un lado", "de otro" ], [ "no", "sino que" ], [ "no", "sino" ], [ "por un lado", "por otro lado" ],
+	return [ [ "de un lado", "de otra parte" ], [ "de un lado", "de otro" ], [ "no", "sino que" ], [ "no", "sino" ], [ "por un lado", "por otro lado" ],
 		[ "por una parte", "por otra parte" ], [ "por una parte", "por otra" ], [ "tanto", "como" ] ];
 };
-

--- a/js/researches/spanish/twoPartTransitionWords.js
+++ b/js/researches/spanish/twoPartTransitionWords.js
@@ -1,0 +1,11 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @returns {Array} The array filled with two-part transition words.
+ */
+module.exports = function() {
+	return [ [ "de un lado", "de otro" ], [ "no", "sino que" ], [ "no", "sino" ], [ "por un lado", "por otro lado" ],
+		[ "por una parte", "por otra parte" ], [ "por una parte", "por otra" ], [ "tanto", "como" ] ];
+};
+

--- a/spec/researches/transitionWordsSpec.js
+++ b/spec/researches/transitionWordsSpec.js
@@ -4,119 +4,155 @@ var Paper = require( "../../js/values/Paper.js" );
 describe("a test for finding transition words from a string", function() {
 
 	it("returns 1 when a transition word is found in the middle of a sentence (English)", function () {
+		// Transition word: above all.
 		mockPaper = new Paper("this story is, above all, about a boy", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a transition word with capital is found at the beginning of a sentence (English)", function () {
+		// Transition word: firstly.
 		mockPaper = new Paper("Firstly, I'd like to say", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a transition word combination is found in the middle of a sentence (English)", function () {
+		// Transition word: different from.
 		mockPaper = new Paper("that is different from something else", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a transition word combination is found at the end of a sentence (English)", function () {
+		// Transition word: for example.
 		mockPaper = new Paper("A story, for example", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a two-part transition word  is found in a sentence (English)", function () {
+		// Transition word: either...or.
 		mockPaper = new Paper("I will either tell you a story, or read you a novel.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a two-part transition word  is found in a sentence, and no transition word in another sentence. (English)", function () {
+		// Transition word: either...or.
 		mockPaper = new Paper("I will either tell you a story, or read you a novel. Okay?", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 2 when a two-part transition word  is found in a sentence, and a transition word in another sentence. (English)", function () {
+		// Transition words: either...or, unless.
 		mockPaper = new Paper("I will either tell you a story, or read you a novel. Unless it is about a boy.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(2);
 	});
+
 	it("returns 2 when a two-part transition word is found in two sentences. (English)", function () {
+		// Transition words: either...or, if...then.
 		mockPaper = new Paper("I will either tell you a story, or read you a novel. If you want, then I will.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(2);
 	});
-	it("returns 2 when a two-part transition word is found in two sentences, and an addition transition word is found in one of them. (English)", function () {
-		mockPaper = new Paper("I will either tell you a story about a boy, or read you a novel. If you want, then I will.", { locale: 'en_US'} );
+
+	it("returns 2 when a two-part transition word is found in two sentences, and an additional transition word is found in one of them. (English)", function () {
+		// Transition words: either...or, if ...then, as soon as.
+		mockPaper = new Paper("I will either tell you a story about a boy, or read you a novel. If you want, then I will start as soon as you're ready.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(2);
 	});
+
 	it("returns 1 when a transition word abbreviation found in a sentence (English)", function () {
+		// Transition word: e.g..
 		mockPaper = new Paper("That is e.g. a story...", { locale: 'en_US'} );
 		 result = transitionWordsResearch(mockPaper);
 		 expect(result.totalSentences).toBe(1);
 		 expect(result.transitionWordSentences).toBe(1);
 	 });
+
 	it("returns 1 when 2 transition words are found in the same sentence (English)", function () {
+		// Transition words: firstly, for example.
 		mockPaper = new Paper("Firstly, I'd like to tell a story, for example", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 2 when 2 transition words are found in two sentences (1 transition word each) (English)", function () {
+		// Transition words: firstly, for example.
 		mockPaper = new Paper("Firstly, I'd like to tell a story. For example.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(2);
 	});
+
 	it("returns 2 in the case of a sentence with 1 transition word and a sentence with 2 transition words) (English)", function () {
-		mockPaper = new Paper("Firstly, I'd like to tell a story. For example, about you.", { locale: 'en_US'} );
+		// Transition words: firstly, for example, as I have said.
+		mockPaper = new Paper("Firstly, I'd like to tell a story. For example, about you, as I have said.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(2);
 	});
+
 	it("returns 1 in the case of a sentence with 1 transition word and a sentence without transition words) (English)", function () {
+		// Transition word: firstly.
 		mockPaper = new Paper("Firstly, I'd like to tell a story. Haha.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(2);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a two-part transition word  is found in a sentence (English)", function () {
+		// Transition word: either...or.
 		mockPaper = new Paper("I will either tell you a story, or read you a novel.", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 0 when no transition words are present in a sentence (English)", function () {
 		mockPaper = new Paper("nothing special", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(0);
 	});
+
 	it("returns 0 when no transition words are present in multiple sentences (English)", function () {
 		mockPaper = new Paper("nothing special. Nothing special Either. Boring!", { locale: 'en_US'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(3);
 		expect(result.transitionWordSentences).toBe(0);
 	});
+
 	it("returns 1 when a transition word is found in a sentence (German)", function () {
+		// Transition word: zuerst.
 		mockPaper = new Paper("Zuerst werde ich versuchen zu verstehen, warum er so denkt.", { locale: 'de_DE'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a two-part transition word is found in a sentence (German)", function () {
+		// Transition word: nicht nur...sondern.
 		mockPaper = new Paper("Man soll nicht nur in seinen Liebesbeziehungen, sondern in sämtlichen Lebensbereichen um das Glück kämpfen.", { locale: 'de_DE'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 0 when no transition words are present in a sentence (German)", function () {
 		mockPaper = new Paper("Eins, zwei, drei.", { locale: 'de_DE'} );
 		result = transitionWordsResearch(mockPaper);
@@ -125,23 +161,29 @@ describe("a test for finding transition words from a string", function() {
 	});
 
 	it("returns 1 when a transition word is found in a sentence (French)", function () {
+		// Transition word: deuxièmement.
 		mockPaper = new Paper("Deuxièmement, il convient de reconnaître la complexité des tâches à entreprendre.", { locale: 'fr_FR'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 1 when a two-part transition word is found in a sentence (French)", function () {
+		// Transition word: non seulement, mais encore. 
 		mockPaper = new Paper("Non seulement on l’estime, mais encore on l’aime.", { locale: 'fr_FR'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
-	it("returns 1 when a transition word with an apostroph is found in a sentence (French)", function () {
+
+	it("returns 1 when a transition word with an apostrophe is found in a sentence (French)", function () {
+		// Transition word: quoi qu’il en soit.
 		mockPaper = new Paper("Quoi qu’il en soit, le gouvernement du Mali a perdu sa légitimité.", { locale: 'fr_FR'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("returns 0 when no transition words are present in a sentence (French)", function () {
 		mockPaper = new Paper("Une, deux, trois.", { locale: 'fr_FR'} );
 		result = transitionWordsResearch(mockPaper);
@@ -149,19 +191,39 @@ describe("a test for finding transition words from a string", function() {
 		expect(result.transitionWordSentences).toBe(0);
 	});
 
-	it("returns a result based on the default English locale in case of a bogus locale", function () {
-		mockPaper = new Paper("A bogus locale.", { locale: 'xx_YY'} );
+	it("returns 1 when a transition word is found in a sentence (Spanish)", function () {
+		// Transition word: pr el contrario.
+		mockPaper = new Paper("Por el contrario, desea que se inicien cambios beneficiosos en Europa.", { locale: 'es_ES'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+
+	it("returns 1 when a two-part transition word is found in a sentence (Spanish)", function () {
+		// Transition word: de un lado...de otra parte.
+		mockPaper = new Paper("Se trata además, de una restauración que ha pretendido de un lado ser reversible y que de otra parte ha intentado minimizar al máximo el impacto material.", { locale: 'es_ES'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+
+	it("returns 0 when no transition words are present in a sentence (Spanish)", function () {
+		mockPaper = new Paper("Uno, dos, tres.", { locale: 'es_ES'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(0);
 	});
+
 	it("defaults to English in case of a bogus locale", function () {
+		// Transition word: because.
 		mockPaper = new Paper("Because of a bogus locale.", { locale: 'xx_YY'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(1);
 	});
+
 	it("defaults to English in case of a bogus locale", function () {
+		// Transition word: none in English (but zuerst is a German transition word).
 		mockPaper = new Paper("Zuerst eine bogus locale.", { locale: 'xx_YY'} );
 		result = transitionWordsResearch(mockPaper);
 		expect(result.totalSentences).toBe(1);
@@ -169,6 +231,7 @@ describe("a test for finding transition words from a string", function() {
 	});
 
 	it( "works with normalizes quotes", function() {
+		// Transition word: what’s more.
 		mockPaper = new Paper( "what’s more", {} );
 		result = transitionWordsResearch( mockPaper );
 
@@ -185,6 +248,7 @@ describe("a test for finding transition words from a string", function() {
 	});
 
 	it( "works with the no-break space character", function() {
+		// Transition word: then.
 		mockPaper = new Paper( "and\u00a0then" );
 		var expected = {
 			totalSentences: 1,

--- a/spec/researches/transitionWordsSpec.js
+++ b/spec/researches/transitionWordsSpec.js
@@ -123,6 +123,32 @@ describe("a test for finding transition words from a string", function() {
 		expect(result.totalSentences).toBe(1);
 		expect(result.transitionWordSentences).toBe(0);
 	});
+
+	it("returns 1 when a transition word is found in a sentence (French)", function () {
+		mockPaper = new Paper("Deuxièmement, il convient de reconnaître la complexité des tâches à entreprendre.", { locale: 'fr_FR'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+	it("returns 1 when a two-part transition word is found in a sentence (French)", function () {
+		mockPaper = new Paper("Non seulement on l’estime, mais encore on l’aime.", { locale: 'fr_FR'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+	it("returns 1 when a transition word with an apostroph is found in a sentence (French)", function () {
+		mockPaper = new Paper("Quoi qu’il en soit, le gouvernement du Mali a perdu sa légitimité.", { locale: 'fr_FR'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+	it("returns 0 when no transition words are present in a sentence (French)", function () {
+		mockPaper = new Paper("Une, deux, trois.", { locale: 'fr_FR'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(0);
+	});
+
 	it("returns a result based on the default English locale in case of a bogus locale", function () {
 		mockPaper = new Paper("A bogus locale.", { locale: 'xx_YY'} );
 		result = transitionWordsResearch(mockPaper);


### PR DESCRIPTION
Adapts transition word assessment for French and Spanish.

Fixes #762 

For testing: change locale to es_ES and fr_FR. Write sentences with and without one-part and two-part transition words. 

Examples French:
- one-part: en général, cela dit, en somme.
- two-part: tantôt...tantôt, si...que.

Examples Spanish: 
- one-part: en primera instancia, a pesar de eso, tal como.
- two-part: de un lado...de otro, no...sino que.