### PR TITLE
Fixed a possible division by zero issue

### DIFF
--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -21,7 +21,7 @@ var calculateTransitionWordPercentage = function ( sentences ) {
 	}
 
 	return ( sentences.transitionWordSentences / sentences.totalSentences ) * 100;
-}
+};
 
 /**
  * Calculates transition word result

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -20,7 +20,7 @@ var calculateTransitionWordPercentage = function ( sentences ) {
 		return 0;
 	}
 
-	return ( sentences.transitionWordSentences / sentences.totalSentences ) * 100;
+	return formatNumber( ( sentences.transitionWordSentences / sentences.totalSentences ) * 100 );
 };
 
 /**

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -9,6 +9,21 @@ var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
 
 /**
+ * Calculates the actual percentage of transition words in the sentences.
+ *
+ * @param {object} sentences The object containing the total number of sentences and the number of sentences containing
+ * a transition word.
+ * @returns {number} The percentage of sentences containing a transition word.
+ */
+var calculateTransitionWordPercentage = function ( sentences ) {
+	if ( sentences.transitionWordSentences === 0 || sentences.totalSentences === 0 ) {
+		return 0;
+	}
+
+	return ( sentences.transitionWordSentences / sentences.totalSentences ) * 100;
+}
+
+/**
  * Calculates transition word result
  * @param {object} transitionWordSentences The object containing the total number of sentences and the number of sentences containing
  * a transition word.
@@ -17,8 +32,7 @@ var marker = require( "../markers/addMark.js" );
  */
 var calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 	var score;
-	var percentage = ( transitionWordSentences.transitionWordSentences / transitionWordSentences.totalSentences ) * 100;
-	percentage     = formatNumber( percentage );
+	var percentage = calculateTransitionWordPercentage( transitionWordSentences );
 	var hasMarks   = ( percentage > 0 );
 	var transitionWordsURL = "<a href='https://yoa.st/transition-words' target='_blank'>";
 

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -52,6 +52,7 @@ describe( "An assessment for transition word percentage", function(){
 			"or phrase, which is great." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
+
 	it( "returns the score for 47% sentences with transition words", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 100,
@@ -61,7 +62,8 @@ describe( "An assessment for transition word percentage", function(){
 			"or phrase, which is great.");
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
-		it( "returns the score for 66.7% of the sentences with transition words", function(){
+
+	it( "returns the score for 66.7% of the sentences with transition words", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 3,
 			transitionWordSentences: 2 } ), i18n );
@@ -71,7 +73,8 @@ describe( "An assessment for transition word percentage", function(){
 			"or phrase, which is great." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
-		it( "is not applicable for empty papers", function(){
+
+	it( "is not applicable for empty papers", function(){
 		mockPaper = new Paper();
 		assessment = transitionWordsAssessment.isApplicable( mockPaper );
 		expect( assessment ).toBe( false );


### PR DESCRIPTION
This PR fixes an issue where the user only inserts an enter into the content, leading into transition words returning NaN due to a division by zero error.

Fixes #819 