### PR TITLE
Don't assume there are multiple words for sentence beginnings. 

### DIFF
--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -58,12 +58,13 @@ module.exports = function( paper ) {
 	var sentences = getSentences( paper.getText() );
 	var firstWordExceptions = getFirstWordExceptions( paper.getLocale() )();
 	var sentenceBeginnings = sentences.map( function( sentence ) {
+
 		var words = getWords( stripSpaces( sentence ) );
 		if( words.length === 0 ) {
 			return "";
 		}
 		var firstWord = removeNonWordCharacters( words[ 0 ] ).toLocaleLowerCase();
-		if ( firstWordExceptions.indexOf( firstWord ) > -1 ) {
+		if ( firstWordExceptions.indexOf( firstWord ) > -1 && words.length > 1 ) {
 			firstWord += " " + removeNonWordCharacters( words[ 1 ] );
 		}
 		return firstWord;

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -58,7 +58,6 @@ module.exports = function( paper ) {
 	var sentences = getSentences( paper.getText() );
 	var firstWordExceptions = getFirstWordExceptions( paper.getLocale() )();
 	var sentenceBeginnings = sentences.map( function( sentence ) {
-
 		var words = getWords( stripSpaces( sentence ) );
 		if( words.length === 0 ) {
 			return "";

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -46,6 +46,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 3 );
 	} );
 
+	it( "returns only an exclusion word, if that is the only word in a sentences (English", function() {
+		var mockPaper = new Paper( "A." );
+		expect( sentenceBeginnings( mockPaper )[0 ].word ).toBe( "a" );
+		expect( sentenceBeginnings( mockPaper )[0 ].count ).toBe( 1 );
+	} );
+
 	it( "returns an object with sentence beginnings and counts based on the default (English) when a non-existing locale is included.", function() {
 		var mockPaper = new Paper( "The boy, hey! The boy. The boy.", { locale: 'xx_yy'} );
 		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "the boy" );


### PR DESCRIPTION
In the sentence beginnings we append the second word in a sentence if the first word is an exclusion word. 
But if the sentence only consists of 1 exclusionword, and no more, it would break. 

This fix makes sure we don't assume there is a second word. If there is no second word, we use only the first word as a sentence beginning. 

Fixes #790 