### PR TITLE
Moved the extending of Assessor in SEOAssessor to support code completion

### DIFF
--- a/js/seoAssessor.js
+++ b/js/seoAssessor.js
@@ -48,7 +48,6 @@ var SEOAssessor = function( i18n, options ) {
 	];
 };
 
+require( "util" ).inherits( SEOAssessor, Assessor );
+
 module.exports = SEOAssessor;
-
-require( "util" ).inherits( module.exports, Assessor );
-


### PR DESCRIPTION
## Summary
When using YoastSEO.js as a third party library, code completion fails in the SEO Assessor due to a "wrong" extend / export order. This PR solves that.
