### PR TITLE
Added a missing if around the seoAssessorPresenter

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -735,7 +735,9 @@ App.prototype.registerAssessment = function( name, assessment, pluginName ) {
  * Disables markers visually in the UI.
  */
 App.prototype.disableMarkers = function() {
-	this.seoAssessorPresenter.disableMarker();
+	if ( !isUndefined( this.seoAssessorPresenter ) ) {
+		this.seoAssessorPresenter.disableMarker();
+	}
 
 	if ( !isUndefined( this.contentAssessorPresenter ) ) {
 		this.contentAssessorPresenter.disableMarker();


### PR DESCRIPTION
If the SEO analysis is disabled, the console will throw an error when attempting to disable the markers.