### PR TITLE
Removes duplicate single quote normalization

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -289,7 +289,6 @@ var getExceptions = function( subSentence, verbs ) {
  * @returns {boolean} True if passive is found, false if no passive is found.
  */
 var determinePassives = function( subSentence ) {
-	subSentence = normalizeSingleQuotes( subSentence );
 
 	var regularVerbs = getRegularVerbs( subSentence );
 	var irregularVerbs = getIrregularVerbs( subSentence );


### PR DESCRIPTION
Removes single quote normalization in subsentences, because these quotes are already normalized in complete sentences. 
Fixes #831 