### PR TITLE
Introduces English-specific Sentence Part object

### DIFF
--- a/js/researches/english/EnglishSentencePart.js
+++ b/js/researches/english/EnglishSentencePart.js
@@ -3,6 +3,7 @@ var getParticiples = require( "./passivevoice-english/getParticiples.js" );
 
 /**
  * Creates a English specific sentence part.
+ *
  * @param {string} sentencePartText The text from the sentence part.
  * @param {Array} auxiliaries The list of auxiliaries from the sentence part.
  * @param {string} locale The locale used for this sentence part.

--- a/js/researches/english/EnglishSentencePart.js
+++ b/js/researches/english/EnglishSentencePart.js
@@ -1,0 +1,26 @@
+var SentencePart = require( "../../values/SentencePart.js" );
+var getParticiples = require( "./passivevoice-english/getParticiples.js" );
+
+/**
+ * Creates a English specific sentence part.
+ * @param {string} sentencePartText The text from the sentence part.
+ * @param {Array} auxiliaries The list of auxiliaries from the sentence part.
+ * @param {string} locale The locale used for this sentence part.
+ * @constructor
+ */
+var EnglishSentencePart = function( sentencePartText, auxiliaries, locale ) {
+	SentencePart.call( this, sentencePartText, auxiliaries, locale );
+};
+
+require( "util" ).inherits( EnglishSentencePart, SentencePart );
+
+/**
+ * Returns the participle objects for the participles found in the sentence part.
+ * @returns {Array} The list of participle objects.
+ */
+
+EnglishSentencePart.prototype.getParticiples = function() {
+	return getParticiples( this.getSentencePartText(), this.getAuxiliaries() );
+};
+
+module.exports = EnglishSentencePart;

