### PR TITLE
Prevents setting the width to 0 when not empty

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1163,7 +1163,9 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	this.data.titleWidth = this.element.rendered.title.offsetWidth;
+	if( this.element.rendered.title.offsetWidth !== 0 || this.element.rendered.title.textContent === "" ){
+		this.data.titleWidth = this.element.rendered.title.offsetWidth;
+	}
 };
 
 /**

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1163,7 +1163,7 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	if( this.element.rendered.title.offsetWidth !== 0 || this.element.rendered.title.textContent === "" ){
+	if( this.element.rendered.title.offsetWidth !== 0 || this.element.input.title.value === "" ){
 		this.data.titleWidth = this.element.rendered.title.offsetWidth;
 	}
 };

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1163,7 +1163,7 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	if( this.element.rendered.title.offsetWidth !== 0 || this.element.input.title.value === "" ){
+	if( this.element.rendered.title.offsetWidth !== 0 || this.element.input.title.value === "" ) {
 		this.data.titleWidth = this.element.rendered.title.offsetWidth;
 	}
 };


### PR DESCRIPTION
If you switch tabs, the title width would be reset to 0. 
The only time when the title width should be 0 is if there is an empty text string. If the text is not empty, we should not updat the data.titleWidth. 

fixes #https://github.com/Yoast/wordpress-seo/issues/5168

For testing:
In the standalone, test that the title width assessment is working like expected
In WP, when you switch tabs (from seo to readability and back), it should not set the value to zero.