### PR TITLE
Fixed a faulty comparison for the textLinksAssessment

### DIFF
--- a/js/assessments/textLinksAssessment.js
+++ b/js/assessments/textLinksAssessment.js
@@ -25,7 +25,7 @@ var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
 		};
 	}
 
-	if ( linkStatistics.externalNofollow < linkStatistics.total ) {
+	if ( linkStatistics.externalNofollow < linkStatistics.externalTotal ) {
 		return {
 			score: 8,
 			/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of outbound links */
@@ -41,6 +41,8 @@ var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
 			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s outbound link(s)." ), linkStatistics.externalTotal )
 		};
 	}
+
+	return {};
 };
 
 /**


### PR DESCRIPTION
The comparison being done applied to the total amount of links and not the total amount of external links, resulting in a nonsensical score being returned.

Fixes https://github.com/Yoast/wordpress-seo/issues/5166