### PR TITLE
Improves keyword density check by not relying on wordboundary

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -1,5 +1,5 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
+var countWordOccurrences = require( "../stringProcessing/countWordOccurrences.js" );
 var countWords = require( "../stringProcessing/countWords.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
 var inRange = require( "../helpers/inRange.js" );
@@ -86,7 +86,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 var keywordDensityAssessment = function( paper, researcher, i18n ) {
 
 	var keywordDensity = researcher.getResearch( "getKeywordDensity" );
-	var keywordCount = matchWords( paper.getText(), paper.getKeyword(), paper.getLocale() );
+	var keywordCount = countWordOccurrences( paper.getText(), paper.getKeyword(), paper.getLocale() );
 
 	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n, keywordCount );
 	var assessmentResult = new AssessmentResult();

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -1,11 +1,7 @@
 /** @module analyses/getKeywordDensity */
 
-var filter = require( "lodash/filter" );
-
 var countWords = require( "../stringProcessing/countWords.js" );
-var transliterate = require ( "../stringProcessing/transliterate.js" );
-
-var getWords = require( "../stringProcessing/getWords.js" );
+var countWordOccurrences = require( "../stringProcessing/countWordOccurrences.js" );
 
 /**
  * Calculates the keyword density .
@@ -21,10 +17,6 @@ module.exports = function( paper ) {
 	if ( wordCount === 0 ) {
 		return 0;
 	}
-	var words = getWords( text );
-	var keywordCount = filter( words, function( word ) {
-		return ( word === keyword || transliterate( word, locale ) === keyword );
-	} );
-
-	return ( keywordCount.length / wordCount ) * 100;
+	var keywordCount = countWordOccurrences( text, keyword, locale );
+	return ( keywordCount / wordCount ) * 100;
 };

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -1,7 +1,11 @@
 /** @module analyses/getKeywordDensity */
 
+var filter = require( "lodash/filter" );
+
 var countWords = require( "../stringProcessing/countWords.js" );
-var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
+var transliterate = require ( "../stringProcessing/transliterate.js" );
+
+var getWords = require( "../stringProcessing/getWords.js" );
 
 /**
  * Calculates the keyword density .
@@ -17,6 +21,10 @@ module.exports = function( paper ) {
 	if ( wordCount === 0 ) {
 		return 0;
 	}
-	var keywordCount = matchWords( text, keyword, locale );
-	return ( keywordCount / wordCount ) * 100;
+	var words = getWords( text );
+	var keywordCount = filter( words, function( word ) {
+		return ( word === keyword || transliterate( word, locale ) === keyword );
+	} );
+
+	return ( keywordCount.length / wordCount ) * 100;
 };

--- a/js/stringProcessing/countWordOccurrences.js
+++ b/js/stringProcessing/countWordOccurrences.js
@@ -1,0 +1,20 @@
+var filter = require( "lodash/filter" );
+
+var transliterate = require ( "./transliterate.js" );
+var getWords = require( "./getWords.js" );
+
+/**
+ * Counts the number of occurrences of a word in a text.
+ *
+ * @param {String} text The text to count the word in.
+ * @param {String} wordToMatch The word to check in the text.
+ * @param {String} locale The locale used for transliteration.
+ * @returns {Number} The number of occurrences.
+ */
+module.exports = function( text, wordToMatch, locale ) {
+	var words = getWords( text );
+	var count = filter( words, function( word ) {
+		return ( wordToMatch === word || transliterate( wordToMatch, locale ) === word );
+	} );
+	return count.length;
+};

--- a/spec/researches/keywordDensitySpec.js
+++ b/spec/researches/keywordDensitySpec.js
@@ -25,5 +25,7 @@ describe("Test for counting the keyword density in a text", function(){
 		expect( keywordDensity( mockPaper ) ).toBe( 7.6923076923076925 );
 		mockPaper = new Paper( "<img src='http://image.com/image.png'>", {keyword: "key&word"} );
 		expect( keywordDensity( mockPaper ) ).toBe( 0 );
+		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", {keyword: "keyword"} );
+		expect( keywordDensity( mockPaper ) ).toBe( 30 );
 	});
 });

--- a/spec/stringProcessing/countWordOccurrencesSpec.js
+++ b/spec/stringProcessing/countWordOccurrencesSpec.js
@@ -1,0 +1,9 @@
+var countWordOccurrences = require( "../../js/stringProcessing/countWordOccurrences.js" );
+
+describe( "Counts words in text and returns occurrences", function(){
+	it( "returns counts", function() {
+		expect( countWordOccurrences( "this is a text", "text", "en_EN") ).toBe( 1 );
+		expect( countWordOccurrences( "this is a text", "thïs", "nl_NL") ).toBe( 1 );
+		expect( countWordOccurrences( "this is a text text", "text", "nl_NL") ).toBe( 2 );
+	} );
+} );


### PR DESCRIPTION
Fixes #203

Simply changing the wordboundary regex would give unpredictable results with empty keywords and spaces. 
This PR implements a check where we match per word, like we already did for the passive voice analysis. This makes sure a keyword is matched if it is followed directly by another keyword. 

For testing: Use a sentence with the keyword 2 or more times after eachother. Make sure you use 100+ words to trigger the keyword density check. 