### PR TITLE
Add alternate source for tooltips.

### DIFF
--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -30,6 +30,14 @@ button.yoast-tooltip {
 	-webkit-font-smoothing: subpixel-antialiased;
 }
 
+/*
+ * Use a data attribute as alternative source for the tooltip text.
+ * Add this selector as modifier of the base selector.
+ */
+.yoast-tooltip-alt::after {
+	content: attr(data-label);
+}
+
 .yoast-tooltip::before {
 	display: none;
 	position: absolute;


### PR DESCRIPTION
Fixes #965.

This adds the ability to use a HTML data attribute to specify the text to be used for the tooltips. This way, the tooltip can display a "visual" info while the `aria-label` attribute is available to provide expanded info and context for assistive technologies.

The tooltips text is created via CSS generated content.

Usage:
- by default, it uses the `aria-label` text
- adding a CSS class to the base class, e.g. `yoast-tooltip yoast-tooltip-alt` it will use the text of a `data-label` attribute



