### PR TITLE
Fixes sentence detection by removing nbsp's

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -14,7 +14,6 @@ var getBlocks = require( "../helpers/html.js" ).getBlocks;
 var normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 
 var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyNonBreakingSpace;
-var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 
 // All characters that indicate a sentence delimiter.
 var fullStop = ".";

--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -13,6 +13,9 @@ var core = require( "tokenizer2/core" );
 var getBlocks = require( "../helpers/html.js" ).getBlocks;
 var normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 
+var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyNonBreakingSpace;
+var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
+
 // All characters that indicate a sentence delimiter.
 var fullStop = ".";
 var sentenceDelimiters = "?!;";
@@ -293,6 +296,7 @@ var getSentencesFromBlockCached = memoize( getSentencesFromBlock );
  * @returns {Array} Sentences found in the text.
  */
 module.exports = function( text ) {
+	text = unifyWhitespace( text );
 	var sentences, blocks = getBlocks( text );
 
 	// Split each block on newlines.

--- a/js/stringProcessing/matchTextWithWord.js
+++ b/js/stringProcessing/matchTextWithWord.js
@@ -1,7 +1,7 @@
 /** @module stringProcessing/matchTextWithWord */
 
 var stripSomeTags = require( "../stringProcessing/stripNonTextTags.js" );
-var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" );
+var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyAllSpaces;
 var matchStringWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
 
 /**

--- a/js/stringProcessing/unifyWhitespace.js
+++ b/js/stringProcessing/unifyWhitespace.js
@@ -1,20 +1,36 @@
 /** @module stringProcessing/unifyWhitespace */
 
 /**
+ *
+ * @param text
+ * @returns {string|void|*|XML}
+ */
+var unifyNonBreakingSpace = function( text ) {
+	return text.replace( /&nbsp;/g, " " );
+};
+
+/**
+ *
+ * @param text
+ * @returns {string|void|*|XML}
+ */
+var unifyWhiteSpace = function( text ) {
+	return text.replace( /\s/g, " " );
+};
+
+/**
  * Converts all whitespace to spaces.
  *
  * @param {string} text The text to replace spaces.
  * @returns {string} The text with unified spaces.
  */
-
-module.exports = function( text ) {
-
-	// Replace &nbsp with space
-	text = text.replace( "&nbsp;", " " );
-
-	// Replace whitespaces with space
-	text = text.replace( /\s/g, " " );
-
-	return text;
+var unifyAllSpaces = function( text ) {
+	text = unifyNonBreakingSpace( text );
+	return unifyWhiteSpace( text );
 };
 
+module.exports = {
+	unifyNonBreakingSpace: unifyNonBreakingSpace,
+	unifyWhiteSpace: unifyWhiteSpace,
+	unifyAllSpaces: unifyAllSpaces
+};

--- a/js/stringProcessing/unifyWhitespace.js
+++ b/js/stringProcessing/unifyWhitespace.js
@@ -1,18 +1,18 @@
 /** @module stringProcessing/unifyWhitespace */
 
 /**
- *
- * @param text
- * @returns {string|void|*|XML}
+ * Replaces a non breaking space with a normal space
+ * @param {string} text The string to replace the non breaking space in.
+ * @returns {string} The text with unified spaces.
  */
 var unifyNonBreakingSpace = function( text ) {
 	return text.replace( /&nbsp;/g, " " );
 };
 
 /**
- *
- * @param text
- * @returns {string|void|*|XML}
+ * Replaces all whitespaces with a normal space
+ * @param {string} text The string to replace the non breaking space in.
+ * @returns {string} The text with unified spaces.
  */
 var unifyWhiteSpace = function( text ) {
 	return text.replace( /\s/g, " " );

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -65,7 +65,6 @@ describe("Get sentences from text", function(){
 		expect( getSentences( text ) ).toEqual( [ "A sentence with an image <img src='http://google.com' />" ] );
 	});
 
-
 	it( "can deal with newlines", function() {
 		var testCases = [
 			{

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -229,4 +229,14 @@ describe("Get sentences from text", function(){
 
 		testGetSentences( testCases );
 	});
+	it( "should ignore non breaking spaces", function() {
+		var testCases = [
+			{
+				input: "First sentence. Second sentence. &nbsp;",
+				expected: [ "First sentence.", "Second sentence." ]
+			}
+		];
+
+		testGetSentences( testCases );
+	} );
 });

--- a/spec/stringProcessing/unifyWhitespaceSpec.js
+++ b/spec/stringProcessing/unifyWhitespaceSpec.js
@@ -1,0 +1,9 @@
+var unifyWhitespace = require( "../../js/stringProcessing/unifyWhitespace.js" );
+
+describe( "A test to check if the whitespaces are filtered correctly", function() {
+	it( "returns a string with uniform whitespaces", function() {
+		expect( unifyWhitespace.unifyNonBreakingSpace( "A text&nbsp;string." ) ).toBe( "A text string." );
+		expect( unifyWhitespace.unifyWhiteSpace( "A\u0020text\u0020string." ) ).toBe( "A text string." );
+		expect( unifyWhitespace.unifyAllSpaces( "A&nbsp;text\u0020string." ) ).toBe( "A text string." );
+	} )
+} );


### PR DESCRIPTION
This strips out non breaking spaces for the sentence checks, to make sure we don't end up with a sentence consisting of only a space.

Fixes #https://github.com/Yoast/wordpress-seo/issues/4805