### PR TITLE
Add spec for empty participle in English Participle

### DIFF
--- a/spec/researches/english/EnglishParticipleSpec.js
+++ b/spec/researches/english/EnglishParticipleSpec.js
@@ -1,8 +1,8 @@
-var EnglishParticiple = require( "../../../js/researches/english/EnglishParticiple.js" );
+let EnglishParticiple = require( "../../../js/researches/english/EnglishParticiple.js" );
 
 describe( "A test for checking the English Participle", function() {
 	it( "checks the properties of the English participle object with a passive", function() {
-		var mockParticiple = new EnglishParticiple( "fired", "He was fired", { auxiliaries: [ "was" ], type: "regular" } );
+		let mockParticiple = new EnglishParticiple( "fired", "He was fired", { auxiliaries: [ "was" ], type: "regular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "fired" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -13,7 +13,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a non-verb ending in -ed", function() {
-		var mockParticiple = new EnglishParticiple( "airbed", "It is an airbed", { auxiliaries: [ "is" ], type: "regular" } );
+		let mockParticiple = new EnglishParticiple( "airbed", "It is an airbed", { auxiliaries: [ "is" ], type: "regular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "airbed" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( true );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -24,7 +24,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a 'rid' exception", function() {
-		var mockParticiple = new EnglishParticiple( "rid", "He wants to get rid of it", { auxiliaries: [ "get" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "rid", "He wants to get rid of it", { auxiliaries: [ "get" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "rid" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( true );
@@ -35,7 +35,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a 'having' exception", function() {
-		var mockParticiple = new EnglishParticiple( "read", "I am wiser for having read that book", { auxiliaries: [ "am" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "read", "I am wiser for having read that book", { auxiliaries: [ "am" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "read" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -46,7 +46,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a 'left' exception", function() {
-		var mockParticiple = new EnglishParticiple( "left", "He was at the left", { auxiliaries: [ "was" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "left", "He was at the left", { auxiliaries: [ "was" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "left" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -57,7 +57,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with 'left' that is not an exception", function() {
-		var mockParticiple = new EnglishParticiple( "left", "He was left", { auxiliaries: [ "was" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "left", "He was left", { auxiliaries: [ "was" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "left" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -68,7 +68,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a 'fit' exception", function() {
-		var mockParticiple = new EnglishParticiple( "fit", "She was a fit girl", { auxiliaries: [ "was" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "fit", "She was a fit girl", { auxiliaries: [ "was" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -79,7 +79,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a 'fit' exception", function() {
-		var mockParticiple = new EnglishParticiple( "fit", "She lithe the fit girl", { auxiliaries: [ "was" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "fit", "She lithe the fit girl", { auxiliaries: [ "was" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -90,7 +90,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with 'fit' that is not an exception", function() {
-		var mockParticiple = new EnglishParticiple( "fit", "The data was then fit by the optimal model", { auxiliaries: [ "was" ], type: "irregular" } );
+		let mockParticiple = new EnglishParticiple( "fit", "The data was then fit by the optimal model", { auxiliaries: [ "was" ], type: "irregular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -100,4 +100,10 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
+	it( "ensures that the sentence part is set to passive if the participle is empty.", function() {
+		let mockParticiple = new EnglishParticiple( "cooked", "It is cooked by him", { auxiliaries: [ "is" ], type: "regular" } );
+		mockParticiple._participle = null;
+		mockParticiple.checkException();
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	});
 });


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: N/A.

- Add spec for empty participle
- Change 'var' to 'let'
