### PR TITLE
Add configuration to run tests with ES2015 syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [ "es2015" ],
+  "ignore": [
+    "js/templates.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "browser": "js/browser.js",
   "devDependencies": {
     "autoprefixer": "^6.4.0",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-register": "^6.16.3",
     "eslint-config-yoast": "^1.3.1",
     "eslint-plugin-react": "^6.0.0",
     "eslint-plugin-yoast": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "url": "https://github.com/Yoast/YoastSEO.js"
   },
   "scripts": {
-    "test": "istanbul test jasmine",
+    "test": "babel-node ./node_modules/istanbul/lib/cli.js test jasmine",
     "check-coverage": "istanbul check-coverage --statements 83 --branches 73 --functions 74 --lines 83"
   },
   "browser": "js/browser.js",
   "devDependencies": {
     "autoprefixer": "^6.4.0",
+    "babel-cli": "^6.16.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
     "eslint-config-yoast": "^1.3.1",

--- a/spec/appSpec.js
+++ b/spec/appSpec.js
@@ -12,7 +12,7 @@ App.prototype.removeLoadingDialog = function(){};
 App.prototype.initSnippetPreview = function(){};
 App.prototype.runAnalyzer = function(){};
 
-document = {};
+global.document = {};
 document.getElementById = function() { return mockElement; };
 
 // Makes lodash think this is a valid HTML element

--- a/spec/assessments/complexWordsSpec.js
+++ b/spec/assessments/complexWordsSpec.js
@@ -6,7 +6,7 @@ var i18n = factory.buildJed();
 describe( "an assessment returning complex words", function() {
 	it( "runs a test with 30% too many syllables", function(){
 		var mockPaper = new Paper( "" );
-		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher(
+		var result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher(
 			[ { sentence: "", words: [
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 2 },
@@ -30,7 +30,7 @@ describe( "an assessment returning complex words", function() {
 
 	it( "runs a test with exactly 5.3% too many syllables", function(){
 		var mockPaper = new Paper( "" );
-		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
+		var result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher( [
 			{ sentence: "", words: [
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 2 },
@@ -61,7 +61,7 @@ describe( "an assessment returning complex words", function() {
 
 	it( "runs a test with exactly 5% too many syllables", function(){
 		var mockPaper = new Paper( "" );
-		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
+		var result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher( [
 			{ sentence: "", words: [
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 2 },
@@ -93,7 +93,7 @@ describe( "an assessment returning complex words", function() {
 
 	it( "runs a test with 2.94% too many syllables", function(){
 		var mockPaper = new Paper( "" );
-		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
+		var result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher( [
 			{ sentence: "", words: [
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 2 },
@@ -139,7 +139,7 @@ describe( "an assessment returning complex words", function() {
 
 	it( "runs a test with 0% too many syllables", function(){
 		var mockPaper = new Paper( "" );
-		var result = wordComplexityAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
+		var result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher( [
 			{ sentence: "", words: [
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 2 },

--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -9,38 +9,38 @@ describe( "An assessment for the fleschReading", function(){
 
 		var paper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop and people were actually in a bit of trouble" );
 
-		var result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 63.9 ), i18n );
+		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 63.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 63.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
 
 		paper = new Paper( "A piece of text to calculate scores." );
 
-		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 78.9 ), i18n );
+		result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 78.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 78.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. " );
 
 		paper = new Paper( "aaaaa" );
 
-		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 36.6 ), i18n );
+		result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 36.6 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 36.6 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 
-		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 0 ), i18n );
+		result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 
-		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 55.0 ), i18n );
+		result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 55.0 ), i18n );
 		expect( result.getScore() ).toBe( 6 );
 		expect( result.getText() ).toBe( "The copy scores 55 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
 
-		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 60.0 ), i18n );
+		result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 60.0 ), i18n );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 60 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
 
-		result = fleschReadingAssessment.getResult( paper, Factory.buildMockResearcher( 100.0 ), i18n );
+		result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100.0 ), i18n );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
 

--- a/spec/assessments/getSubheadingLengthSpec.js
+++ b/spec/assessments/getSubheadingLengthSpec.js
@@ -5,6 +5,8 @@ var i18n = Factory.buildJed();
 
 var paper = new Paper();
 describe( "An assessment for finding the length of the subheadings.", function() {
+	let assessment;
+
 	it( "returns headings < 50 chars. ", function() {
 		var assessment = subHeadingLengthAssessment.getResult( paper, Factory.buildMockResearcher( [ 5, 5, 40 ] ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );

--- a/spec/assessments/keywordDensitySpec.js
+++ b/spec/assessments/keywordDensitySpec.js
@@ -8,22 +8,22 @@ describe( "An assessment for the keywordDensity", function(){
 	it( "runs the keywordDensity on the paper", function(){
 
 		var paper = new Paper( "string without the key", {keyword: "keyword"} );
-		var result = keywordDensityAssessment.getResult( paper, Factory.buildMockResearcher( 0.0 ), i18n );
+		var result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( 0.0 ), i18n );
 		expect( result.getScore() ).toBe( 4 );
 		expect( result.getText() ).toBe( "The keyword density is 0%, which is too low; the focus keyword was found 0 times.");
 
 		paper = new Paper( "string with the keyword", {keyword: "keyword"} );
-		result = keywordDensityAssessment.getResult( paper, Factory.buildMockResearcher( 10.0 ), i18n );
+		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( 10.0 ), i18n );
 		expect( result.getScore() ).toBe( -50 );
 		expect( result.getText() ).toBe( "The keyword density is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 times.");
 
 		paper = new Paper( "string with the keyword", {keyword: "keyword"} );
-		result = keywordDensityAssessment.getResult( paper, Factory.buildMockResearcher( 2.0 ), i18n );
+		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( 2.0 ), i18n );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The keyword density is 2%, which is great; the focus keyword was found 1 times.");
 
 		paper = new Paper( "string with the keyword  and keyword ", {keyword: "keyword"} );
-		result = keywordDensityAssessment.getResult( paper, Factory.buildMockResearcher( 3.0 ), i18n );
+		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( 3.0 ), i18n );
 		expect( result.getScore() ).toBe( -10 );
 		expect( result.getText() ).toBe( "The keyword density is 3%, which is over the advised 2.5% maximum; the focus keyword was found 2 times.");
 

--- a/spec/assessments/sentenceLengthInDescriptionSpec.js
+++ b/spec/assessments/sentenceLengthInDescriptionSpec.js
@@ -4,6 +4,8 @@ var Factory = require( "../helpers/factory.js" );
 var i18n = Factory.buildJed();
 
 describe( "An assessment for sentence length", function(){
+	let mockPaper, assessment;
+
 	it( "returns the score for all short sentences", function(){
 		var mockPaper = new Paper();
 		var assessment = sentenceLengthInDescriptionAssessment.getResult( mockPaper, Factory.buildMockResearcher( [

--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -6,6 +6,8 @@ var i18n = Factory.buildJed();
 
 
 describe( "An assessment for sentence length", function(){
+	let mockPaper, assessment;
+
 	it( "returns the score for all short sentences", function(){
 		var mockPaper = new Paper();
 		var assessment = sentenceLengthInTextAssessment.getResult( mockPaper, Factory.buildMockResearcher( [

--- a/spec/assessments/textLinksSpec.js
+++ b/spec/assessments/textLinksSpec.js
@@ -25,7 +25,7 @@ describe( "An assessor running the linkStatistics", function(){
 			totalKeyword: 0,
 			totalNaKeyword: 1};
 
-		var assessment = linkStatisticAssessment.getResult( mockPaper, Factory.buildMockResearcher( mockResult ), i18n );
+		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
 		expect( assessment.getText() ).toEqual ( 'This page has 0 nofollowed link(s) and 1 normal outbound link(s).' );
@@ -45,7 +45,7 @@ describe( "An assessor running the linkStatistics", function(){
 			totalKeyword: 0,
 			totalNaKeyword: 0};
 
-		assessment = linkStatisticAssessment.getResult( mockPaper, Factory.buildMockResearcher( mockResult ), i18n );
+		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
 		expect( assessment.getText() ).toEqual ( 'This page has 1 outbound link(s), all nofollowed.' );
@@ -53,7 +53,7 @@ describe( "An assessor running the linkStatistics", function(){
 
 	it( "Accepts a paper and i18nobject  ", function(){
 		var mockPaper = new Paper( "" );
-		var assessment = linkStatisticAssessment.getResult( mockPaper, Factory.buildMockResearcher({ total: 0 }), i18n );
+		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher({ total: 0 }), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual ( 'No links appear in this page, consider adding some as appropriate.' );

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -4,6 +4,8 @@ var Factory = require( "../helpers/factory.js" );
 var i18n = Factory.buildJed();
 
 describe( "An assessment for transition word percentage", function(){
+	let mockPaper, assessment;
+
 	it( "returns the score for 10.0% of the sentences with transition words", function(){
 		var mockPaper = new Paper();
 		var assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,

--- a/spec/assessments/urlLengthSpec.js
+++ b/spec/assessments/urlLengthSpec.js
@@ -7,13 +7,13 @@ var i18n = factory.buildJed();
 describe( "An assessment for the urlLengthAssessment", function(){
     it( "runs the url length assessment on the paper", function(){
         var paper = new Paper();
-        var result = urlLengthAssessment.getResult( paper, Factory.buildMockResearcher( true ), i18n );
+        var result = urlLengthAssessment.getResult( paper, factory.buildMockResearcher( true ), i18n );
 
         expect( result.score ).toBe( 5 );
         expect( result.text ).toBe( "The slug for this page is a bit long, consider shortening it." );
 
         var paper = new Paper();
-        var result = urlLengthAssessment.getResult( paper, Factory.buildMockResearcher( false ), i18n );
+        var result = urlLengthAssessment.getResult( paper, factory.buildMockResearcher( false ), i18n );
 
         expect( result.score ).toBe( 0 );
     } );

--- a/spec/assessorSpec.js
+++ b/spec/assessorSpec.js
@@ -6,7 +6,7 @@ var MissingArgument = require( "../js/errors/missingArgument" );
 var factory = require( "./helpers/factory.js" );
 var i18n = factory.buildJed();
 
-window = {};
+global.window = {};
 
 describe( "an assessor object", function() {
 

--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -18,6 +18,7 @@ var args = {
 };
 
 describe( "checks for keyword doubles", function(){
+
 	it("returns array with keyword", function(){
 		var paper = new Paper( "text", { keyword: "keyword"} );
 
@@ -52,7 +53,7 @@ describe( "replaces keyword usage", function(){
 			postUrl: postUrl
 		};
 
-		plugin = new PreviouslyUsedKeywords( app, args, i18n );
+		let plugin = new PreviouslyUsedKeywords( app, args, i18n );
 		expect( plugin.usedKeywords ).not.toBeDefined();
 		plugin.updateKeywordUsage(  { "keyword": [1], "test": [2,3,4] } );
 		expect( plugin.usedKeywords[ "keyword" ] ).toContain( 1 );

--- a/spec/helpers/errors.js
+++ b/spec/helpers/errors.js
@@ -1,12 +1,5 @@
 var showTrace = require( "../../js/helpers/errors" ).showTrace;
 
-var receivedMessage = null;
-console = {
-	trace: function( message ) {
-		receivedMessage = message;
-	}
-};
-
 describe( "showTrace", function() {
 	beforeEach( function() {
 		spyOn( console, "trace" )

--- a/spec/helpers/factory.js
+++ b/spec/helpers/factory.js
@@ -1,9 +1,9 @@
 // Make sure the Jed object is globally available
-Jed = require('jed');
+let Jed = require('jed');
 
-_ = require("lodash");
+let _ = require("lodash");
 
-FactoryProto = function(){};
+let FactoryProto = function(){};
 
 FactoryProto.prototype.buildJed = function() {
 	return new Jed({
@@ -60,6 +60,6 @@ FactoryProto.prototype.buildMockString = function( string, repetitions ) {
 	return resultString;
 };
 
-Factory = new FactoryProto;
+let Factory = new FactoryProto();
 
 module.exports = Factory;

--- a/spec/researches/getSentencesLengthFromTextSpec.js
+++ b/spec/researches/getSentencesLengthFromTextSpec.js
@@ -2,6 +2,8 @@ var getSentences = require( "../../js/researches/countSentencesFromText.js" );
 var Paper = require( "../../js/values/Paper" );
 
 describe("counts words in sentences from text", function(){
+	let paper;
+
 	it("returns sentences with question mark", function () {
 		var paper = new Paper("Hello. How are you? Bye");
 		expect( getSentences( paper )[0].sentenceLength ).toBe( 1 );

--- a/spec/researches/getSubheadingPresenceSpec.js
+++ b/spec/researches/getSubheadingPresenceSpec.js
@@ -2,6 +2,7 @@ var subheadingPresence = require( "../../js/researches/getSubheadingPresence.js"
 var Paper = require( "../../js/values/Paper.js" );
 
 describe( "checks if there is a subheading in text", function() {
+	let paper;
 
 	it( "returns 0", function() {
 		var paper = new Paper( "this is text" );

--- a/spec/researches/imageCountSpec.js
+++ b/spec/researches/imageCountSpec.js
@@ -2,6 +2,8 @@ var imageCountFunction = require( "../../js/researches/imageCountInText.js" );
 var Paper = require( "../../js/values/Paper" );
 
 describe( "Counts images in an text", function(){
+	let imageCount;
+
 	it( "returns object with the imagecount", function() {
 		imageCount = imageCountFunction(
 			new Paper( "string <img src='http://plaatje' alt='' />" )

--- a/spec/researches/passiveVoiceSpec.js
+++ b/spec/researches/passiveVoiceSpec.js
@@ -4,6 +4,8 @@ var Paper = require( "../../js/values/Paper.js" );
 // Tests inspired by the examples on http://www.englishpage.com/verbpage/activepassive.html
 describe( "detecting passive voice in sentences", function() {
 
+	let paper;
+
 	it( "returns active voice (Simple Present)", function () {
 		paper = new Paper("Once a week, Tom cleans the house.");
 		expect( passiveVoice( paper ).passives.length ).toBe( 0 );

--- a/spec/researches/transitionWordsSpec.js
+++ b/spec/researches/transitionWordsSpec.js
@@ -2,6 +2,7 @@ var transitionWordsResearch = require( "../../js/researches/findTransitionWords.
 var Paper = require( "../../js/values/Paper.js" );
 
 describe("a test for finding transition words from a string", function() {
+	let mockPaper, result;
 
 	it("returns 1 when a transition word is found in the middle of a sentence (English)", function () {
 		// Transition word: above all.

--- a/spec/stringProcessing/addWordBoundarySpec.js
+++ b/spec/stringProcessing/addWordBoundarySpec.js
@@ -1,4 +1,6 @@
-var addWordBoundary = require( "../../js/stringProcessing/addWordboundary.js" );
+// var addWordBoundary = require( "../../js/stringProcessing/addWordboundary.js" );
+
+import addWordBoundary from "../../js/stringProcessing/addWordboundary";
 
 describe("a test adding wordboundaries to a string", function(){
 	it("adds start and end boundaries", function(){

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -4,6 +4,7 @@
     "**/*[sS]pec.js"
   ],
   "helpers": [
-    "helpers/**/*.js"
+    "helpers/**/*.js",
+    "../node_modules/babel-register/lib/node.js"
   ]
 }

--- a/spec/values/WordCombinationSpec.js
+++ b/spec/values/WordCombinationSpec.js
@@ -29,7 +29,7 @@ describe( "WordCombination", function() {
 
 	describe( "getLengthBonus", function() {
 		it( "is based on the length", function() {
-			combination = new WordCombination( [ "word", "word2" ] );
+			let combination = new WordCombination( [ "word", "word2" ] );
 
 			expect( combination.getLengthBonus() ).toBe( WordCombination.lengthBonus[ "2" ] );
 		});


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Start using ES2015

## Relevant technical choices:

* Include the following packages:
	* babel-cli, for using babel in generating the test coverage.
	* babel-preset-es2015, for using ES2015.
	* babel-register, for using babel when running jasmine tests.

## Test instructions

This PR can be tested by following these steps:

* Use any ES2015 feature inside the tests or the code that is covered and see that the tests don't fail on the syntax. (For example import)