### PR TITLE
Replaces hidden element for titlewidth in snippet preview.

### DIFF
--- a/css/_snippet-editor.scss
+++ b/css/_snippet-editor.scss
@@ -284,6 +284,3 @@ $snippet_width: 600px;
 @include progress-bar-color(".snippet-editor__progress--ok", $color_ok);
 @include progress-bar-color(".snippet-editor__progress--good", $color_good);
 
-.hidden-title {
-	font-size: 18px;
-}

--- a/js/assessments/pageTitleWidthAssessment.js
+++ b/js/assessments/pageTitleWidthAssessment.js
@@ -1,5 +1,5 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var inRange = require( "lodash/inRange" );
+var inRange = require( "../helpers/inRange" ).inRangeEndInclusive;
 
 /**
  * Returns the score and text for the pageTitleLength

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -150,7 +150,7 @@ function rateTitleLength( titleLength ) {
 
 	switch ( true ) {
 		case titleLength > 0 && titleLength <= 399:
-		case titleLength >= 600:
+		case titleLength > 600:
 			rating = "ok";
 			break;
 
@@ -383,7 +383,6 @@ SnippetPreview.prototype.renderTemplate = function() {
 
 	this.element = {
 		measurers: {
-			titleWidth: null,
 			metaHeight: null
 		},
 		rendered: {
@@ -1143,14 +1142,7 @@ SnippetPreview.prototype.setMetaDescription = function( metaDesc ) {
  * Creates elements with the purpose to calculate the sizes of elements and puts these elemenents to the body.
  */
 SnippetPreview.prototype.createMeasurementElements = function() {
-	var titleElement, metaDescriptionElement, spanHolder;
-
-	titleElement = hiddenElement( {
-		width: "auto",
-		whiteSpace: "nowrap",
-		fontSize: "18px"
-	} );
-
+	var metaDescriptionElement, spanHolder;
 	metaDescriptionElement = hiddenElement(
 		{
 			width: document.getElementById( "meta_container" ).offsetWidth + "px",
@@ -1160,12 +1152,10 @@ SnippetPreview.prototype.createMeasurementElements = function() {
 
 	spanHolder = document.createElement( "div" );
 
-	spanHolder.innerHTML = titleElement + metaDescriptionElement;
+	spanHolder.innerHTML = metaDescriptionElement;
 
 	document.body.appendChild( spanHolder );
 
-	this.element.measurers.titleWidth = spanHolder.childNodes[ 0 ];
-	this.element.measurers.titleWidth.className = "hidden-title";
 	this.element.measurers.metaHeight = spanHolder.childNodes[ 1 ];
 };
 
@@ -1173,11 +1163,7 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	var titleWidthElement = this.element.measurers.titleWidth;
-
-	titleWidthElement.innerHTML = this.element.rendered.title.innerHTML;
-
-	this.data.titleWidth = titleWidthElement.offsetWidth;
+	this.data.titleWidth = this.element.rendered.title.offsetWidth;
 };
 
 /**

--- a/js/templates.js
+++ b/js/templates.js
@@ -351,9 +351,9 @@
     __e( i18n.snippetPreviewDescription ) +
     '</p>\n\n        <div class="snippet_container snippet-editor__container" id="title_container">\n            <span class="screen-reader-text">' +
     __e( i18n.titleLabel ) +
-    '</span>\n            <span class="title" id="snippet_title">\n                ' +
+    '</span>\n            <span class="title" id="render_title_container">\n                <span id="snippet_title">\n                    ' +
     __e( rendered.title ) +
-    '\n            </span>\n            <span class="title" id="snippet_sitename"></span>\n        </div>\n        <div class="snippet_container snippet-editor__container" id="url_container">\n            <span class="screen-reader-text">' +
+    '\n                </span>\n            </span>\n            <span class="title" id="snippet_sitename"></span>\n        </div>\n        <div class="snippet_container snippet-editor__container" id="url_container">\n            <span class="screen-reader-text">' +
     __e( i18n.slugLabel ) +
     '</span>\n            <cite class="url urlBase" id="snippet_citeBase">\n                ' +
     __e( rendered.baseUrl ) +

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -29,6 +29,14 @@ describe( "the page title length assessment", function() {
 
 	});
 
+	it( "should assess a paper with a page title that's in range of the recommended value", function() {
+		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
+		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ), i18n );
+		expect( result.getScore() ).toEqual( 9 );
+		expect( result.getText() ).toEqual( "The page title has a nice length." );
+
+	});
+
 	it( "should assess a paper with a page title that's longer than the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );

--- a/spec/researches/pageTitleWidthSpec.js
+++ b/spec/researches/pageTitleWidthSpec.js
@@ -1,8 +1,8 @@
 var pageTitleLength = require( "../../js/researches/pageTitleWidth.js" );
 var Paper = require( "../../js/values/Paper.js" );
 
-describe( "the page title length research", function() {
-	it( "should count the words in the title", function() {
+describe( "the page title width research", function() {
+	it( "should return the pixels in the title", function() {
 		expect( pageTitleLength( new Paper( "", { title: "title", titleWidth: 10 } ) ) ).toBe( 10 );
 		expect( pageTitleLength( new Paper( "", { title: "" } ) ) ).toBe( 0 );
 		expect( pageTitleLength( new Paper( "" ) ) ).toBe( 0 );

--- a/templates/snippetEditor.jst
+++ b/templates/snippetEditor.jst
@@ -5,8 +5,10 @@
 
         <div class="snippet_container snippet-editor__container" id="title_container">
             <span class="screen-reader-text"><%- i18n.titleLabel %></span>
-            <span class="title" id="snippet_title">
-                <%- rendered.title %>
+            <span class="title" id="render_title_container">
+                <span id="snippet_title">
+                    <%- rendered.title %>
+                </span>
             </span>
             <span class="title" id="snippet_sitename"></span>
         </div>


### PR DESCRIPTION
This replaces the hidden element used for measuring the title width. This makes sure the CSS isn't overwritten and differs from the visible element. 
Added a span in the snippet template that sizes with the content. The assessment and progressbars now use the visible snippet title, making it consistent. 

Added some small tweaks to the title width assessment, where a title of exactly 600px wide would not be seen as too long or as a nice size. 

For testing, make sure the title width works as expected in the snippet preview, as soon as the snippet preview starts abbreviating the title, it should report it is too long and the progressbars should turn orange. 
`wwwWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW` is exactly 600px wide (on my machine) to test the treshold. 

Fixes #776 