### PR TITLE
Fix markers on passive voice with HTMLtags. 

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -314,9 +314,9 @@ module.exports = function( paper ) {
 
 	// Get subsentences for each sentence.
 	forEach( sentences, function( sentence ) {
-		sentence = stripHTMLTags( sentence );
+		var strippedSentence = stripHTMLTags( sentence );
 
-		var subSentences = getSubsentences( sentence );
+		var subSentences = getSubsentences( strippedSentence );
 
 		var passive = false;
 		forEach( subSentences, function( subSentence ) {

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1163,7 +1163,9 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	this.data.titleWidth = this.element.rendered.title.offsetWidth;
+	if( this.element.rendered.title.offsetWidth !== 0 || this.element.input.title.value === "" ) {
+		this.data.titleWidth = this.element.rendered.title.offsetWidth;
+	}
 };
 
 /**


### PR DESCRIPTION
Fixes #803 

For correct matching we stripped the tags from the sentences, but did not store the original sentence to push in the array that would be used for markers. 
This creates a new variable for testing, but pushes the unaltered sentence so it can be marked.

For testing, create a passive voice sentence with a HTMLtag, this should be marked. 