### PR TITLE
Fixes check for combinations with 'rid'

### DIFF
--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -223,11 +223,11 @@ var getIrregularVerbs = function( sentence ) {
 
 	return filter( irregularVerbs, function( verb ) {
 		// If rid is used with get, gets, getting, got or gotten, remove it.
-		if ( verb.match !== "rid" ) {
+		if ( verb !== "rid" ) {
 			return true;
 		}
 
-		return hasExcludedIrregularVerb( sentence );
+		return !hasExcludedIrregularVerb( sentence );
 	} );
 };
 

--- a/js/researches/getPassiveVoice.js
+++ b/js/researches/getPassiveVoice.js
@@ -227,7 +227,7 @@ var getIrregularVerbs = function( sentence ) {
 			return true;
 		}
 
-		return !hasExcludedIrregularVerb( sentence );
+		return ! hasExcludedIrregularVerb( sentence );
 	} );
 };
 

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -361,4 +361,13 @@ describe( "detecting passive voice in sentences", function() {
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );
 	});
 
+	it( "returns no passive sentence when there is an exception with 'rid'", function () {
+		// Passive: no passive, auxiliary: got
+		paper = new Paper( "He got rid of it" );
+		expect( passiveVoice( paper ) ).toEqual( {
+			total: 1,
+			passives: []
+		} );
+	});
+
 } );


### PR DESCRIPTION
This fixes an issue where 'got rid' was seen as a passive sentence when it should not be passive. 


For testing:
'He got rid of it should now not seen as passive