### PR TITLE
Makes sure we don't mark block elements in paragraphs

### DIFF
--- a/js/assessments/paragraphTooLongAssessment.js
+++ b/js/assessments/paragraphTooLongAssessment.js
@@ -4,6 +4,11 @@ var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
 var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
 
+var blockElements = require( "../helpers/html.js" ).blockElements;
+
+var blockElementStartRegex = new RegExp( "^<(" + blockElements.join( "|" ) + ")[^>]*?>", "i" );
+var blockElementEndRegex = new RegExp( "</(" + blockElements.join( "|" ) + ")[^>]*?>$", "i" );
+
 var filter = require( "lodash/filter" );
 var map = require( "lodash/map" );
 
@@ -97,9 +102,10 @@ var paragraphLengthMarker = function( paper, researcher ) {
 	var paragraphsLength = researcher.getResearch( "getParagraphLength" );
 	var tooLongParagraphs = getTooLongParagraphs( paragraphsLength );
 	return map( tooLongParagraphs, function( paragraph ) {
-		var marked = marker( paragraph.paragraph );
+		var paragraphText = paragraph.paragraph.replace( blockElementStartRegex, "" ).replace( blockElementEndRegex, "" );
+		var marked = marker( paragraphText );
 		return new Mark( {
-			original: paragraph.paragraph,
+			original: paragraphText,
 			marked: marked
 		} );
 	} );

--- a/js/assessments/paragraphTooLongAssessment.js
+++ b/js/assessments/paragraphTooLongAssessment.js
@@ -98,8 +98,7 @@ var paragraphLengthMarker = function( paper, researcher ) {
 	var paragraphsLength = researcher.getResearch( "getParagraphLength" );
 	var tooLongParagraphs = getTooLongParagraphs( paragraphsLength );
 	return map( tooLongParagraphs, function( paragraph ) {
-
-		var paragraphText = stripHTMLTags( paragraph.text )
+		var paragraphText = stripHTMLTags( paragraph.text );
 		var marked = marker( paragraphText );
 		return new Mark( {
 			original: paragraphText,

--- a/js/assessments/paragraphTooLongAssessment.js
+++ b/js/assessments/paragraphTooLongAssessment.js
@@ -1,13 +1,9 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
+var stripHTMLTags = require( "../stringProcessing/stripHTMLTags" ).stripBlockTagsAtStartEnd;
 var isParagraphTooLong = require( "../helpers/isValueTooLong" );
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
 var inRange = require( "../helpers/inRange.js" ).inRangeEndInclusive;
-
-var blockElements = require( "../helpers/html.js" ).blockElements;
-
-var blockElementStartRegex = new RegExp( "^<(" + blockElements.join( "|" ) + ")[^>]*?>", "i" );
-var blockElementEndRegex = new RegExp( "</(" + blockElements.join( "|" ) + ")[^>]*?>$", "i" );
 
 var filter = require( "lodash/filter" );
 var map = require( "lodash/map" );
@@ -102,7 +98,8 @@ var paragraphLengthMarker = function( paper, researcher ) {
 	var paragraphsLength = researcher.getResearch( "getParagraphLength" );
 	var tooLongParagraphs = getTooLongParagraphs( paragraphsLength );
 	return map( tooLongParagraphs, function( paragraph ) {
-		var paragraphText = paragraph.paragraph.replace( blockElementStartRegex, "" ).replace( blockElementEndRegex, "" );
+
+		var paragraphText = stripHTMLTags( paragraph.text )
 		var marked = marker( paragraphText );
 		return new Mark( {
 			original: paragraphText,

--- a/js/researches/getParagraphLength.js
+++ b/js/researches/getParagraphLength.js
@@ -15,7 +15,7 @@ module.exports = function( paper ) {
 	paragraphs.map( function ( paragraph ) {
 		paragraphsLength.push( {
 			wordCount: countWords( paragraph ),
-			paragraph: paragraph
+			text: paragraph
 		} );
 	} );
 

--- a/js/stringProcessing/stripHTMLTags.js
+++ b/js/stringProcessing/stripHTMLTags.js
@@ -2,6 +2,11 @@
 
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 
+var blockElements = require( "../helpers/html.js" ).blockElements;
+
+var blockElementStartRegex = new RegExp( "^<(" + blockElements.join( "|" ) + ")[^>]*?>", "i" );
+var blockElementEndRegex = new RegExp( "</(" + blockElements.join( "|" ) + ")[^>]*?>$", "i" );
+
 /**
  * Strip incomplete tags within a text. Strips an endtag at the beginning of a string and the start tag at the end of a
  * start of a string.
@@ -11,6 +16,18 @@ var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 var stripIncompleteTags = function( text ) {
 	text = text.replace( /^(<\/([^>]+)>)+/i, "" );
 	text = text.replace( /(<([^\/>]+)>)+$/i, "" );
+	return text;
+};
+
+/**
+ * Removes the block element tags at the beginning and end of a string and returns this string.  
+ *
+ * @param {string} text The unformatted string.
+ * @returns {string} The text with removed HTML begin and end block elements
+ */
+var stripBlockTagsAtStartEnd = function( text ) {
+	text = text.replace( blockElementStartRegex, "" );
+	text = text.replace( blockElementEndRegex, "" );
 	return text;
 };
 
@@ -28,5 +45,6 @@ var stripFullTags = function( text ) {
 
 module.exports = {
 	stripFullTags: stripFullTags,
-	stripIncompleteTags: stripIncompleteTags
+	stripIncompleteTags: stripIncompleteTags,
+	stripBlockTagsAtStartEnd: stripBlockTagsAtStartEnd
 };

--- a/js/stringProcessing/stripHTMLTags.js
+++ b/js/stringProcessing/stripHTMLTags.js
@@ -20,7 +20,7 @@ var stripIncompleteTags = function( text ) {
 };
 
 /**
- * Removes the block element tags at the beginning and end of a string and returns this string.  
+ * Removes the block element tags at the beginning and end of a string and returns this string.
  *
  * @param {string} text The unformatted string.
  * @returns {string} The text with removed HTML begin and end block elements


### PR DESCRIPTION
This makes sure we don't include the block elements in the markings of the paragraph, by removing them from the marked string if the block element is at the begin or end. This makes sure the mark is placed inside the block elements, without changing the textstring. 
Since all other markers are sentence based, this is the only assessment with this issue. 

Fixes #816 

For testing: Use the text mentioned in the issue and mark the long paragraph. 