### PR TITLE
Dt/keyword casesensitivity

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -1,5 +1,5 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var countWordOccurrences = require( "../stringProcessing/countWordOccurrences.js" );
+var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
 var countWords = require( "../stringProcessing/countWords.js" );
 var formatNumber = require( "../helpers/formatNumber.js" );
 var inRange = require( "../helpers/inRange.js" );
@@ -85,7 +85,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
  */
 var keywordDensityAssessment = function( paper, researcher, i18n ) {
 	var keywordDensity = researcher.getResearch( "getKeywordDensity" );
-	var keywordCount = countWordOccurrences( paper.getText(), paper.getKeyword(), paper.getLocale() );
+	var keywordCount = matchWords( paper.getText(), paper.getKeyword(), paper.getLocale() );
 
 	var keywordDensityResult = calculateKeywordDensityResult( keywordDensity, i18n, keywordCount );
 	var assessmentResult = new AssessmentResult();

--- a/js/researches/findKeywordInFirstParagraph.js
+++ b/js/researches/findKeywordInFirstParagraph.js
@@ -15,6 +15,6 @@ var escapeRegExp = require( "lodash/escapeRegExp" );
  */
 module.exports = function( paper ) {
 	var paragraph = matchParagraphs( paper.getText() );
-	var keyword = escapeRegExp( paper.getKeyword() );
+	var keyword = escapeRegExp( paper.getKeyword().toLocaleLowerCase() );
 	return wordMatch( paragraph[ 0 ], keyword, paper.getLocale() );
 };

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -1,7 +1,7 @@
 /** @module analyses/getKeywordDensity */
 
 var countWords = require( "../stringProcessing/countWords.js" );
-var countWordOccurrences = require( "../stringProcessing/countWordOccurrences.js" );
+var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
 
 /**
  * Calculates the keyword density .
@@ -17,6 +17,6 @@ module.exports = function( paper ) {
 	if ( wordCount === 0 ) {
 		return 0;
 	}
-	var keywordCount = countWordOccurrences( text, keyword, locale );
+	var keywordCount = matchWords( text, keyword, locale );
 	return ( keywordCount / wordCount ) * 100;
 };

--- a/js/researches/getKeywordDensity.js
+++ b/js/researches/getKeywordDensity.js
@@ -3,6 +3,8 @@
 var countWords = require( "../stringProcessing/countWords.js" );
 var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
 
+var escapeRegExp = require( "lodash/escapeRegExp" );
+
 /**
  * Calculates the keyword density .
  *
@@ -10,7 +12,7 @@ var matchWords = require( "../stringProcessing/matchTextWithWord.js" );
   * @returns {number} The keyword density.
  */
 module.exports = function( paper ) {
-	var keyword = paper.getKeyword();
+	var keyword = escapeRegExp( paper.getKeyword() );
 	var text = paper.getText();
 	var locale = paper.getLocale();
 	var wordCount = countWords( text );

--- a/js/researches/imageAltTags.js
+++ b/js/researches/imageAltTags.js
@@ -54,12 +54,12 @@ var matchAltProperties = function( imageMatches, keyword, locale ) {
 };
 
 /**
- * Checks the text for images, checks the type of each image and alttags for containing keywords
+ * Checks the text for images, checks the type of each image and alt attributes for containing keywords
  *
  * @param {Paper} paper The paper to check for images
  * @returns {object} Object containing all types of found images
  */
 module.exports = function( paper ) {
-	var keyword = escapeRegExp( paper.getKeyword() );
+	var keyword = escapeRegExp( paper.getKeyword().toLocaleLowerCase() );
 	return matchAltProperties( imageInText( paper.getText() ), keyword, paper.getLocale() );
 };

--- a/js/stringProcessing/matchTextWithWord.js
+++ b/js/stringProcessing/matchTextWithWord.js
@@ -4,6 +4,8 @@ var stripSomeTags = require( "../stringProcessing/stripNonTextTags.js" );
 var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyAllSpaces;
 var matchStringWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
 
+var escapeRegExp = require( "lodash/escapeRegExp" );
+
 /**
  * Returns the number of matches in a given string
  *
@@ -16,6 +18,8 @@ var matchStringWithTransliteration = require( "../stringProcessing/matchTextWith
 module.exports = function( text, wordToMatch, locale, extraBoundary ) {
 	text = stripSomeTags( text );
 	text = unifyWhitespace( text );
+	text = text.toLocaleLowerCase();
+	wordToMatch = escapeRegExp( wordToMatch.toLocaleLowerCase() );
 	var matches = matchStringWithTransliteration( text, wordToMatch, locale, extraBoundary );
 	return matches.length;
 };

--- a/js/stringProcessing/matchTextWithWord.js
+++ b/js/stringProcessing/matchTextWithWord.js
@@ -4,8 +4,6 @@ var stripSomeTags = require( "../stringProcessing/stripNonTextTags.js" );
 var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyAllSpaces;
 var matchStringWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
-
 /**
  * Returns the number of matches in a given string
  *
@@ -18,8 +16,6 @@ var escapeRegExp = require( "lodash/escapeRegExp" );
 module.exports = function( text, wordToMatch, locale, extraBoundary ) {
 	text = stripSomeTags( text );
 	text = unifyWhitespace( text );
-	text = text.toLocaleLowerCase();
-	wordToMatch = escapeRegExp( wordToMatch.toLocaleLowerCase() );
 	var matches = matchStringWithTransliteration( text, wordToMatch, locale, extraBoundary );
 	return matches.length;
 };

--- a/spec/researches/keywordDensitySpec.js
+++ b/spec/researches/keywordDensitySpec.js
@@ -25,9 +25,14 @@ describe("Test for counting the keyword density in a text", function(){
 		expect( keywordDensity( mockPaper ) ).toBe( 7.6923076923076925 );
 		mockPaper = new Paper( "<img src='http://image.com/image.png'>", {keyword: "key&word"} );
 		expect( keywordDensity( mockPaper ) ).toBe( 0 );
+		// consecutive keywords are skipped, so this will match 2 times.
 		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", {keyword: "keyword"} );
-		expect( keywordDensity( mockPaper ) ).toBe( 30 );
+		expect( keywordDensity( mockPaper ) ).toBe( 20 );
 		mockPaper = new Paper( "a string of text with the $keyword in it, density should be 7.7%", {keyword: "$keyword"} );
 		expect( keywordDensity( mockPaper ) ).toBe( 7.6923076923076925 );
+		mockPaper = new Paper( "a string of text with the Keyword in it, density should be 7.7%", {keyword: "keyword"} );
+		expect( keywordDensity( mockPaper ) ).toBe( 7.6923076923076925 );
+		mockPaper = new Paper( "a string of text with the Key word in it, density should be 7.14%", {keyword: "key word"} );
+		expect( keywordDensity( mockPaper ) ).toBe( 7.142857142857142 );
 	});
 });

--- a/spec/stringProcessing/wordMatchSpec.js
+++ b/spec/stringProcessing/wordMatchSpec.js
@@ -55,5 +55,9 @@ describe("Counts the occurences of a word in a string", function(){
 		expect( wordMatch( "Sed «keyword> dictum", "keyword" ) ).toBe( 1 );
 		expect( wordMatch( "Sed ‹keyword› dictum", "keyword" ) ).toBe( 1 );
 		expect( wordMatch( "", "keyword" ) ).toBe( 0 );
-	})
+	});
+
+	it( "should match keyphrases comprised of multiple words. ", function() {
+		expect( wordMatch( "text key word text", "key word" ) ).toBe( 1 );
+	});
 });


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Makes sure keywords are matched case insensitive. 

## Relevant technical choices:

* Added toLocaleLowercase for matching the keywords. 

## Test instructions

This PR can be tested by following these steps:

* Test with keywords with or without capitals. both should match the keywords in text. 

Fixes #891

