### PR TITLE
fix for meta-box overlap in snippet editor on repository https://gith…

### DIFF
--- a/css/_snippet-editor.scss
+++ b/css/_snippet-editor.scss
@@ -2,7 +2,7 @@
 @import "mixins";
 @import "icons";
 
-$snippet_width: 600px;
+$snippet_width: 100%;
 
 @mixin svg-caret-before($color) {
 	background-image: url(svg-icon-caret-right($color));
@@ -24,7 +24,7 @@ $snippet_width: 600px;
 	border-radius: 20px;
 	background-color: #fff;
 	position: relative;
-	width: $snippet_width + 40;
+	width: $snippet_width;
 }
 
 .snippet_container {


### PR DESCRIPTION
## Summary

I was trying to fix an issue on wordpress-seo branch and I was lead to this repository.
## Relevant technical choices:

See https://github.com/Yoast/wordpress-seo/issues/5253
## Test instructions

See https://github.com/Yoast/wordpress-seo/issues/5253

*

Fixes #

…ub.com/Yoast/wordpress-seo/issues/5253
