### PR TITLE
Improves language check in assessments

### DIFF
--- a/js/assessments/fleschReadingEaseAssessment.js
+++ b/js/assessments/fleschReadingEaseAssessment.js
@@ -1,6 +1,10 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 var inRange = require( "lodash/inRange" );
 
+var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
+
+var availableLanguages = [ "en" ];
+
 /**
  * Calculates the assessment result based on the fleschReadingScore
  * @param {int} fleschReadingScore The score from the fleschReadingtest
@@ -104,6 +108,7 @@ module.exports = {
 	identifier: "fleschReadingEase",
 	getResult: fleschReadingEaseAssessment,
 	isApplicable: function( paper ) {
-		return ( paper.getLocale().indexOf( "en_" ) > -1 && paper.hasText() );
+		var isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
+		return ( isLanguageAvailable && paper.hasText() );
 	}
 };

--- a/js/assessments/passiveVoiceAssessment.js
+++ b/js/assessments/passiveVoiceAssessment.js
@@ -8,6 +8,9 @@ var marker = require( "../markers/addMark.js" );
 
 var map = require( "lodash/map" );
 
+var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
+var availableLanguages = [ "en" ];
+
 /**
  * Calculates the result based on the number of sentences and passives.
  * @param {object} passiveVoice The object containing the number of sentences and passives
@@ -121,7 +124,8 @@ module.exports = {
 	identifier: "passiveVoice",
 	getResult: paragraphLengthAssessment,
 	isApplicable: function( paper ) {
-		return ( paper.getLocale().indexOf( "en_" ) > -1 && paper.hasText() );
+		var isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
+		return ( isLanguageAvailable && paper.hasText() );
 	},
 	getMarks: passiveVoiceMarker
 };

--- a/js/assessments/sentenceBeginningsAssessment.js
+++ b/js/assessments/sentenceBeginningsAssessment.js
@@ -1,5 +1,4 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var getLanguage = require( "../helpers/getLanguage.js" );
 var stripTags = require( "../stringProcessing/stripHTMLTags" ).stripIncompleteTags;
 
 var partition = require( "lodash/partition" );

--- a/js/assessments/sentenceBeginningsAssessment.js
+++ b/js/assessments/sentenceBeginningsAssessment.js
@@ -13,6 +13,9 @@ var marker = require( "../markers/addMark.js" );
 
 var maximumConsecutiveDuplicates = 2;
 
+var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
+var availableLanguages = [ "en", "de", "es", "fr" ];
+
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.
  * @param {array} sentenceBeginnings The array containing the objects containing the beginning words and counts.
@@ -111,9 +114,9 @@ module.exports = {
 	identifier: "sentenceBeginnings",
 	getResult: sentenceBeginningsAssessment,
 	isApplicable: function( paper ) {
-		var locale = getLanguage( paper.getLocale() );
-		var validLocale = locale === "en" || locale === "de" || locale === "fr" || locale === "es";
-		return ( validLocale && paper.hasText() );
+
+		var isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
+		return ( isLanguageAvailable && paper.hasText() );
 	},
 	getMarks: sentenceBeginningMarker
 };

--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -3,10 +3,12 @@ var formatNumber = require( "../helpers/formatNumber.js" );
 var map = require( "lodash/map" );
 var inRange = require( "../helpers/inRange.js" ).inRangeStartInclusive;
 var stripTags = require( "../stringProcessing/stripHTMLTags" ).stripIncompleteTags;
-var getLanguage = require( "../helpers/getLanguage.js" );
 
 var Mark = require( "../values/Mark.js" );
 var marker = require( "../markers/addMark.js" );
+
+var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
+var availableLanguages = [ "en", "de", "es", "fr" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.
@@ -122,9 +124,8 @@ module.exports = {
 	identifier: "textTransitionWords",
 	getResult: transitionWordsAssessment,
 	isApplicable: function( paper ) {
-		var locale = getLanguage( paper.getLocale() );
-		var validLocale = locale === "en" || locale === "de" || locale === "es" || locale === "fr";
-		return ( validLocale && paper.hasText() );
+		var isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
+		return ( isLanguageAvailable && paper.hasText() );
 	},
 	getMarks: transitionWordsMarker
 };

--- a/js/helpers/getLanguageAvailability.js
+++ b/js/helpers/getLanguageAvailability.js
@@ -1,0 +1,15 @@
+var indexOf = require( "lodash/indexOf" );
+
+var getLanguage = require( "./getLanguage.js" );
+
+/**
+ * Checks whether the language of the locale is available.
+ *
+ * @param {string} locale The locale to get the language from.
+ * @param {array} languages The list of languages to match.
+ * @returns {boolean} Returns true if the language is found in the array.
+ */
+module.exports = function( locale, languages ) {
+	var language = getLanguage( locale );
+	return indexOf( languages, language ) > -1;
+};

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -79,4 +79,16 @@ describe( "An assessment for transition word percentage", function(){
 		assessment = transitionWordsAssessment.isApplicable( mockPaper );
 		expect( assessment ).toBe( false );
 	} );
+
+	it( "is applicable for supported locales, en_US in this case", function(){
+		mockPaper = new Paper( "This is a string", { locale: "en_US" } );
+		assessment = transitionWordsAssessment.isApplicable( mockPaper );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for unsupported locales, nl_NL in this case", function(){
+		mockPaper = new Paper( "This is a string", { locale: "nl_NL" } );
+		assessment = transitionWordsAssessment.isApplicable( mockPaper );
+		expect( assessment ).toBe( false );
+	} );
 } );

--- a/spec/helpers/getLanguageAvailabilitySpec.js
+++ b/spec/helpers/getLanguageAvailabilitySpec.js
@@ -1,0 +1,26 @@
+var getLanguageAvailability = require( "../../js/helpers/getLanguageAvailability.js" );
+describe( "checks is a language is available, based on locale and a given list", function() {
+
+	it( "Returns true when a language is available", function() {
+		var locale = "en_US";
+		expect( getLanguageAvailability( locale, [ "en" ] ) ).toBe( true );
+		expect( getLanguageAvailability( locale, [ "nl", "de", "en" ] ) ).toBe( true );
+	} );
+	it( "Returns false when a language isn't available", function() {
+		var locale = "en_US";
+		expect( getLanguageAvailability( locale, [ "nl" ] ) ).toBe( false );
+		expect( getLanguageAvailability( locale, [ "nl", "de", "fr" ] ) ).toBe( false );
+	} );
+
+	it( "Returns true when a language is available with a partial locale", function() {
+		var locale = "en";
+		expect( getLanguageAvailability( locale, [ "en" ] ) ).toBe( true );
+		expect( getLanguageAvailability( locale, [ "en", "de", "fr" ] ) ).toBe( true );
+	} );
+
+	it( "Returns false when an empty locale is passed", function() {
+		var locale = "";
+		expect( getLanguageAvailability( locale, [ "en" ] ) ).toBe( false );
+		expect( getLanguageAvailability( locale, [ "en", "de", "fr" ] ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Fixes #838 
This creates a uniform way of getting the availability of languages used in assessments. 

Replaces the current checks in the isApplicable of the assessment where we would match a bunch of languages. 

For testing: Change the locale in the stand alone and see if all the assessments are available as expected. 