### PR TITLE
Enhances feedback strings for metadescription length assessment

### DIFF
--- a/js/assessments/metaDescriptionLengthAssessment.js
+++ b/js/assessments/metaDescriptionLengthAssessment.js
@@ -19,7 +19,7 @@ var calculateDescriptionLengthResult = function( descriptionLength, i18n ) {
 	if ( descriptionLength <= recommendedValue ) {
 		return {
 			score: 6,
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is under %1$d characters. " +
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is under %1$d characters long. " +
 				"However, up to %2$d characters are available." ), recommendedValue, maximumValue ),
 		};
 	}
@@ -33,7 +33,7 @@ var calculateDescriptionLengthResult = function( descriptionLength, i18n ) {
 	if ( descriptionLength >= recommendedValue && descriptionLength <= maximumValue ) {
 		return {
 			score: 9,
-			text: i18n.dgettext( "js-text-analysis", "The meta description is of sufficient length. " +
+			text: i18n.dgettext( "js-text-analysis", "The length of the meta description is sufficient. " +
 				"But how does it compare to the competition? Could it be made more appealing?" ),
 		};
 	}

--- a/js/assessments/metaDescriptionLengthAssessment.js
+++ b/js/assessments/metaDescriptionLengthAssessment.js
@@ -12,29 +12,29 @@ var calculateDescriptionLengthResult = function( descriptionLength, i18n ) {
 	if ( descriptionLength === 0 ) {
 		return {
 			score: 1,
-			text: i18n.dgettext( "js-text-analysis", "No meta description has been specified, " +
-				"search engines will display copy from the page instead." ),
+			text: i18n.dgettext( "js-text-analysis", "No meta description has been specified. " +
+				"Search engines will display copy from the page instead." ),
 		};
 	}
 	if ( descriptionLength <= recommendedValue ) {
 		return {
 			score: 6,
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is under %1$d characters, " +
-				"however up to %2$d characters are available." ), recommendedValue, maximumValue ),
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is under %1$d characters. " +
+				"However, up to %2$d characters are available." ), recommendedValue, maximumValue ),
 		};
 	}
 	if ( descriptionLength > maximumValue ) {
 		return {
 			score: 6,
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "The specified meta description is over %1$d characters. " +
-				"Reducing it will ensure the entire description is visible." ), maximumValue ),
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is over %1$d characters. " +
+				"Reducing the length will ensure the entire description will be visible." ), maximumValue ),
 		};
 	}
 	if ( descriptionLength >= recommendedValue && descriptionLength <= maximumValue ) {
 		return {
 			score: 9,
-			text: i18n.dgettext( "js-text-analysis", "In the specified meta description, consider: " +
-				"How does it compare to the competition? Could it be made more appealing?" ),
+			text: i18n.dgettext( "js-text-analysis", "The meta description is of sufficient length. " +
+				"But how does it compare to the competition? Could it be made more appealing?" ),
 		};
 	}
 };

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -17,7 +17,7 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters. However, up to 156 characters are available." );
+		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters long. However, up to 156 characters are available." );
 	} );
 
 	it( "assesses a too long description", function(){
@@ -33,6 +33,6 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The meta description is of sufficient length. But how does it compare to the competition? Could it be made more appealing?" );
+		expect( assessment.getText() ).toEqual ( "The length of the meta description is sufficient. But how does it compare to the competition? Could it be made more appealing?" );
 	} );
 } );

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -9,7 +9,7 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual ( "No meta description has been specified, search engines will display copy from the page instead." );
+		expect( assessment.getText() ).toEqual ( "No meta description has been specified. Search engines will display copy from the page instead." );
 	} );
 
 	it( "assesses a short description", function(){
@@ -17,7 +17,7 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters, however up to 156 characters are available." );
+		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters. However, up to 156 characters are available." );
 	} );
 
 	it( "assesses a too long description", function(){
@@ -25,7 +25,7 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 200 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The specified meta description is over 156 characters. Reducing it will ensure the entire description is visible." );
+		expect( assessment.getText() ).toEqual ( "The meta description is over 156 characters. Reducing the length will ensure the entire description will be visible." );
 	} );
 
 	it( "assesses a good description", function(){
@@ -33,6 +33,6 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "In the specified meta description, consider: How does it compare to the competition? Could it be made more appealing?" );
+		expect( assessment.getText() ).toEqual ( "The meta description is of sufficient length. But how does it compare to the competition? Could it be made more appealing?" );
 	} );
 } );


### PR DESCRIPTION
## Summary

- Made the verb tense more consistent.
- Replaced commas by periods between sentences. 
- Made the feedback string for `score: 9` more descriptive. Before, there was no link between the feedback and the assessment: the length of the description was not mentioned at all. 

This PR can be summarized in the following changelog entry: Enhanced feedback strings for the metadescription length assessment. 
