### PR TITLE
Place marks after closing tags. 

### DIFF
--- a/js/assessments/passiveVoiceAssessment.js
+++ b/js/assessments/passiveVoiceAssessment.js
@@ -86,6 +86,7 @@ var calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 var passiveVoiceMarker = function( paper, researcher ) {
 	var passiveVoice = researcher.getResearch( "passiveVoice" );
 	return map( passiveVoice.passives, function( sentence ) {
+		sentence = stripTags( sentence );
 		var marked = marker( sentence );
 		return new Mark( {
 			original: sentence,

--- a/js/assessments/sentenceBeginningsAssessment.js
+++ b/js/assessments/sentenceBeginningsAssessment.js
@@ -1,6 +1,6 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var getLanguage = require( "../helpers/getLanguage.js" );
-var stripTags = require( "../stringProcessing/stripHTMLTags" ).stripTagsBeginEnd;
+var stripTags = require( "../stringProcessing/stripHTMLTags" ).stripTagParts;
 
 var partition = require( "lodash/partition" );
 var sortBy = require( "lodash/sortBy" );
@@ -75,7 +75,6 @@ var sentenceBeginningMarker = function( paper, researcher ) {
 	} );
 	return map( flatten( sentences ), function( sentence ) {
 		sentence = stripTags( sentence );
-		console.log( sentence );
 		var marked = marker( sentence );
 		return new Mark( {
 			original: sentence,

--- a/js/assessments/sentenceBeginningsAssessment.js
+++ b/js/assessments/sentenceBeginningsAssessment.js
@@ -1,5 +1,6 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var getLanguage = require( "../helpers/getLanguage.js" );
+var stripTags = require( "../stringProcessing/stripHTMLTags" ).stripTagsBeginEnd;
 
 var partition = require( "lodash/partition" );
 var sortBy = require( "lodash/sortBy" );
@@ -73,6 +74,8 @@ var sentenceBeginningMarker = function( paper, researcher ) {
 		return begin.sentences;
 	} );
 	return map( flatten( sentences ), function( sentence ) {
+		sentence = stripTags( sentence );
+		console.log( sentence );
 		var marked = marker( sentence );
 		return new Mark( {
 			original: sentence,

--- a/js/assessments/sentenceLengthInTextAssessment.js
+++ b/js/assessments/sentenceLengthInTextAssessment.js
@@ -129,7 +129,7 @@ var sentenceLengthInTextAssessment = function( paper, researcher, i18n ) {
 var sentenceLengthMarker = function( paper, researcher ) {
 	var sentenceCount = researcher.getResearch( "countSentencesFromText" );
 	var sentenceObjects = tooLongSentences( sentenceCount, recommendedValue );
-
+	sentence = stripTags( sentence );
 	return map( sentenceObjects, function( sentenceObject ) {
 		return new Mark( {
 			original: sentenceObject.sentence,

--- a/js/assessments/textPresenceAssessment.js
+++ b/js/assessments/textPresenceAssessment.js
@@ -1,4 +1,4 @@
-var stripHTMLTags = require( "../stringProcessing/stripHTMLTags" );
+var stripHTMLTags = require( "../stringProcessing/stripHTMLTags" ).stripFullTags;
 var AssessmentResult = require( "../values/AssessmentResult" );
 
 /**

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -95,7 +95,7 @@ var transitionWordsMarker = function( paper, researcher ) {
 
 	return map( transitionWordSentences.sentenceResults, function( sentenceResult ) {
 		var sentence = sentenceResult.sentence;
-
+		sentence = stripTags( sentence );
 		return new Mark( {
 			original: sentence,
 			marked: marker( sentence )

--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -1,7 +1,7 @@
 var getSentences = require( "../stringProcessing/getSentences.js" );
 var arrayToRegex = require( "../stringProcessing/createRegexFromArray.js" );
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
-var stripHTMLTags = require( "../stringProcessing/stripHTMLTags.js" );
+var stripHTMLTags = require( "../stringProcessing/stripHTMLTags.js" ).stripFullTags;
 var matchWordInSentence = require( "../stringProcessing/matchWordInSentence.js" );
 var normalizeSingleQuotes = require( "../stringProcessing/quotes.js" ).normalizeSingle;
 

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -68,7 +68,6 @@ module.exports = function( paper ) {
 		if ( firstWordExceptions.indexOf( firstWord ) > -1 && words.length > 1 ) {
 			firstWord += " " + removeNonWordCharacters( words[ 1 ] );
 		}
-		console.log( firstWord );
 		return firstWord;
 	} );
 	return compareFirstWords( sentenceBeginnings, sentences );

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -1,7 +1,7 @@
 var getSentences = require( "../stringProcessing/getSentences.js" );
 var getWords = require( "../stringProcessing/getWords.js" );
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
-var stripHTMLTags = require( "../stringProcessing/stripHTMLTags.js" );
+var stripTagParts = require( "../stringProcessing/stripHTMLTags.js" ).stripTagParts;
 var removeNonWordCharacters = require( "../stringProcessing/removeNonWordCharacters.js" );
 var getFirstWordExceptions = require( "../helpers/getFirstWordExceptions.js" );
 
@@ -56,9 +56,10 @@ var compareFirstWords = function ( sentenceBeginnings, sentences ) {
  * @returns {Object} The object containing the first word of each sentence and the corresponding counts.
  */
 module.exports = function( paper ) {
-	var sentences = getSentences( stripHTMLTags( paper.getText() ) );
+	var sentences = getSentences( paper.getText() );
 	var firstWordExceptions = getFirstWordExceptions( paper.getLocale() )();
 	var sentenceBeginnings = sentences.map( function( sentence ) {
+		sentence = stripTagParts( sentence );
 		var words = getWords( stripSpaces( sentence ) );
 		if( words.length === 0 ) {
 			return "";

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -68,6 +68,7 @@ module.exports = function( paper ) {
 		if ( firstWordExceptions.indexOf( firstWord ) > -1 && words.length > 1 ) {
 			firstWord += " " + removeNonWordCharacters( words[ 1 ] );
 		}
+		console.log( firstWord );
 		return firstWord;
 	} );
 	return compareFirstWords( sentenceBeginnings, sentences );

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -1,6 +1,7 @@
 var getSentences = require( "../stringProcessing/getSentences.js" );
 var getWords = require( "../stringProcessing/getWords.js" );
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
+var stripHTMLTags = require( "../stringProcessing/stripHTMLTags.js" );
 var removeNonWordCharacters = require( "../stringProcessing/removeNonWordCharacters.js" );
 var getFirstWordExceptions = require( "../helpers/getFirstWordExceptions.js" );
 
@@ -55,7 +56,7 @@ var compareFirstWords = function ( sentenceBeginnings, sentences ) {
  * @returns {Object} The object containing the first word of each sentence and the corresponding counts.
  */
 module.exports = function( paper ) {
-	var sentences = getSentences( paper.getText() );
+	var sentences = getSentences( stripHTMLTags( paper.getText() ) );
 	var firstWordExceptions = getFirstWordExceptions( paper.getLocale() )();
 	var sentenceBeginnings = sentences.map( function( sentence ) {
 		var words = getWords( stripSpaces( sentence ) );

--- a/js/researches/getSubheadingLength.js
+++ b/js/researches/getSubheadingLength.js
@@ -1,5 +1,5 @@
 var getSubheadingContents = require( "../stringProcessing/getSubheadings.js" ).getSubheadingContents;
-var stripTags = require( "../stringProcessing/stripHTMLTags.js" );
+var stripTags = require( "../stringProcessing/stripHTMLTags.js" ).stripFullTags;
 var forEach = require( "lodash/forEach" );
 
 /**

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -9,7 +9,7 @@ var forEach = require( "lodash/forEach" );
 var debounce = require( "lodash/debounce" );
 
 var stringToRegex = require( "../js/stringProcessing/stringToRegex.js" );
-var stripHTMLTags = require( "../js/stringProcessing/stripHTMLTags.js" );
+var stripHTMLTags = require( "../js/stringProcessing/stripHTMLTags.js" ).stripFullTags;
 var sanitizeString = require( "../js/stringProcessing/sanitizeString.js" );
 var stripSpaces = require( "../js/stringProcessing/stripSpaces.js" );
 var replaceDiacritics = require( "../js/stringProcessing/replaceDiacritics.js" );

--- a/js/stringProcessing/getWords.js
+++ b/js/stringProcessing/getWords.js
@@ -1,6 +1,6 @@
 /** @module stringProcessing/countWords */
 
-var stripTags = require( "./stripHTMLTags.js" );
+var stripTags = require( "./stripHTMLTags.js" ).stripFullTags;
 var stripSpaces = require( "./stripSpaces.js" );
 var removeTerminators = require( "./removeTerminators.js" );
 var map = require( "lodash/map" );

--- a/js/stringProcessing/sanitizeString.js
+++ b/js/stringProcessing/sanitizeString.js
@@ -1,6 +1,6 @@
 /** @module stringProcessing/sanitizeString */
 
-var stripTags = require( "../stringProcessing/stripHTMLTags.js" );
+var stripTags = require( "../stringProcessing/stripHTMLTags.js" ).stripFullTags;
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 
 /**

--- a/js/stringProcessing/sentencesLength.js
+++ b/js/stringProcessing/sentencesLength.js
@@ -1,6 +1,6 @@
 var wordCount = require( "./countWords.js" );
 var forEach = require( "lodash/forEach" );
-var stripHTMLTags = require( "./stripHTMLTags.js" );
+var stripHTMLTags = require( "./stripHTMLTags.js" ).stripFullTags;
 
 /**
  * Returns an array with the number of words in a sentence.

--- a/js/stringProcessing/stripHTMLTags.js
+++ b/js/stringProcessing/stripHTMLTags.js
@@ -15,6 +15,37 @@ var stripTagParts = function( text ) {
 };
 
 /**
+ * Strip tags at the beginning of the text.
+ * @param text
+ * @returns {*}
+ */
+var stripTagsBegin = function( text ) {
+	return text.replace( /^(<([^>]+)>)+/ig, "" );
+};
+
+/**
+ * Strip tags at the end of the text.
+ * @param text
+ * @returns {*}
+ */
+var stripTagsEnd = function( text ) {
+	return text.replace( /(<([^>]+)>)+$/ig, "" );
+};
+
+/**
+ * Strip tags at the beginning and end of the text. 
+ * @param text
+ * @returns {*}
+ */
+var stripTagsBeginEnd = function( text ) {
+	text = stripTagsBegin( text );
+	text = stripTagsEnd( text );
+	return text;
+};
+
+
+
+/**
  * Strip HTML-tags from text
  *
  * @param {String} text The text to strip the HTML-tags from.
@@ -28,5 +59,9 @@ var stripFullTags = function( text ) {
 
 module.exports = {
 	stripFullTags: stripFullTags,
-	stripTagParts: stripTagParts
+	stripTagParts: stripTagParts,
+	stripTagsBegin: stripTagsBegin,
+	stripTagsEnd: stripTagsEnd,
+	stripTagsBeginEnd: stripTagsBeginEnd
+
 };

--- a/js/stringProcessing/stripHTMLTags.js
+++ b/js/stringProcessing/stripHTMLTags.js
@@ -5,45 +5,14 @@ var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 /**
  * Strip incomplete tags within a text. Strips an endtag at the beginning of a string and the start tag at the end of a
  * start of a string.
- * @param text
- * @returns {*}
+ * @param {String} text The text to strip the HTML-tags from at the begin and end.
+ * @returns {String} The text without HTML-tags at the begin and end.
  */
 var stripTagParts = function( text ) {
 	text = text.replace( /^(<\/([^>]+)>)+/i, "" );
 	text = text.replace( /(<([^\/>]+)>)+$/i, "" );
 	return text;
 };
-
-/**
- * Strip tags at the beginning of the text.
- * @param text
- * @returns {*}
- */
-var stripTagsBegin = function( text ) {
-	return text.replace( /^(<([^>]+)>)+/ig, "" );
-};
-
-/**
- * Strip tags at the end of the text.
- * @param text
- * @returns {*}
- */
-var stripTagsEnd = function( text ) {
-	return text.replace( /(<([^>]+)>)+$/ig, "" );
-};
-
-/**
- * Strip tags at the beginning and end of the text. 
- * @param text
- * @returns {*}
- */
-var stripTagsBeginEnd = function( text ) {
-	text = stripTagsBegin( text );
-	text = stripTagsEnd( text );
-	return text;
-};
-
-
 
 /**
  * Strip HTML-tags from text
@@ -59,9 +28,5 @@ var stripFullTags = function( text ) {
 
 module.exports = {
 	stripFullTags: stripFullTags,
-	stripTagParts: stripTagParts,
-	stripTagsBegin: stripTagsBegin,
-	stripTagsEnd: stripTagsEnd,
-	stripTagsBeginEnd: stripTagsBeginEnd
-
+	stripTagParts: stripTagParts
 };

--- a/js/stringProcessing/stripHTMLTags.js
+++ b/js/stringProcessing/stripHTMLTags.js
@@ -3,13 +3,30 @@
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 
 /**
+ * Strip incomplete tags within a text. Strips an endtag at the beginning of a string and the start tag at the end of a
+ * start of a string.
+ * @param text
+ * @returns {*}
+ */
+var stripTagParts = function( text ) {
+	text = text.replace( /^(<\/([^>]+)>)+/i, "" );
+	text = text.replace( /(<([^\/>]+)>)+$/i, "" );
+	return text;
+};
+
+/**
  * Strip HTML-tags from text
  *
  * @param {String} text The text to strip the HTML-tags from.
  * @returns {String} The text without HTML-tags.
  */
-module.exports = function( text ) {
+var stripFullTags = function( text ) {
 	text = text.replace( /(<([^>]+)>)/ig, " " );
 	text = stripSpaces( text );
 	return text;
+};
+
+module.exports = {
+	stripFullTags: stripFullTags,
+	stripTagParts: stripTagParts
 };

--- a/spec/stringProcessing/stripHTMLTagsSpec.js
+++ b/spec/stringProcessing/stripHTMLTagsSpec.js
@@ -1,4 +1,5 @@
-var stripHTMLTags = require( "../../js/stringProcessing/stripHTMLTags.js" );
+var stripHTMLTags = require( "../../js/stringProcessing/stripHTMLTags.js" ).stripFullTags;
+var stripTagParts = require( "../../js/stringProcessing/stripHTMLTags.js" ).stripTagParts;
 
 describe( "strips the HTMLtags from a string", function(){
 	it( "returns a string without HTMLtags", function(){
@@ -15,4 +16,21 @@ describe( "strips the HTMLtags from a string", function(){
 		expect(stripHTMLTags( "this    <b> is    a </b> textstring" )).toBe( "this is a textstring" );
 		expect(stripHTMLTags( "this is <a href='text'>an anchor</a>" )).toBe( "this is an anchor" );
 	} );
+} );
+
+describe( "strips the HTML tag parts at the beginning of the sentence", function() {
+	it( "returns a string without the HTML closing tags at the start", function() {
+		expect( stripTagParts ( "this is a textstring") ).toBe( "this is a textstring" );
+		expect( stripTagParts ( "</span>this is a textstring") ).toBe( "this is a textstring" );
+		expect( stripTagParts ( "</strong></span>this is a textstring") ).toBe( "this is a textstring" );
+	} );
+	it( "returns a string without the HTML start tags at the end", function() {
+		expect( stripTagParts ( "this is a textstring<span>") ).toBe( "this is a textstring" );
+		expect( stripTagParts ( "this is a textstring<strong><span>") ).toBe( "this is a textstring" );
+	} );
+	it( "should return the same string", function(){
+		expect( stripTagParts( "this is a textstring" ) ).toBe( "this is a textstring" );
+		expect( stripTagParts( "<span>this is a textstring</span>" ) ).toBe( "<span>this is a textstring</span>" );
+		expect( stripTagParts( "</strong><span>this is a textstring</span>" ) ).toBe( "<span>this is a textstring</span>" );
+	});
 } );


### PR DESCRIPTION
This removes broken HTML-tags in markers. When starting a sentence with an HTML-endtag the Yoastmark would be closed when that tag was closed, and not showing the mark. 

This fix adds the marker after the closing tags, so the mark is visible, while not changing anything in the assessment. This only affects markers. 

Partially fixes #766 #788 and #801 