### PR TITLE
Multiple indices of the same auxiliary are all matched

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -25,18 +25,24 @@ var ingExclusionArray = [ "king", "cling", "ring", "being" ];
 var irregularExclusionArray = [ "get", "gets", "getting", "got", "gotten" ];
 
 /**
- * Returns the indices of a string in a sentence. If it is found multiple times, will return multiple indices.
+ * Returns the indices of a string in a sentence. If it is found multiple times, it will return multiple indices.
  *
  * @param {string} part The part to find in the sentence.
  * @param {string} sentence The sentence to check for parts.
  * @returns {Array} All indices found.
  */
 function getIndicesOf( part, sentence ) {
-	var startIndex = 0, searchStrLen = part.length;
+	var startIndex = 0;
+	var searchStringLength = part.length;
 	var index, indices = [];
 	while ( ( index = sentence.indexOf( part, startIndex ) ) > -1 ) {
-		indices.push( index );
-		startIndex = index + searchStrLen;
+		indices.push(
+			{
+				index: index,
+				match: part
+			}
+		);
+		startIndex = index + searchStringLength;
 	}
 	return indices;
 }
@@ -54,14 +60,10 @@ var matchArray = function( sentence, matches ) {
 
 	forEach( matches, function( part ) {
 		part = stripSpaces( part );
-		var indices = getIndicesOf( part, sentence );
-
 		if ( !matchWordInSentence( part, sentence ) ) {
 			return;
 		}
-		forEach( indices, function( index ) {
-			matchedParts.push( { index: index, match: part } );
-		} );
+		matchedParts = matchedParts.concat( getIndicesOf( part, sentence ) );
 	} );
 
 	return matchedParts;

--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -25,6 +25,23 @@ var ingExclusionArray = [ "king", "cling", "ring", "being" ];
 var irregularExclusionArray = [ "get", "gets", "getting", "got", "gotten" ];
 
 /**
+ * Returns the indices of a string in a sentence. If it is found multiple times, will return multiple indices.
+ *
+ * @param {string} part The part to find in the sentence.
+ * @param {string} sentence The sentence to check for parts.
+ * @returns {Array} All indices found.
+ */
+function getIndicesOf( part, sentence ) {
+	var startIndex = 0, searchStrLen = part.length;
+	var index, indices = [];
+	while ( ( index = sentence.indexOf( part, startIndex ) ) > -1 ) {
+		indices.push( index );
+		startIndex = index + searchStrLen;
+	}
+	return indices;
+}
+
+/**
  * Matches string with an array, returns the word and the index it was found on.
  *
  * @param {string} sentence The sentence to match the strings from the array to.
@@ -37,12 +54,14 @@ var matchArray = function( sentence, matches ) {
 
 	forEach( matches, function( part ) {
 		part = stripSpaces( part );
+		var indices = getIndicesOf( part, sentence );
 
 		if ( !matchWordInSentence( part, sentence ) ) {
 			return;
 		}
-
-		matchedParts.push( { index: sentence.indexOf( part ), match: part } );
+		forEach( indices, function( index ) {
+			matchedParts.push( { index: index, match: part } );
+		} );
 	} );
 
 	return matchedParts;

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -353,5 +353,12 @@ describe( "detecting passive voice in sentences", function() {
 			total: 1,
 			passives: []
 		} );
-	})
+	});
+
+	it( "returns no passive sentence when the subsentence has no auxiliary, when the auxiliary is used multiple times", function () {
+		// Passive: no passive, auxiliary: was
+		paper = new Paper("He thought she was the one who knew about the six buried in his back yard, but he was wrong.");
+		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
+	});
+
 } );

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -357,7 +357,7 @@ describe( "detecting passive voice in sentences", function() {
 
 	it( "returns no passive sentence when the subsentence has no auxiliary, when the auxiliary is used multiple times", function () {
 		// Passive: no passive, auxiliary: was
-		paper = new Paper("He thought she was the one who knew about the six buried in his back yard, but he was wrong.");
+		paper = new Paper( "He thought she was the one who knew about the six buried in his back yard, but he was wrong." );
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	});
 


### PR DESCRIPTION
Fixes #793. 

The problem in 793 was that the index of the second occurence of 'was' was discarded, since we only saved the first index of an auxiliary. 
This makes sure all indices are saved for auxiliaries, so we don't report sentences being passive, when they are not. 
Because the sentence was not split on the second 'was', the subsentenced validated since there was a auxiliary in there, but only after a verb ending in -ed. 

For testing, use a sentence with the same auxiliary twice (like the example in 793). 