### PR TITLE
Improve snippet style.

### DIFF
--- a/css/_snippet-editor.scss
+++ b/css/_snippet-editor.scss
@@ -232,21 +232,21 @@ $snippet_width: 600px;
 	line-height: 1.4;
 }
 
-.snippet_container .down_arrow {
-	border-left: 4px solid transparent;
-	border-right: 4px solid transparent;
-	border-top: 5px solid #006621;
-	margin-top: 6px;
-	margin-left: 5px;
-	float: left;
-}
-
 .snippet_container .url {
 	display: inline-block;
 	font-size: 14px;
 	line-height: 16px;
 	color: #006621;
 	font-style: normal;
+	float: left;
+}
+
+.snippet_container .down_arrow {
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-top: 5px solid #006621;
+	margin-top: 6px;
+	margin-left: 5px;
 	float: left;
 }
 

--- a/css/_snippet-editor.scss
+++ b/css/_snippet-editor.scss
@@ -232,6 +232,10 @@ $snippet_width: 600px;
 	line-height: 1.4;
 }
 
+.snippet_container .url .down_arrow {
+
+}
+
 .snippet_container .url {
 	display: block;
 	font-size: 14px;
@@ -245,7 +249,11 @@ $snippet_width: 600px;
 }
 
 .snippet_container .desc-default {
-	color: #333;
+	color: #545454;
+}
+
+.snippet_container .desc-default strong{
+	color: #6a6a6a;
 }
 
 .snippet_container .desc-render {

--- a/css/_snippet-editor.scss
+++ b/css/_snippet-editor.scss
@@ -232,19 +232,21 @@ $snippet_width: 600px;
 	line-height: 1.4;
 }
 
-.snippet_container .url .down_arrow {
-
+.snippet_container .down_arrow {
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-top: 5px solid #006621;
+	margin-top: 6px;
+	margin-left: 5px;
+	float: left;
 }
 
 .snippet_container .url {
-	display: block;
+	display: inline-block;
 	font-size: 14px;
 	line-height: 16px;
 	color: #006621;
 	font-style: normal;
-}
-
-.snippet_container .urlBase{
 	float: left;
 }
 

--- a/templates/snippetEditor.jst
+++ b/templates/snippetEditor.jst
@@ -20,6 +20,7 @@
             <cite class="url" id="snippet_cite">
                 <%- rendered.snippetCite %>
             </cite>
+            <span class="down_arrow"></span>
         </div>
         <div class="snippet_container snippet-editor__container" id="meta_container">
             <span class="screen-reader-text"><%- i18n.metaDescriptionLabel %></span>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Improves the styling of the snippet  to comply with the current google styling. 

## Relevant technical choices:

* Added a css entry so we can set a different color to the highlighted parts. 
* Changed display block to display inline-block for the URL fields, so the arrow lines out. 

## Test instructions

This PR can be tested by following these steps:

* Check if the current snippet styling looks the same as google.

Fixes point 2 and 3 of https://github.com/Yoast/wordpress-seo/issues/6042