### PR TITLE
Adds german to flesch reading

### DIFF
--- a/js/assessments/fleschReadingEaseAssessment.js
+++ b/js/assessments/fleschReadingEaseAssessment.js
@@ -3,7 +3,7 @@ var inRange = require( "lodash/inRange" );
 
 var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
 
-var availableLanguages = [ "en", "nl" ];
+var availableLanguages = [ "en", "nl", "de" ];
 
 /**
  * Calculates the assessment result based on the fleschReadingScore

--- a/js/researches/calculateFleschReading.js
+++ b/js/researches/calculateFleschReading.js
@@ -54,6 +54,9 @@ module.exports = function( paper ) {
 			var syllablesPer100Words = numberOfSyllables * ( 100 / numberOfWords );
 			score = 206.84 - ( 0.77 * syllablesPer100Words ) - ( 0.93 * ( averageWordsPerSentence  ) );
 			break;
+		case "de":
+			score = 180 - averageWordsPerSentence - ( 58.5 * numberOfSyllables / numberOfWords );
+			break;
 		case "en":
 		default:
 			score = 206.835 - ( 1.015 * ( averageWordsPerSentence ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );

--- a/spec/researches/fleschReadingSpec.js
+++ b/spec/researches/fleschReadingSpec.js
@@ -33,3 +33,15 @@ describe( "A test that uses the Dutch Flesch Reading", function() {
 		expect( fleschFunction( mockPaper ) ).toBe( 78.2 );
 	} );
 } );
+
+describe( "A test that uses the German Flesch Reading", function() {
+	it( "returns a score", function() {
+		var mockPaper = new Paper( "Zero Hour ist eine nach kanadischer Idee in Großbritannien produzierte dokumentarische Fernsehreihe die auf dem History Channel in Kanada.", { locale: "de_DE" } );
+		expect( fleschFunction( mockPaper ) ).toBe( 25.5 );
+	} );
+
+	it( "returns a score", function() {
+		var mockPaper = new Paper( "Unterhalb der Szene, die aus plastischen Figuren besteht, erkennt man wieder Fruchtornament.", { locale: "de_DE" } );
+		expect( fleschFunction( mockPaper ) ).toBe( 46.1 );
+	} );
+} );


### PR DESCRIPTION
This adds german to the Flesch Reading researcher. 

For testing:
In the standalone example set the locale to de_DE and check the flesch reading. 

Fixes #735