### PR TITLE
Adds space in sentence in sentence length assessment

### DIFF
--- a/js/assessments/sentenceLengthInTextAssessment.js
+++ b/js/assessments/sentenceLengthInTextAssessment.js
@@ -92,7 +92,7 @@ var calculateSentenceLengthResult = function( sentences, i18n ) {
 			// Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
 			// %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
 			// %5$s expands to the recommended maximum percentage.
-			"%1$s of the sentences contain %2$smore than %3$s words%4$s, which is more than the recommended maximum of %5$s." +
+			"%1$s of the sentences contain %2$smore than %3$s words%4$s, which is more than the recommended maximum of %5$s. " +
 			"Try to shorten the sentences."
 			), percentage + "%", sentenceLengthURL, recommendedValue, "</a>", maximumPercentage + "%"
 		)

--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -31,7 +31,7 @@ describe( "An assessment for sentence length", function(){
 		expect( assessment.hasScore()).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual ( "50% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%.Try to shorten the sentences." );
+			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -44,7 +44,7 @@ describe( "An assessment for sentence length", function(){
 		expect( assessment.hasScore()).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual ( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%.Try to shorten the sentences." );
+			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 25% long sentences", function(){
@@ -80,7 +80,7 @@ describe( "An assessment for sentence length", function(){
 		expect( assessment.hasScore()).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( "30% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%.Try to shorten the sentences." )
+			"which is more than the recommended maximum of 25%. Try to shorten the sentences." )
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "is not applicable for empty papers", function(){


### PR DESCRIPTION
There was a space missing, added this. 
Fixes #https://github.com/Yoast/wordpress-seo/issues/5210