### PR TITLE
Prevents empty sentences from being marked

### DIFF
--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -103,6 +103,9 @@ module.exports = function( paper ) {
 		return getSentenceBeginning( sentence, firstWordExceptions );
 	} );
 
+	sentences = sentences.filter( function( sentence ) {
+		return getWords( stripSpaces( sentence ) ).length > 0
+	} );
 	sentenceBeginnings = filter( sentenceBeginnings );
 
 	return compareFirstWords( sentenceBeginnings, sentences );

--- a/js/researches/getSentenceBeginnings.js
+++ b/js/researches/getSentenceBeginnings.js
@@ -104,7 +104,7 @@ module.exports = function( paper ) {
 	} );
 
 	sentences = sentences.filter( function( sentence ) {
-		return getWords( stripSpaces( sentence ) ).length > 0
+		return getWords( stripSpaces( sentence ) ).length > 0;
 	} );
 	sentenceBeginnings = filter( sentenceBeginnings );
 

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -161,4 +161,9 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		var mockPaper = new Paper( '<img class="alignnone wp-image-514079 size-full" src="https://yoast-mercury.s3.amazonaws.com/uploads/2015/10/Twitter_analytics_FI.png" alt="" width="1200" height="628" />' );
 		expect( sentenceBeginnings( mockPaper ) ).toEqual( [] );
 	} );
+
+	it( "returns matching sentences if there is an 'empty' sentence", function() {
+		var mockPaper = new Paper( "\"A sentence with multiple terminators!\"). Test one. Test two. Test three." );
+		expect( sentenceBeginnings( mockPaper ) ).toContain( { word: 'test', count: 3, sentences: [ "Test one.", "Test two.", "Test three."] } );
+	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes a bug where wrong sentences could be marked in the sentence beginnings check. 

## Relevant technical choices:

* This PR adds a filter to check for empty sentences. If the sentence beginnings where empty because of the sentence was empty, it removed this entry from the sentence beginnings array. This makes sure we also remove the empty sentence, since it should never be marked. 

## Test instructions

This PR can be tested by following these steps:

* Use the following text  `"Fasten your seat belts!").
The1 most obvious change from the RSO Stuttgart to the ZKO is in the smaller orchestra size, which de-emphasized the strings relative to the wind instruments. The1 Of course, as in the piano concerto, no <em>vibrato</em> was allowed. The1 Meanwhile, this is getting accepted more widely — but still, those whirring, long string tones (particularly on "empty" strings) caught the listener's attention (and none of these tones sounded "bad" or disruptive — quite to the contrary!). The1 articulation was light throughout, devoid of heaviness, consequently "discharging" notes, but the interpretation was full of drive and momentum in the fast movements. Everything was stunningly vivid, "al fresco": in conducting, Norrington did not control every detail in the score, but shed light onto individual instrument groups for their prominent phrases. All of this, as of course the refreshing drum accents, was "as expected" — and yet, to me, this music sounded all-new, it made me discover numerous details that sofar went unnoticed! Some brief details on individual movements:
<ol style="list-style-type: upper-roman;">
 	<li>Here, the galloping was so intense at times that it reminded me of specific sequences of <a href="http://www.rolf-musicblog.net/orff-carmina-burana-beethoven-9th-geneva-2012-12-27/">Carl Orff's "Carmina burana"</a> ("... <em>ist geritten hinnen hinnen...</em>"); that movement received an extra applause!</li>
`
* Mark the sentence beginnings. The sentences should be marked correctly. This is best tested in the standalone where we can see the raw text with yoastmarks. 

Fixes #https://github.com/Yoast/wordpress-seo/issues/5635

