### PR TITLE
Fixes error in textlength assessments

### DIFF
--- a/js/assessments/taxonomyTextLengthAssessment.js
+++ b/js/assessments/taxonomyTextLengthAssessment.js
@@ -9,7 +9,7 @@ var recommendedMinimum = 150;
  * @returns {object} The resulting score object.
  */
 var calculateWordCountResult = function( wordCount, i18n ) {
-	if ( wordCount > 150 ) {
+	if ( wordCount >= 150 ) {
 		return {
 			score: 9,
 			text: i18n.dngettext(
@@ -23,8 +23,8 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 			) + " " + i18n.dngettext(
 				"js-text-analysis",
 				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is more than the recommended minimum of %2$d word.",
-				"This is more than the recommended minimum of %2$d words.",
+				"This is more than or equal to the recommended minimum of %2$d word.",
+				"This is more than or equal to the recommended minimum of %2$d words.",
 				recommendedMinimum
 			)
 		};

--- a/js/assessments/textLengthAssessment.js
+++ b/js/assessments/textLengthAssessment.js
@@ -9,7 +9,7 @@ var recommendedMinimum = 300;
  * @returns {object} The resulting score object.
  */
 var calculateWordCountResult = function( wordCount, i18n ) {
-	if ( wordCount > 300 ) {
+	if ( wordCount >= 300 ) {
 		return {
 			score: 9,
 			text: i18n.dngettext(
@@ -21,8 +21,8 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 			) + " " + i18n.dngettext(
 				"js-text-analysis",
 				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is more than the recommended minimum of %2$d word.",
-				"This is more than the recommended minimum of %2$d words.",
+				"This is more than or equal to the recommended minimum of %2$d word.",
+				"This is more than or equal to the recommended minimum of %2$d words.",
 				recommendedMinimum
 			)
 		};

--- a/spec/assessments/taxonomyTextLengthSpec.js
+++ b/spec/assessments/taxonomyTextLengthSpec.js
@@ -54,6 +54,6 @@ describe( "A word count assessment", function(){
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 175 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( 'The text contains 175 words. This is more than the recommended minimum of 150 words.' );
+		expect( assessment.getText() ).toEqual ( 'The text contains 175 words. This is more than or equal to the recommended minimum of 150 words.' );
 	} );
 } );

--- a/spec/assessments/textLengthSpec.js
+++ b/spec/assessments/textLengthSpec.js
@@ -56,6 +56,6 @@ describe( "A word count assessment", function(){
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 325 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The text contains 325 words. This is more than the recommended minimum of 300 words." );
+		expect( assessment.getText() ).toEqual ( "The text contains 325 words. This is more than or equal to the recommended minimum of 300 words." );
 	} );
 } );


### PR DESCRIPTION
When a text had exactly 300 words it would break, since it wouldn't return a valid assessment result. 
Also fixes the taxonomy length, that had the same issue with 150 words. 

Fixes https://github.com/Yoast/wordpress-seo/issues/3226