### PR TITLE
Creates Flesch Reading for Dutch.

### DIFF
--- a/js/assessments/fleschReadingEaseAssessment.js
+++ b/js/assessments/fleschReadingEaseAssessment.js
@@ -3,7 +3,7 @@ var inRange = require( "lodash/inRange" );
 
 var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
 
-var availableLanguages = [ "en" ];
+var availableLanguages = [ "en", "nl" ];
 
 /**
  * Calculates the assessment result based on the fleschReadingScore

--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -40,13 +40,12 @@ module.exports = function( paper ) {
 	switch( language ) {
 		case "nl":
 			var syllablesPer100Words = numberOfSyllables * ( 100 / numberOfWords );
-
 			score = 206.84 - ( 0.77 * syllablesPer100Words ) - ( 0.93 * ( numberOfWords / numberOfSentences ) );
-		break;
+			break;
 		case "en":
 		default:
 			score = 206.835 - ( 1.015 * ( numberOfWords / numberOfSentences ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );
-		break;
+			break;
 	}
 
 

--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -13,10 +13,10 @@ var getLanguage = require( "../helpers/getLanguage.js" );
  *
  * @param {number} numberOfWords The number of words.
  * @param {number} numberOfSentences The number of sentences.
- * @returns {number} The average number of words in sentences. 
+ * @returns {number} The average number of words in sentences.
  */
 var getAverageWords = function( numberOfWords, numberOfSentences ) {
-	return numberOfWords / numberOfSentences
+	return numberOfWords / numberOfSentences;
 };
 
 /**

--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -9,6 +9,17 @@ var formatNumber = require( "../helpers/formatNumber.js" );
 var getLanguage = require( "../helpers/getLanguage.js" );
 
 /**
+ * Calculates the average number of words per sentence.
+ *
+ * @param {number} numberOfWords The number of words.
+ * @param {number} numberOfSentences The number of sentences.
+ * @returns {number} The average number of words in sentences. 
+ */
+var getAverageWords = function( numberOfWords, numberOfSentences ) {
+	return numberOfWords / numberOfSentences
+};
+
+/**
  * This calculates the fleschreadingscore for a given text
  * The formula used:
  * 206.835 - 1.015 (total words / total sentences) - 84.6 ( total syllables / total words);
@@ -37,14 +48,15 @@ module.exports = function( paper ) {
 	}
 
 	var numberOfSyllables = countSyllables( text, locale );
+	var averageWordsPerSentence = getAverageWords( numberOfWords, numberOfSentences );
 	switch( language ) {
 		case "nl":
 			var syllablesPer100Words = numberOfSyllables * ( 100 / numberOfWords );
-			score = 206.84 - ( 0.77 * syllablesPer100Words ) - ( 0.93 * ( numberOfWords / numberOfSentences ) );
+			score = 206.84 - ( 0.77 * syllablesPer100Words ) - ( 0.93 * ( averageWordsPerSentence  ) );
 			break;
 		case "en":
 		default:
-			score = 206.835 - ( 1.015 * ( numberOfWords / numberOfSentences ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );
+			score = 206.835 - ( 1.015 * ( averageWordsPerSentence ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );
 			break;
 	}
 

--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -6,6 +6,8 @@ var countWords = require( "../stringProcessing/countWords.js" );
 var countSyllables = require( "../stringProcessing/countSyllables.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
 
+var getLanguage = require( "../helpers/getLanguage.js" );
+
 /**
  * This calculates the fleschreadingscore for a given text
  * The formula used:
@@ -15,8 +17,10 @@ var formatNumber = require( "../helpers/formatNumber.js" );
  * @returns {number} the score of the fleschreading test
  */
 module.exports = function( paper ) {
+	var score;
 	var text = paper.getText();
 	var locale = paper.getLocale();
+	var language = getLanguage( locale );
 	if ( text === "" ) {
 		return 0;
 	}
@@ -33,8 +37,18 @@ module.exports = function( paper ) {
 	}
 
 	var numberOfSyllables = countSyllables( text, locale );
+	switch( language ) {
+		case "nl":
+			var syllablesPer100Words = numberOfSyllables * ( 100 / numberOfWords );
 
-	var score = 206.835 - ( 1.015 * ( numberOfWords / numberOfSentences ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );
+			score = 206.84 - ( 0.77 * syllablesPer100Words ) - ( 0.93 * ( numberOfWords / numberOfSentences ) );
+		break;
+		case "en":
+		default:
+			score = 206.835 - ( 1.015 * ( numberOfWords / numberOfSentences ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );
+		break;
+	}
+
 
 	return formatNumber( score );
 };

--- a/spec/researches/fleschReadingSpec.js
+++ b/spec/researches/fleschReadingSpec.js
@@ -21,3 +21,15 @@ describe( "A test to check the filtere of digits", function() {
 		expect( fleschFunction( mockPaper ) ).toBe( fleschFunction( mockPaperWithDigits ) );
 	});
 });
+
+describe( "A test that uses the Dutch Flesch Reading", function() {
+	it( "returns a score", function() {
+		var mockPaper = new Paper( "Een kort stukje tekst in het Nederlands om te testen.", { locale: "nl_NL" } );
+		expect( fleschFunction( mockPaper ) ).toBe( 89.7 );
+	} );
+
+	it( "returns a score", function() {
+		var mockPaper = new Paper( "Dit is wat meer tekst om te testen. Het bestaat uit meerdere zinnen waardoor we een andere score moeten krijgen.", { locale: "nl_NL" } );
+		expect( fleschFunction( mockPaper ) ).toBe( 78.2 );
+	} );
+} );


### PR DESCRIPTION
Fixes #496.

This enables the Flesch Reading to be used for Dutch, with the correct formula. 

For testing, in the standalone you can set locale to nl_NL, then the Flesch Reading should be available.