### PR TITLE
Includes ¿ and ¡ to tokenizer

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -83,7 +83,7 @@ function isBreakTag( htmlTag ) {
 /**
  * Returns whether or not a given character is quotation mark.
  *
- * @param {string} character character The character to check.
+ * @param {string} character The character to check.
  * @returns {boolean} Whether or not the given character is a quotation mark.
  */
 function isQuotation( character ) {
@@ -91,6 +91,18 @@ function isQuotation( character ) {
 
 	return "'" === character
 		|| "\"" === character;
+}
+
+/**
+ * Returns whether or not a given character is a punctuation mark that can be at the beginning
+ * of a sentence, like ¿ and ¡ used in Spanish.
+ *
+ * @param {string} character The character to check.
+ * @returns {boolean} Whether or not the given character is a punctuation mark.
+ */
+function isPunctuation( character ) {
+	return "¿" === character
+		|| "¡" === character;
 }
 
 /**
@@ -213,6 +225,7 @@ function getSentencesFromTokens( tokens ) {
 						isCapitalLetter( nextSentenceStart )
 						|| isNumber( nextSentenceStart ) )
 						|| isQuotation( nextSentenceStart )
+						|| isPunctuation( nextSentenceStart )
 					|| ( !isUndefined( nextToken ) && (
 						"html-start" === nextToken.type
 						|| "html-end" === nextToken.type

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -217,6 +217,14 @@ describe("Get sentences from text", function(){
 			{
 				input: "First sentence. 'Second sentence'",
 				expected: [ "First sentence.", "'Second sentence'" ]
+			},
+			{
+				input: "First sentence. ¿Second sentence?",
+				expected: [ "First sentence.", "¿Second sentence?" ]
+			},
+			{
+				input: "First sentence. ¡Second sentence!",
+				expected: [ "First sentence.", "¡Second sentence!" ]
 			}
 		];
 


### PR DESCRIPTION
¿ and ¡ are valid sentence beginnings in languages like spanish, so these should be added to the tokenizer so it validates. 

Fixes #768 