### PR TITLE
Make assessments for stopwords language dependant.

### DIFF
--- a/js/assessments/keywordStopWordsAssessment.js
+++ b/js/assessments/keywordStopWordsAssessment.js
@@ -1,5 +1,9 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 
+var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
+
+var availableLanguages = [ "en" ];
+
 /**
  * Calculate the score based on the amount of stop words in the keyword.
  * @param {number} stopWordCount The amount of stop words to be checked against.
@@ -52,6 +56,7 @@ module.exports = {
 	identifier: "keywordStopWords",
 	getResult: keywordHasStopWordsAssessment,
 	isApplicable: function( paper ) {
-		return paper.hasKeyword();
+		var isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
+		return paper.hasKeyword() && isLanguageAvailable;
 	},
 };

--- a/js/assessments/urlStopWordsAssessment.js
+++ b/js/assessments/urlStopWordsAssessment.js
@@ -1,5 +1,9 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
 
+var getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
+
+var availableLanguages = [ "en" ];
+
 /**
  * Calculate the score based on the amount of stop words in the url.
  * @param {number} stopWordCount The amount of stop words to be checked against.
@@ -48,5 +52,8 @@ var urlHasStopWordsAssessment = function( paper, researcher, i18n ) {
 
 module.exports = {
 	identifier: "urlStopWords",
+	isApplicable: function( paper ) {
+		return getLanguageAvailability( paper.getLocale(), availableLanguages );
+	},
 	getResult: urlHasStopWordsAssessment,
 };

--- a/spec/assessments/keywordStopWordsSpec.js
+++ b/spec/assessments/keywordStopWordsSpec.js
@@ -36,3 +36,22 @@ describe( "A stop word in keyword assessment", function() {
 		expect( assessment.getText() ).toEqual ( "The focus keyword contains 2 stop words. This may or may not be wise depending on the circumstances. Read <a href='https://yoast.com/handling-stopwords/' target='_blank'>this article</a> for more info.");
 	} );
 } );
+
+describe( "Checks if the assessment is applicable", function() {
+	it( "returns false for isApplicable for an English paper without keyword.", function() {
+		var paper = new Paper( "", {locale: "en_EN"} );
+		expect( stopWordsInKeywordAssessment.isApplicable( paper )).toBe( false );
+	} );
+	it( "returns true for isApplicable for an English paper with keyword.", function() {
+		var paper = new Paper( "", {locale: "en_EN", keyword: "keyword"} );
+		expect( stopWordsInKeywordAssessment.isApplicable( paper )).toBe( true );
+	} );
+	it( "returns false for isApplicable for an Dutch paper without keyword.", function() {
+		var paper = new Paper( "", {locale: "nl_NL"} );
+		expect( stopWordsInKeywordAssessment.isApplicable( paper )).toBe( false );
+	} );
+	it( "returns false for isApplicable for an Dutch paper with keyword.", function() {
+		var paper = new Paper( "", {locale: "nl_NL", keyword: "keyword"} );
+		expect( stopWordsInKeywordAssessment.isApplicable( paper )).toBe( false );
+	} );
+});

--- a/spec/assessments/urlStopWordsSpec.js
+++ b/spec/assessments/urlStopWordsSpec.js
@@ -34,3 +34,14 @@ describe( "A stop word in url assessment", function() {
 		expect( assessment.getText() ).toEqual ( "The slug for this page contains <a href='http://en.wikipedia.org/wiki/Stop_words' target='_blank'>stop words</a>, consider removing them." );
 	} );
 } );
+
+describe( "Checks if the assesment is applicable", function() {
+	it( "returns true for isApplicable for an English paper", function() {
+		var paper = new Paper( "", {locale: "en_EN"} );
+		expect( stopWordsInUrlAssessment.isApplicable( paper )).toBe( true );
+	} );
+	it( "returns false for isApplicable for an Dutch paper", function() {
+		var paper = new Paper( "", {locale: "nl_NL"} );
+		expect( stopWordsInUrlAssessment.isApplicable( paper )).toBe( false );
+	} );
+});

--- a/spec/assessments/urlStopWordsSpec.js
+++ b/spec/assessments/urlStopWordsSpec.js
@@ -35,7 +35,7 @@ describe( "A stop word in url assessment", function() {
 	} );
 } );
 
-describe( "Checks if the assesment is applicable", function() {
+describe( "Checks if the assessment is applicable", function() {
 	it( "returns true for isApplicable for an English paper", function() {
 		var paper = new Paper( "", {locale: "en_EN"} );
 		expect( stopWordsInUrlAssessment.isApplicable( paper )).toBe( true );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Only applies stopword assessments for available languages

## Relevant technical choices:

* Restricted the stopwords to only be checked in English. Currently we don't have other languages supported in JS than English, so running these checks on other languages don't make any sense. 

## Test instructions

This PR can be tested by following these steps:

* Set language to English (if that is not already the site language). 
* Create a keyword and slug with a stop word in it
* See that the stopwords assessments give feedback. 
* Set language to something else. 
* See that the stopwords assessments no longer return feedback. 

Related: #972