### PR TITLE
Reverts keyword density to match key phrases

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -1,5 +1,5 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var countWordOccurrences = require( "../stringProcessing/countWordOccurrences.js" );
+var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
 var countWords = require( "../stringProcessing/countWords.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
 var inRange = require( "../helpers/inRange.js" );
@@ -85,7 +85,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
  */
 var keywordDensityAssessment = function( paper, researcher, i18n ) {
 	var keywordDensity = researcher.getResearch( "getKeywordDensity" );
-	var keywordCount = countWordOccurrences( paper.getText(), paper.getKeyword(), paper.getLocale() );
+	var keywordCount = matchWords( paper.getText(), paper.getKeyword(), paper.getLocale() );
 
 	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n, keywordCount );
 	var assessmentResult = new AssessmentResult();

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -1,13 +1,13 @@
 /** @module analyses/getKeywordDensity */
 
 var countWords = require( "../stringProcessing/countWords.js" );
-var countWordOccurrences = require( "../stringProcessing/countWordOccurrences.js" );
+var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
 
 /**
  * Calculates the keyword density .
  *
  * @param {object} paper The paper containing keyword and text.
-  * @returns {number} The keyword density.
+ * @returns {number} The keyword density.
  */
 module.exports = function( paper ) {
 	var keyword = paper.getKeyword();
@@ -17,6 +17,7 @@ module.exports = function( paper ) {
 	if ( wordCount === 0 ) {
 		return 0;
 	}
-	var keywordCount = countWordOccurrences( text, keyword, locale );
+
+	var keywordCount = matchWords( text, keyword, locale );
 	return ( keywordCount / wordCount ) * 100;
 };

--- a/spec/researches/keywordDensitySpec.js
+++ b/spec/researches/keywordDensitySpec.js
@@ -25,7 +25,5 @@ describe("Test for counting the keyword density in a text", function(){
 		expect( keywordDensity( mockPaper ) ).toBe( 7.6923076923076925 );
 		mockPaper = new Paper( "<img src='http://image.com/image.png'>", {keyword: "key&word"} );
 		expect( keywordDensity( mockPaper ) ).toBe( 0 );
-		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", {keyword: "keyword"} );
-		expect( keywordDensity( mockPaper ) ).toBe( 30 );
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/Yoast/wordpress-seo/issues/5485

This reverts the fix for consecutive keywords( https://github.com/Yoast/YoastSEO.js/pull/829 ), because that broke keyword analysis with multiple keywords. 

For testing: use a keyphrase with 2 or more words. 

