### PR TITLE
Fixes the wording of the feedback string for the subheading too long assessment. 

### DIFF
--- a/js/assessments/subheadingDistributionTooLongAssessment.js
+++ b/js/assessments/subheadingDistributionTooLongAssessment.js
@@ -78,7 +78,7 @@ var subheadingsTextLength = function( subheadingTextsLength, tooLongTexts, i18n 
 		text: i18n.sprintf(
 			i18n.dngettext(
 				"js-text-analysis",
-				"%1$d of the subheadings is followed by more than the recommended maximum of %2$d words. Try to insert another subheading.",
+				"%1$d subheading is followed by more than the recommended maximum of %2$d words. Try to insert another subheading.",
 				"%1$d of the subheadings are followed by more than the recommended maximum of %2$d words. Try to insert additional subheadings.",
 				tooLongTexts ),
 			tooLongTexts, recommendedValue

--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -25,7 +25,7 @@ describe( "An assessment for scoring too long sub texts.", function() {
 	it ( "returns a heading that is too long", function() {
 		var assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 400}, {text: "", wordCount: 300} ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "1 of the subheadings is followed by more than the recommended maximum of 300 words. Try to insert another subheading." );
+		expect( assessment.getText() ).toBe( "1 subheading is followed by more than the recommended maximum of 300 words. Try to insert another subheading." );
 	} );
 
 	it ( "returns a heading that is too long", function() {


### PR DESCRIPTION
Fixes #https://github.com/Yoast/wordpress-seo/issues/5089

The wording of the feedback string wasn't correct. This fixes that. This is a string only change.