### PR TITLE
Don't match passives in URLs

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -1,6 +1,7 @@
 var getSentences = require( "../stringProcessing/getSentences.js" );
 var arrayToRegex = require( "../stringProcessing/createRegexFromArray.js" );
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
+var stripHTMLTags = require( "../stringProcessing/stripHTMLTags.js" );
 var matchWordInSentence = require( "../stringProcessing/matchWordInSentence.js" );
 var normalizeSingleQuotes = require( "../stringProcessing/quotes.js" ).normalizeSingle;
 
@@ -313,6 +314,8 @@ module.exports = function( paper ) {
 
 	// Get subsentences for each sentence.
 	forEach( sentences, function( sentence ) {
+		sentence = stripHTMLTags( sentence );
+
 		var subSentences = getSubsentences( sentence );
 
 		var passive = false;

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -346,4 +346,12 @@ describe( "detecting passive voice in sentences", function() {
 		} );
 
 	});
+
+	it( "strips HTMLtags", function() {
+		paper = new Paper( "<a href='get lost'>No passive</a>" );
+		expect( passiveVoice( paper ) ).toEqual( {
+			total: 1,
+			passives: []
+		} );
+	})
 } );

--- a/spec/stringProcessing/stripHTMLTagsSpec.js
+++ b/spec/stringProcessing/stripHTMLTagsSpec.js
@@ -13,5 +13,6 @@ describe( "strips the HTMLtags from a string", function(){
 		expect(stripHTMLTags( "<li></li>")).toBe( "" );
 		expect(stripHTMLTags( "<span><b>this is</b> </span> a <p>textstring</p>" )).toBe( "this is a textstring" );
 		expect(stripHTMLTags( "this    <b> is    a </b> textstring" )).toBe( "this is a textstring" );
+		expect(stripHTMLTags( "this is <a href='text'>an anchor</a>" )).toBe( "this is an anchor" );
 	} );
 } );


### PR DESCRIPTION
The URL was checked for passives, but we shouldn't do that, since they aren't part of the written text. 

This removes HTMLtags so we don't match any passives here. 

Fixes #789

For testing: use a text with only a passive in a URL, the assessment now shouldn't show a passive found. 