### PR TITLE
Fixes quote normalization

### DIFF
--- a/js/stringProcessing/quotes.js
+++ b/js/stringProcessing/quotes.js
@@ -5,7 +5,7 @@
  * @returns {string} The normalized text.
  */
 function normalizeSingleQuotes( text ) {
-	return text.replace( /‘|’|‛|`/g, "'" );
+	return text.replace( /[‘’‛`]/g, "'" );
 }
 
 /**
@@ -15,7 +15,7 @@ function normalizeSingleQuotes( text ) {
  * @returns {string} The normalized text.
  */
 function normalizeDoubleQuotes( text ) {
-	return text.replace( /“|”|〝|〞|〟|‟|„/g, "\"" );
+	return text.replace( /[“”〝〞〟‟„]/g, "\"" );
 }
 
 /**

--- a/js/stringProcessing/quotes.js
+++ b/js/stringProcessing/quotes.js
@@ -5,11 +5,7 @@
  * @returns {string} The normalized text.
  */
 function normalizeSingleQuotes( text ) {
-	return text
-		.replace( "‘", "'" )
-		.replace( "’", "'" )
-		.replace( "‛", "'" )
-		.replace( "`", "'" );
+	return text.replace( /‘|’|‛|`/g, "'" );
 }
 
 /**
@@ -19,14 +15,7 @@ function normalizeSingleQuotes( text ) {
  * @returns {string} The normalized text.
  */
 function normalizeDoubleQuotes( text ) {
-	return text
-		.replace( "“", "\"" )
-		.replace( "”", "\"" )
-		.replace( "〝", "\"" )
-		.replace( "〞", "\"" )
-		.replace( "〟", "\"" )
-		.replace( "‟", "\"" )
-		.replace( "„", "\"" );
+	return text.replace( /“|”|〝|〞|〟|‟|„/g, "\"" );
 }
 
 /**


### PR DESCRIPTION
## Summary

Before, the quote normalization would only normalize the first occurrence of a quote. Now, using a global regex, it normalizes all occurrences.

## Test instructions

Please benchmark the passive voice assessment to check whether the regexes in this fix slow down the assessment. 

