### PR TITLE
Checks the correct element for defining width of pagetitle

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1163,7 +1163,7 @@ SnippetPreview.prototype.createMeasurementElements = function() {
  * Copies the title text to the title measure element to calculate the width in pixels.
  */
 SnippetPreview.prototype.measureTitle = function() {
-	if( this.element.rendered.title.offsetWidth !== 0 || this.element.input.title.value === "" ) {
+	if( this.element.rendered.title.offsetWidth !== 0 || this.element.rendered.title.textContent === "" ) {
 		this.data.titleWidth = this.element.rendered.title.offsetWidth;
 	}
 };


### PR DESCRIPTION
We should check the rendered element for the page title, not the input title because that can stay empty (if the snippet title is generated from the page title, and not filled in in the snippet itself). 

Fixes the first issue of https://github.com/Yoast/wordpress-seo/issues/5198