### PR TITLE
Adds horizontal ellipsis as sentence terminator

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -17,7 +17,7 @@ var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyN
 
 // All characters that indicate a sentence delimiter.
 var fullStop = ".";
-var sentenceDelimiters = "?!;";
+var sentenceDelimiters = "?!;\u2026";
 var newLines = "\n\r|\n|\r";
 
 var fullStopRegex = new RegExp( "^[" + fullStop + "]$" );

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -239,4 +239,12 @@ describe("Get sentences from text", function(){
 
 		testGetSentences( testCases );
 	} );
+	it( "should accept the horizontal ellipsis as sentence terminator", function() {
+		var testCases = [
+			{
+				input: "This is the first sentence… Followed by a second one.",
+				expected: [ "This is the first sentence…", "Followed by a second one." ]
+			}
+		]
+	} );
 });


### PR DESCRIPTION
Fixes #799 
This adds the `…` (horizontal ellipsis) as a valid sentence terminator.

For testing, use a sentence with …