### PR TITLE
Add exclusionwords for english syllable count

### DIFF
--- a/js/config/syllables.js
+++ b/js/config/syllables.js
@@ -21,14 +21,15 @@ module.exports = function() {
 			}
 		},
 		exclusionWords: [
+			{ word: "business", syllables: 2 },
+			{ word: "coheiress", syllables: 3 },
+			{ word: "heiress", syllables: 2 },
+			// The abbreviation i.e. should be counted as 2 syllables.
+			{ word: "i.e", syllables: 2},
 			{ word: "shoreline", syllables: 2 },
 			{ word: "simile", syllables: 3 },
-			{ word: "business", syllables: 2 },
-			{ word: "heiress", syllables: 2 },
-			{ word: "coheiress", syllables: 3 },
 			{ word: "unheired", syllables: 2 },
-			// The abbreviation i.e. should be counted as 2 syllables.
-			{ word: "i.e", syllables: 2}
+			{ word: "wednesday", syllables: 2 }
 		],
 		vowels: 'aeiouy'
 	};

--- a/js/config/syllables.js
+++ b/js/config/syllables.js
@@ -23,6 +23,7 @@ module.exports = function() {
 		exclusionWords: [
 			{ word: "business", syllables: 2 },
 			{ word: "coheiress", syllables: 3 },
+			{ word: "colonel", syllables: 2 },
 			{ word: "heiress", syllables: 2 },
 			// The abbreviation i.e. should be counted as 2 syllables.
 			{ word: "i.e", syllables: 2},


### PR DESCRIPTION
Adds 'colonel' and 'wednesday' to the exclusionwords, since they both cannot be counted with regular syllable counters. 