### PR TITLE
Improves the scoring based on the amount of applicable assessments. 

### DIFF
--- a/js/assessor.js
+++ b/js/assessor.js
@@ -279,4 +279,20 @@ Assessor.prototype.getAssessment = function( identifier ) {
 	} );
 };
 
+/**
+ * Checks which of the available assessments are applicable and returns an array with applicable assessments.
+ *
+ * @returns {Array} The array with applicable assessments.
+ */
+Assessor.prototype.getApplicableAssessments = function() {
+	var availableAssessments = this.getAvailableAssessments();
+	return filter(
+		availableAssessments,
+		function( availableAssessment ) {
+			return this.isApplicable( availableAssessment, this.getPaper() );
+		}.bind( this )
+	);
+};
+
+
 module.exports = Assessor;

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -90,7 +90,7 @@ ContentAssessor.prototype.getApplicableAssessments = function() {
 	return filter(
 		availableAssessments,
 		function( availableAssessment ) {
-			return this.isApplicable( availableAssessment, this.getPaper() )
+			return this.isApplicable( availableAssessment, this.getPaper() );
 		}.bind( this )
 	);
 };

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -45,12 +45,12 @@ var ContentAssessor = function( i18n, options ) {
 require( "util" ).inherits( ContentAssessor, Assessor );
 
 /**
- * Calculates the weighted rating for English languages based on a given rating.
+ * Calculates the weighted rating for languages that have all assessments based on a given rating.
  *
  * @param {number} rating The rating to be weighted.
  * @returns {number} The weighted rating.
  */
-ContentAssessor.prototype.calculatePenaltyPointsSupportedLanguage = function( rating ) {
+ContentAssessor.prototype.calculatePenaltyPointsFullSupport = function( rating ) {
 	switch ( rating ) {
 		case "bad":
 			return 3;
@@ -63,12 +63,12 @@ ContentAssessor.prototype.calculatePenaltyPointsSupportedLanguage = function( ra
 };
 
 /**
- * Calculates the weighted rating for non-English languages based on a given rating.
+ * Calculates the weighted rating for languages that don't have all assessments based on a given rating.
  *
  * @param {number} rating The rating to be weighted.
  * @returns {number} The weighted rating.
  */
-ContentAssessor.prototype.calculatePenaltyPointsUnsupportedLanguage = function( rating ) {
+ContentAssessor.prototype.calculatePenaltyPointsPartialSupport = function( rating ) {
 	switch ( rating ) {
 		case "bad":
 			return 4;
@@ -81,18 +81,15 @@ ContentAssessor.prototype.calculatePenaltyPointsUnsupportedLanguage = function( 
 };
 
 /**
- * Checks which of the available assessments are applicable and returns an array with applicable assessments.
+ * Determines whether a language is fully supported. If a language supports 8 content assessments
+ * it is fully supported
  *
- * @returns {Array} The array with applicable assessments.
+ * @returns {boolean} True if fully supported.
  */
-ContentAssessor.prototype.getApplicableAssessments = function() {
-	var availableAssessments = this.getAvailableAssessments();
-	return filter(
-		availableAssessments,
-		function( availableAssessment ) {
-			return this.isApplicable( availableAssessment, this.getPaper() );
-		}.bind( this )
-	);
+ContentAssessor.prototype._allAssessmentsSupported = function() {
+	var numberOfAssessments = 8;
+	var applicableAssessments = this.getApplicableAssessments();
+	return applicableAssessments.length === numberOfAssessments;
 };
 
 /**
@@ -103,17 +100,14 @@ ContentAssessor.prototype.getApplicableAssessments = function() {
 ContentAssessor.prototype.calculatePenaltyPoints = function() {
 	var results = this.getValidResults();
 
-	var numberOfAssessments = 8;
-	var applicableAssessments = this.getApplicableAssessments();
-
 	var penaltyPoints = map( results, function( result ) {
 		var rating = scoreToRating( result.getScore() );
 
-		if ( applicableAssessments.length >= numberOfAssessments ) {
-			return this.calculatePenaltyPointsSupportedLanguage( rating );
+		if ( this._allAssessmentsSupported() ) {
+			return this.calculatePenaltyPointsFullSupport( rating );
 		}
 
-		return this.calculatePenaltyPointsUnsupportedLanguage( rating );
+		return this.calculatePenaltyPointsPartialSupport( rating );
 	}.bind( this ) );
 
 	return sum( penaltyPoints );
@@ -133,7 +127,7 @@ ContentAssessor.prototype._ratePenaltyPoints = function( totalPenaltyPoints ) {
 		return 30;
 	}
 
-	if ( this.getPaper().getLocale().indexOf( "en_" ) > -1 ) {
+	if ( this._allAssessmentsSupported() ) {
 		// Determine the total score based on the total penalty points.
 		if ( totalPenaltyPoints > 6 ) {
 			// A red indicator.

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -87,11 +87,10 @@ ContentAssessor.prototype.calculatePenaltyPointsUnsupportedLanguage = function( 
  */
 ContentAssessor.prototype.getApplicableAssessments = function() {
 	var availableAssessments = this.getAvailableAssessments();
-	var paper = this.getPaper();
 	return filter(
 		availableAssessments,
 		function( availableAssessment ) {
-			return this.isApplicable( availableAssessment, paper )
+			return this.isApplicable( availableAssessment, this.getPaper() )
 		}.bind( this )
 	);
 };

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -15,7 +15,6 @@ var scoreToRating = require( "./interpreters/scoreToRating" );
 
 var map = require( "lodash/map" );
 var sum = require( "lodash/sum" );
-var filter = require( "lodash/filter" );
 
 /**
  * Creates the Assessor

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -184,4 +184,26 @@ describe( "A content assesor", function() {
 			});
 		});
 	});
+	describe( "Checks the applicable assessments", function() {
+		var contentAssessor = new ContentAssessor( i18n );
+		it( "Should have 8 available assessments for a fully supported language", function() {
+			contentAssessor.getPaper = function() {
+				return new Paper( "test", { locale: "en_EN" } );
+			};
+
+			var actual = contentAssessor.getApplicableAssessments().length;
+			var expected = 8;
+			expect( actual ).toBe( expected );
+		});
+
+		it( "Should have 4 available assessments for a basic supported language", function() {
+			contentAssessor.getPaper = function() {
+				return new Paper( "test", { locale: "xx_XX" } );
+			};
+
+			var actual = contentAssessor.getApplicableAssessments().length;
+			var expected = 4;
+			expect( actual ).toBe( expected );
+		});
+	})
 });

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -51,8 +51,8 @@ describe( "A content assesor", function() {
 		});
 
 		it( "should return 3 for a red assessment result", function() {
-			contentAssessor.getApplicableAssessments = function () {
-				return [ {}, {}, {}, {}, {}, {}, {}, {} ];
+			contentAssessor.isLanguageFullySupported = function () {
+				return true;
 			};
 
 			results = [
@@ -77,8 +77,8 @@ describe( "A content assesor", function() {
 		});
 
 		it( "should return an aggregate for a mixed resultset", function() {
-			contentAssessor.getApplicableAssessments = function () {
-				return [ {}, {}, {}, {}, {}, {}, {}, {} ];
+			contentAssessor.isLanguageFullySupported = function () {
+				return true;
 			};
 			results = [
 				new AssessmentResult({ score: 9 }),
@@ -140,6 +140,10 @@ describe( "A content assesor", function() {
 
 			forEach( testCases, function( testCase ) {
 				points = testCase.points;
+
+				contentAssessor.isLanguageFullySupported = function () {
+					return true;
+				};
 
 				var actual = contentAssessor.calculateOverallScore();
 

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -51,6 +51,10 @@ describe( "A content assesor", function() {
 		});
 
 		it( "should return 3 for a red assessment result", function() {
+			contentAssessor.getApplicableAssessments = function () {
+				return [ {}, {}, {}, {}, {}, {}, {}, {} ];
+			};
+
 			results = [
 				new AssessmentResult({ score: 3 })
 			];
@@ -73,6 +77,9 @@ describe( "A content assesor", function() {
 		});
 
 		it( "should return an aggregate for a mixed resultset", function() {
+			contentAssessor.getApplicableAssessments = function () {
+				return [ {}, {}, {}, {}, {}, {}, {}, {} ];
+			};
 			results = [
 				new AssessmentResult({ score: 9 }),
 				new AssessmentResult({ score: 6 }),


### PR DESCRIPTION
## Summary
We used to score English different from other languages, because we supported more assessments in English than any other language. With all assessments created for German and working insights we now also fully support German, so this should be supported as well. 

To make sure we don't need to check this for every language, this is based on the number of assessments that are available. If all 8 assessments are available for a supported language, we score it the same as we scored English (so 3 penalty points per red bullet) instead of 4 points per red bullet. This increases the accuracy of the feedback. 

This PR can be summarized in the following changelog entry:
Improves the scoring for fully supported languages. 

## Relevant technical choices:

* This PR makes sure we look at the available assessments, rather than the language. 

## Test instructions

This PR can be tested by following these steps:
* Test on develop
* Create a post in German
* Have 2 red bullets for assessments
* Total SEO should be red
* Test on this branch, yarn link yoastseo.js into wordpress, and build the js. 
* Check the same post, still have 2 red bullets
* Total SEO should be orange. 

Fixes #990