--- a/js/researches/english/getSentenceParts.js
+++ b/js/researches/english/getSentenceParts.js
@@ -1,0 +1,99 @@
+var verbEndingInIngRegex = /\w+ing($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
+var ingExclusionArray = [ "king", "cling", "ring", "being" ];
+var getIndicesOfList = require( "../../stringProcessing/indices" ).getIndicesByWordList;
+var filterIndices = require( "../../stringProcessing/indices" ).filterIndices;
+var sortIndices = require( "../../stringProcessing/indices" ).sortIndices;
+var stripSpaces = require( "../../stringProcessing/stripSpaces.js" );
+var normalizeSingleQuotes = require( "../../stringProcessing/quotes.js" ).normalizeSingle;
+var arrayToRegex = require( "../../stringProcessing/createRegexFromArray.js" );
+
+var auxiliaries = require( "./passivevoice-english/auxiliaries.js" )().all;
+var SentencePart = require( "./EnglishSentencePart.js" );
+var auxiliaryRegex = arrayToRegex( auxiliaries );
+var stopwords = require( "./passivevoice-english/stopwords.js" )();
+
+var filter = require( "lodash/filter" );
+var isUndefined = require( "lodash/isUndefined" );
+var includes = require( "lodash/includes" );
+var map = require( "lodash/map" );
+
+/**
+ * Gets active verbs (ending in ing) to determine sentence breakers.
+ *
+	* @param {string} sentence The sentence to get the active verbs from.
+	* @returns {Array} The array with valid matches.
+	*/
+	var getVerbsEndingInIng = function( sentence ) {
+		// Matches the sentences with words ending in ing
+		var matches = sentence.match( verbEndingInIngRegex ) || [];
+
+		// Filters out words ending in -ing that aren't verbs.
+		return filter( matches, function( match ) {
+			return ! includes( ingExclusionArray, stripSpaces( match ) );
+		} );
+	};
+
+	/**
+	 * Gets the indexes of sentence breakers (auxiliaries, stopwords and active verbs) to determine sentence parts.
+	 * Indices are filtered because there could be duplicate matches, like "even though" and "though".
+	 * In addition, 'having' will be matched both as a -ing verb as well as an auxiliary.
+	 *
+	 * @param {string} sentence The sentence to check for indices of auxiliaries, stopwords and active verbs.
+	 * @returns {Array} The array with valid indices to use for determining sentence parts.
+	 */
+	var getSentenceBreakers = function( sentence ) {
+		sentence = sentence.toLocaleLowerCase();
+		var auxiliaryIndices = getIndicesOfList( sentence, auxiliaries );
+
+		var stopwordIndices = getIndicesOfList( sentence, stopwords );
+
+		var ingVerbs = getVerbsEndingInIng( sentence );
+		var ingVerbsIndices = getIndicesOfList( sentence, ingVerbs );
+
+		// Concat all indices arrays, filter them and sort them.
+		var indices = [].concat( auxiliaryIndices, stopwordIndices, ingVerbsIndices );
+		indices = filterIndices( indices );
+		return sortIndices( indices );
+	};
+
+	/**
+	 * Gets the sentence parts from a sentence by determining sentence breakers.
+	 *
+	 * @param {string} sentence The sentence to split up in sentence parts.
+	 * @returns {Array} The array with all parts of a sentence that have an auxiliary.
+	 */
+	var getSentenceParts = function( sentence ) {
+		var sentenceParts = [];
+
+		sentence = normalizeSingleQuotes( sentence );
+
+	// First check if there is an auxiliary in the sentence.
+	if ( sentence.match( auxiliaryRegex ) !== null ) {
+		var indices = getSentenceBreakers( sentence );
+		// Get the words after the found auxiliary.
+		for ( var i = 0; i < indices.length; i++ ) {
+			var endIndex = sentence.length;
+			if ( ! isUndefined( indices[ i + 1 ] ) ) {
+				endIndex = indices[ i + 1 ].index;
+			}
+
+			// Cut the sentence from the current index to the endIndex (start of next breaker, of end of sentence).
+			var sentencePart = stripSpaces( sentence.substr( indices[ i ].index, endIndex - indices[ i ].index ) );
+
+			var auxiliaryMatches = sentencePart.match( auxiliaryRegex );
+
+			// If a sentence part doesn't have an auxiliary, we don't need it, so it can be filtered out.
+			if ( auxiliaryMatches !== null ) {
+				auxiliaryMatches = map( auxiliaryMatches, function( auxiliaryMatch ) {
+					return stripSpaces( auxiliaryMatch )
+				} );
+				sentenceParts.push( new SentencePart( sentencePart, auxiliaryMatches ) );
+			}
+		}
+	}
+	return sentenceParts;
+};
+
+module.exports = function( sentence ) {
+	return getSentenceParts( sentence );
+};

--- a/js/researches/english/getSentenceParts.js
+++ b/js/researches/english/getSentenceParts.js
@@ -23,51 +23,51 @@ var map = require( "lodash/map" );
 	* @param {string} sentence The sentence to get the active verbs from.
 	* @returns {Array} The array with valid matches.
 	*/
-	var getVerbsEndingInIng = function( sentence ) {
-		// Matches the sentences with words ending in ing
-		var matches = sentence.match( verbEndingInIngRegex ) || [];
+var getVerbsEndingInIng = function( sentence ) {
+	// Matches the sentences with words ending in ing
+	var matches = sentence.match( verbEndingInIngRegex ) || [];
 
-		// Filters out words ending in -ing that aren't verbs.
-		return filter( matches, function( match ) {
-			return ! includes( ingExclusionArray, stripSpaces( match ) );
-		} );
-	};
+	// Filters out words ending in -ing that aren't verbs.
+	return filter( matches, function( match ) {
+		return ! includes( ingExclusionArray, stripSpaces( match ) );
+	} );
+};
 
-	/**
-	 * Gets the indexes of sentence breakers (auxiliaries, stopwords and active verbs) to determine sentence parts.
-	 * Indices are filtered because there could be duplicate matches, like "even though" and "though".
-	 * In addition, 'having' will be matched both as a -ing verb as well as an auxiliary.
-	 *
-	 * @param {string} sentence The sentence to check for indices of auxiliaries, stopwords and active verbs.
-	 * @returns {Array} The array with valid indices to use for determining sentence parts.
-	 */
-	var getSentenceBreakers = function( sentence ) {
-		sentence = sentence.toLocaleLowerCase();
-		var auxiliaryIndices = getIndicesOfList( sentence, auxiliaries );
+/**
+ * Gets the indexes of sentence breakers (auxiliaries, stopwords and active verbs) to determine sentence parts.
+ * Indices are filtered because there could be duplicate matches, like "even though" and "though".
+ * In addition, 'having' will be matched both as a -ing verb as well as an auxiliary.
+ *
+ * @param {string} sentence The sentence to check for indices of auxiliaries, stopwords and active verbs.
+ * @returns {Array} The array with valid indices to use for determining sentence parts.
+ */
+var getSentenceBreakers = function( sentence ) {
+	sentence = sentence.toLocaleLowerCase();
+	var auxiliaryIndices = getIndicesOfList( auxiliaries, sentence );
 
-		var stopwordIndices = getIndicesOfList( sentence, stopwords );
+	var stopwordIndices = getIndicesOfList( stopwords, sentence );
 
-		var ingVerbs = getVerbsEndingInIng( sentence );
-		var ingVerbsIndices = getIndicesOfList( sentence, ingVerbs );
+	var ingVerbs = getVerbsEndingInIng( sentence );
+	var ingVerbsIndices = getIndicesOfList( ingVerbs, sentence );
 
-		// Concat all indices arrays, filter them and sort them.
-		var indices = [].concat( auxiliaryIndices, stopwordIndices, ingVerbsIndices );
-		indices = filterIndices( indices );
-		return sortIndices( indices );
-	};
+	// Concat all indices arrays, filter them and sort them.
+	var indices = [].concat( auxiliaryIndices, stopwordIndices, ingVerbsIndices );
+	indices = filterIndices( indices );
+	return sortIndices( indices );
+};
 
-	/**
-	 * Gets the sentence parts from a sentence by determining sentence breakers.
-	 *
-	 * @param {string} sentence The sentence to split up in sentence parts.
-	 * @returns {Array} The array with all parts of a sentence that have an auxiliary.
-	 */
-	var getSentenceParts = function( sentence ) {
-		var sentenceParts = [];
+/**
+ * Gets the sentence parts from a sentence by determining sentence breakers.
+ *
+ * @param {string} sentence The sentence to split up in sentence parts.
+ * @returns {Array} The array with all parts of a sentence that have an auxiliary.
+ */
+var getSentenceParts = function( sentence ) {
+	var sentenceParts = [];
 
-		sentence = normalizeSingleQuotes( sentence );
+	sentence = normalizeSingleQuotes( sentence );
 
-	// First check if there is an auxiliary in the sentence.
+// First check if there is an auxiliary in the sentence.
 	if ( sentence.match( auxiliaryRegex ) !== null ) {
 		var indices = getSentenceBreakers( sentence );
 		// Get the words after the found auxiliary.
@@ -82,10 +82,10 @@ var map = require( "lodash/map" );
 
 			var auxiliaryMatches = sentencePart.match( auxiliaryRegex );
 
-			// If a sentence part doesn't have an auxiliary, we don't need it, so it can be filtered out.
+				// If a sentence part doesn't have an auxiliary, we don't need it, so it can be filtered out.
 			if ( auxiliaryMatches !== null ) {
 				auxiliaryMatches = map( auxiliaryMatches, function( auxiliaryMatch ) {
-					return stripSpaces( auxiliaryMatch )
+					return stripSpaces( auxiliaryMatch );
 				} );
 				sentenceParts.push( new SentencePart( sentencePart, auxiliaryMatches ) );
 			}

--- a/js/researches/english/passivevoice-english/getParticiples.js
+++ b/js/researches/english/passivevoice-english/getParticiples.js
@@ -12,11 +12,11 @@ var forEach = require( "lodash/forEach" );
  * Creates English participle objects for the participles found in a sentence part.
  *
  * @param {string} sentencePart The sentence part to find participles in.
+ * @param {array} auxiliaries The list of auxiliaries from the sentence part.
  * @returns {Array} The list with English participle objects.
  */
-module.exports = function( sentencePart ) {
-	var words = getWords( sentencePart.getSentencePartText() );
-
+module.exports = function( sentencePart, auxiliaries ) {
+	var words = getWords( sentencePart );
 	var foundParticiples = [];
 
 	forEach( words, function( word ) {
@@ -28,8 +28,8 @@ module.exports = function( sentencePart ) {
 			type = "irregular";
 		}
 		if ( type !== "" ) {
-			foundParticiples.push( new EnglishParticiple( word, sentencePart.getSentencePartText(),
-				{ auxiliaries: sentencePart.getAuxiliaries(), type: type } ) );
+			foundParticiples.push( new EnglishParticiple( word, sentencePart,
+				{ auxiliaries: auxiliaries, type: type } ) );
 		}
 	} );
 	return foundParticiples;

--- a/js/researches/english/passivevoice-english/matchParticiples.js
+++ b/js/researches/english/passivevoice-english/matchParticiples.js
@@ -1,4 +1,4 @@
-var find = require ( "lodash/find" );
+var find = require( "lodash/find" );
 
 var irregulars = require( "./irregulars" )();
 
@@ -10,7 +10,6 @@ var irregulars = require( "./irregulars" )();
  * @returns {Array} A list with the matches.
  */
 var regularParticiples = function( word ) {
-
 	// Matches all words ending in ed.
 	var regularParticiplesRegex = /\w+ed($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
 

--- a/spec/researches/english/EnglishSentencePartSpec.js
+++ b/spec/researches/english/EnglishSentencePartSpec.js
@@ -1,0 +1,22 @@
+var EnglishSentencePart = require( "../../../js/researches/english/EnglishSentencePart.js");
+
+describe( "creates a English sentence part", function() {
+	it ( "makes sure the English sentence part inherits all functions", function() {
+		var mockPart = new EnglishSentencePart( "English texts are great.", [ "are" ], "en_US" );
+		expect( mockPart.getSentencePartText() ).toBe( "English texts are great." );
+		expect( mockPart.getAuxiliaries() ).toEqual( [ "are" ] );
+		expect( mockPart.getLocale() ).toBe( "en_US" );
+	} );
+	it ( "returns a irregular participle for an English sentence part", function() {
+		var mockPart = new EnglishSentencePart( "English texts are written.", [ "are" ], "en_US" );
+		expect( mockPart.getParticiples()[ 0 ].getParticiple() ).toBe( "written" );
+		expect( mockPart.getParticiples()[ 0 ].getType() ).toBe( "irregular" );
+		expect( mockPart.getParticiples()[ 0 ].determinesSentencePartIsPassive() ).toBe( true );
+	} );
+	it ( "returns a regular participle for an English sentence part", function() {
+		var mockPart = new EnglishSentencePart( "The kitchen cabinets were nailed to the wall.", [ "are" ], "en_US" );
+		expect( mockPart.getParticiples()[ 0 ].getParticiple() ).toBe( "nailed" );
+		expect( mockPart.getParticiples()[ 0 ].getType() ).toBe( "regular" );
+		expect( mockPart.getParticiples()[ 0 ].determinesSentencePartIsPassive() ).toBe( true );
+	} );
+} );

--- a/spec/researches/english/getSentencePartsSpec.js
+++ b/spec/researches/english/getSentencePartsSpec.js
@@ -3,6 +3,7 @@ var getSentenceParts = require( "../../../js/researches/english/getSentenceParts
 describe( "splits English sentences into parts", function() {
 	it ( "returns all sentence parts from the auxiliary to the end of the sentence", function() {
 		var sentence =  "The English are still having a party.";
+		console.log( getSentenceParts( sentence ) );
 		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "are still" );
 		expect( getSentenceParts( sentence )[ 1 ].getSentencePartText() ).toBe( "having a party." );
 		expect( getSentenceParts( sentence ).length ).toBe( 2 );

--- a/spec/researches/english/getSentencePartsSpec.js
+++ b/spec/researches/english/getSentencePartsSpec.js
@@ -3,7 +3,6 @@ var getSentenceParts = require( "../../../js/researches/english/getSentenceParts
 describe( "splits English sentences into parts", function() {
 	it ( "returns all sentence parts from the auxiliary to the end of the sentence", function() {
 		var sentence =  "The English are still having a party.";
-		console.log(getSentenceParts( sentence ))
 		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "are still" );
 		expect( getSentenceParts( sentence )[ 1 ].getSentencePartText() ).toBe( "having a party." );
 		expect( getSentenceParts( sentence ).length ).toBe( 2 );

--- a/spec/researches/english/getSentencePartsSpec.js
+++ b/spec/researches/english/getSentencePartsSpec.js
@@ -1,0 +1,16 @@
+var getSentenceParts = require( "../../../js/researches/english/getSentenceParts.js");
+
+describe( "splits English sentences into parts", function() {
+	it ( "returns all sentence parts from the auxiliary to the end of the sentence", function() {
+		var sentence =  "The English are still having a party.";
+		console.log(getSentenceParts( sentence ))
+		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "are still" );
+		expect( getSentenceParts( sentence )[ 1 ].getSentencePartText() ).toBe( "having a party." );
+		expect( getSentenceParts( sentence ).length ).toBe( 2 );
+	} );
+	it ( "filters out sentence parts without auxiliary", function() {
+		var sentence =  "The English are always throwing parties.";
+		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "are always" );
+		expect( getSentenceParts( sentence ).length ).toBe( 1 );
+	} );
+} );

--- a/spec/researches/english/passivevoice-english/getParticiplesSpec.js
+++ b/spec/researches/english/passivevoice-english/getParticiplesSpec.js
@@ -4,7 +4,9 @@ var sentencePart = require ( "../../../../js/values/SentencePart.js");
 describe("Test for matching English participles", function(){
 	it("returns matched regular participles.", function(){
 		var mockSentence = new sentencePart( "He was fired.", [ "was" ] );
-		var foundParticiples = getParticiples( mockSentence );
+		var sentencePartText = mockSentence.getSentencePartText();
+		var auxiliaries = mockSentence.getAuxiliaries();
+		var foundParticiples = getParticiples( sentencePartText, auxiliaries );
 		expect( foundParticiples[ 0 ].getParticiple() ).toEqual( "fired" );
 		expect( foundParticiples[ 0 ].getType() ).toEqual( "regular" );
 		expect( foundParticiples[ 0 ].getSentencePart() ).toEqual( "He was fired." );
@@ -14,7 +16,9 @@ describe("Test for matching English participles", function(){
 
 	it("returns matched irregular participles.", function(){
 		var mockSentence = new sentencePart( "The show was broadcast at a new channel.", [ "was" ] );
-		var foundParticiples = getParticiples( mockSentence );
+		var sentencePartText = mockSentence.getSentencePartText();
+		var auxiliaries = mockSentence.getAuxiliaries();
+		var foundParticiples = getParticiples( sentencePartText, auxiliaries );
 		expect( foundParticiples[ 0 ].getParticiple() ).toEqual( "broadcast" );
 		expect( foundParticiples[ 0 ].getType() ).toEqual( "irregular" );
 		expect( foundParticiples[ 0 ].getSentencePart() ).toEqual( "The show was broadcast at a new channel." );
@@ -24,7 +28,9 @@ describe("Test for matching English participles", function(){
 
 	it("returns an empty array when there is no participle", function(){
 		var mockSentence = new sentencePart( "Yahoo prüfte seitdem den Sachverhalt.", [] );
-		var foundParticiples = getParticiples( mockSentence );
+		var sentencePartText = mockSentence.getSentencePartText();
+		var auxiliaries = mockSentence.getAuxiliaries();
+		var foundParticiples = getParticiples( sentencePartText, auxiliaries );
 		expect( foundParticiples ).toEqual( [] );
 	});
 });


### PR DESCRIPTION
## Summary

Introduces the English-specific Sentence Part object.

This PR can be summarized in the following changelog entry: N/A

## Relevant technical choices:

* EnglishSentencePart.js: Extends the Sentence Part object for English.
* getSentenceParts.js: Determines English sentence parts based on sentence breakers.

## Test instructions

This PR can be tested by following these steps:

* Make sure all tests pass.