### PR TITLE
Refreshes the snippetPreview before measuring

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -525,7 +525,7 @@ App.prototype.runAnalyzer = function() {
 	}
 
 	this.analyzerData = this.modifyData( this.rawData );
-	
+
 	this.snippetPreview.refresh();
 
 	// Create a paper object for the Researcher

--- a/js/app.js
+++ b/js/app.js
@@ -524,12 +524,9 @@ App.prototype.runAnalyzer = function() {
 		this.startTime();
 	}
 
-	
-	
 	this.analyzerData = this.modifyData( this.rawData );
 	
-	this.snippetPreview.measureTitle();
-
+	this.snippetPreview.refresh();
 
 	// Create a paper object for the Researcher
 	this.paper = new Paper( this.analyzerData.text, {

--- a/js/app.js
+++ b/js/app.js
@@ -524,9 +524,12 @@ App.prototype.runAnalyzer = function() {
 		this.startTime();
 	}
 
+	
+	
 	this.analyzerData = this.modifyData( this.rawData );
 	
 	this.snippetPreview.measureTitle();
+
 
 	// Create a paper object for the Researcher
 	this.paper = new Paper( this.analyzerData.text, {

--- a/js/app.js
+++ b/js/app.js
@@ -525,6 +525,8 @@ App.prototype.runAnalyzer = function() {
 	}
 
 	this.analyzerData = this.modifyData( this.rawData );
+	
+	this.snippetPreview.measureTitle();
 
 	// Create a paper object for the Researcher
 	this.paper = new Paper( this.analyzerData.text, {


### PR DESCRIPTION
This make sure the snippet is refreshed before the title is measure, because otherwise it could fail due to rendering of replacable variables. 

This we we get the correct width to use for the assessments.

Fixes #https://github.com/Yoast/wordpress-seo/issues/5198