### PR TITLE
Removed the assumption that the loading dialog is always present when trying to remove it

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -638,8 +638,9 @@ App.prototype.updateLoadingDialog = function( plugins ) {
  */
 App.prototype.removeLoadingDialog = function() {
 	var outputElement = document.getElementById( this.defaultOutputElement );
+	var loadingDialog = document.getElementById( "YoastSEO-plugin-loading" );
 
-	if ( this.defaultOutputElement !== "" && !isEmpty( outputElement ) ) {
+	if ( ( this.defaultOutputElement !== "" && !isEmpty( outputElement ) ) && !isEmpty( loadingDialog ) ) {
 		document.getElementById( this.defaultOutputElement ).removeChild( document.getElementById( "YoastSEO-plugin-loading" ) );
 	}
 };


### PR DESCRIPTION
Required to fix https://github.com/Yoast/wordpress-seo/issues/5194