### PR TITLE
Strip numbers before counting in flesch reading

### DIFF
--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -20,6 +20,8 @@ module.exports = function( paper ) {
 		return 0;
 	}
 
+	text = stripNumbers( text );
+
 	var numberOfSentences = countSentences( text );
 
 	var numberOfWords = countWords( text );
@@ -29,7 +31,6 @@ module.exports = function( paper ) {
 		return 0;
 	}
 
-	text = stripNumbers( text );
 	var numberOfSyllables = countSyllables( text );
 
 	var score = 206.835 - ( 1.015 * ( numberOfWords / numberOfSentences ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );

--- a/spec/researches/fleschReadingSpec.js
+++ b/spec/researches/fleschReadingSpec.js
@@ -14,3 +14,10 @@ describe("a test to calculate the fleschReading score", function(){
 		expect( fleschFunction( mockPaper ) ).toBe( 0 );
 	});
 });
+describe( "A test to check the filtere of digits", function() {
+	var mockPaper = new Paper( "A text string to test with digits");
+	var mockPaperWithDigits = new Paper( "A 456 text string to test with 123 digits");
+	it( "should return the same for a text string with only extra digits", function(){
+		expect( fleschFunction( mockPaper ) ).toBe( fleschFunction( mockPaperWithDigits ) );
+	});
+});


### PR DESCRIPTION
We stripped the numbers after counting the number of words. Since we don't want to include them in the FleschReading at all, it makes more sense to remove them before counting the words. 

Fixes #741