### PR TITLE
Raise maximum number of eslint warnings

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	target: {
 		src: [ "<%= files.js %>", "!js/templates.js" ],
 		options: {
-			maxWarnings: 20,
+			maxWarnings: 22,
 		},
 	},
 };


### PR DESCRIPTION
Increases the maximum number of eslint warnings, because eslint now throws a warning for todo's.

Please merge https://github.com/Yoast/eslint/pull/1 first.