### PR TITLE
Add Dutch prominent words

### DIFF
--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -1,11 +1,12 @@
 let transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
- * Returns an array with exceptions for the keyword suggestion researcher.
+ * Returns an array with exceptions for the prominent words researcher.
  * @returns {Array} The array filled with exceptions.
  */
 
 let articles = [ "de", "het", "een" ];
+
 let numerals = [ "eén", "één", "twee", "drie", "vier", "vijf", "zes", "zeven", "acht", "negen", "tien", "elf", "twaalf", "dertien",
 	"veertien", "vijftien", "zestien", "zeventien", "achttien", "negentien", "twintig", "eerste", "tweede", "derde", "vierde",
 	"vijfde", "zesde", "zevende", "achtste", "negende", "tiende", "elfde", "twaalfde", "dertiende", "veertiende", "vijftiende",
@@ -24,15 +25,21 @@ let quantifiers = [ "alle", "sommige", "sommigen", "allen", "weinig", "weinige",
 	"laatste", "laatsten", "ieder", "iedere", "allemaal", "alles", "al", "zekere", "ander", "andere", "gene", "enig", "enige", "verscheidene",
 	"verschillende", "voldoende", "wat", "allerlei", "allerhande", "enerlei", "enerhande", "beiderlei", "beiderhande", "tweeërlei", "tweeërhande",
 	"drieërlei", "drieërhande", "velerlei", "velerhande", "menigerlei", "menigerhande", "enigerlei", "enigerhande", "generlei", "generhande" ];
+
 let reflexivePronouns = [ "mezelf", "mijzelf", "jezelf", "jouzelf", "zichzelf", "haarzelf", "hemzelf", "onszelf", "julliezelf",
 	"henzelf", "hunzelf", "zich" ];
+
 let reciprocalPronouns = [ "mekaar", "elkaar", "elkander", "mekander" ];
+
 let indefinitePronouns = [ "iedereen", "ieder", "eenieder", "alleman", "allen", "alles", "iemand", "niemand", "iets",
 	"niets", "menigeen" ];
+
 let indefinitePronounsPossessive  = [ "ieders", "aller", "iedereens", "eenieders" ];
 
 let interrogativePronouns = [ "welke", "welk", "wat", "wie", "wiens", "wier" ];
+
 let interrogativeAdverbs = [ "hoe", "waarom", "waar", "hoezo", "wanneer", "hoeveel" ];
+
 let pronominalAdverbs = [ "daaraan", "daarachter", "daaraf", "daarbij", "daarbinnen", "daarboven", "daarbuiten", "daardoor", "daardoorheen",
 	"daarheen", "daarin", "daarjegens", "daarmede", "daarmee", "daarna", "daarnaar", "daarnaartoe", "daarnaast", "daarom", "daaromtrent",
 	"daaronder", "daarop", "daarover", "daaroverheen", "daarrond", "daartegen", "daartoe", "daartussen", "daartussenuit", "daaruit", "daarvan",
@@ -46,10 +53,14 @@ let pronominalAdverbs = [ "daaraan", "daarachter", "daaraf", "daarbij", "daarbin
 	"waarbuiten", "waardoor", "waardoorheen", "waarheen", "waarin", "waarjegens", "waarmede", "waarmee", "waarna", "waarnaar", "waarnaartoe",
 	"waarnaast", "waaronder", "waarop", "waarover", "waaroverheen", "waarrond", "waartegen", "waartegenin", "waartoe", "waartussen",
 	"waartussenuit", "waaruit", "waarvan", "waarvandaan", "waarvoor" ];
+
 let locativeAdverbs = [ "daar", "hier", "ginder", "daarginds", "ginds", "ver", "veraf", "ergens", "nergens", "overal", "dichtbij",
 	"nabij", "kortbij" ];
+
 let filteredPassiveAuxiliaries = [ "word", "wordt", "werd", "werden", "ben", "bent", "is", "was", "waren" ];
+
 let infinitivePassiveAuxiliaries = [ "worden", "zijn" ];
+
 let otherAuxiliaries = [ "heb", "hebt", "heeft", "hebben", "hadden", "had", "kun", "kan", "kunt", "kunnen", "kon", "konden", "mag",
 	"mogen", "mocht", "mochten", "dien", "dient", "dienen", "diende", "dienden", "moet", "moeten", "moest", "moesten", "ga", "gaat",
 	"gaan", "ging", "gingen" ];
@@ -77,13 +88,13 @@ let coordinatingConjunctions = [ "en", "noch", "alsmede", "alsook", "maar", "doc
 /* 'Zowel' and 'als' are part of 'zowel...als', 'evenmin' is part of 'evenmin...als', 'zomin' is part of 'zomin...als',
  'hetzij' is part of 'hetzij...hetzij'. */
 let correlativeConjunctions = [ "zowel", "als", "evenmin", "zomin", "hetzij" ];
+
 let subordinatingConjunctions = [ "omdat", "doordat", "aangezien", "vermits", "dewijl", "dorodien", "naardien", "nademaal", "overmits",
 	"wijl", "voordat", "eer", "eerdat", "aleer", "vooraleer", "alvorens", "tot", "totdat", "terwijl", "zolang", "zodra", "sinds", "sedert",
 	"toen", "nu", "nadat", "zodat", "opdat", "teneinde", "indien", "ingeval", "tenware", "hoewel", "alhoewel", "ofschoon", "hoezeer",
 	"behalve", "uitgezonderd", "zoverre", "zover", "naargelang", "naarmate", "alsof", "zoals", "evenals" ];
 
 // These verbs are frequently used in interviews to indicate questions and answers.
-// 'Claim','claims', 'state' and 'states' are not included, because these words are also nouns.
 let interviewVerbs = [ "zegt", "zei", "aldus", "vraagt", "vroeg", "denkt", "dacht", "stelt", "pleit", "pleitte" ];
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
@@ -125,7 +136,6 @@ let interjections = [ "oh", "wauw", "hèhè", "hè", "hé", "au", "ai", "jaja", 
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
 let recipeWords = [ "ml", "cl", "dl", "l", "tl", "el", "mg", "g", "gr", "kg", "ca", "theel", "min", "sec", "uur"  ];
 
-// 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
 let vagueNouns = [ "ding", "dingen", "manier", "manieren", "item", "items", "keer", "maal", "procent", "geval", "aspect", "persoon",
 	"personen", "deel" ];
 

--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -139,8 +139,12 @@ let recipeWords = [ "ml", "cl", "dl", "l", "tl", "el", "mg", "g", "gr", "kg", "c
 let vagueNouns = [ "ding", "dingen", "manier", "manieren", "item", "items", "keer", "maal", "procent", "geval", "aspect", "persoon",
 	"personen", "deel" ];
 
-// 'No' is already included in the quantifier list.
 let miscellaneous = [ "niet", "wel", "ja", "nee", "neen", "oké", "oke", "okee", "ok", "niets", "zoiets", "%", "€", "euro" ];
+
+/*
+Exports all function words concatenated, and specific word categories and category combinations
+to be used as filters for the prominent words.
+ */
 
 module.exports = function() {
 	return {

--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -14,12 +14,12 @@ let numerals = [ "eén", "één", "twee", "drie", "vier", "vijf", "zes", "zeven"
 	"miljoenen", "biljoen", "biljoenen" ];
 
 // 'Het' is already included in the list of articles.
-let personalPronounsNominative = [ "ik", "je", "jij", "hij", "ze", "we", "wij", "jullie", "zij" ];
-let personalPronounsAccusative = [ "mij", "jou", "hem", "haar", "hen", "hun" ];
+let personalPronounsNominative = [ "ik", "je", "jij", "hij", "ze", "we", "wij", "jullie", "zij", "u", "ge", "gij" ];
+let personalPronounsAccusative = [ "mij", "jou", "hem", "haar", "hen", "hun", "uw" ];
 let demonstrativePronouns = [ "dit", "dat", "deze", "die", "zelf" ];
 
 // What to do with 'zijn', since it is also a verb?
-let possessivePronouns = [ "mijn", "mijne", "jouw", "jouwe", "zijne", "hare", "ons", "onze", "hunne" ];
+let possessivePronouns = [ "mijn", "mijne", "jouw", "jouwe", "zijne", "hare", "ons", "onze", "hunne", "uwe" ];
 let quantifiers = [ "alle", "sommige", "sommigen", "allen", "weinig", "weinige", "weinigen", "veel", "vele", "velen", "geen", "beetje",
 	"elke", "elk", "genoeg", "meer", "meest", "meeste", "meesten", "paar", "zoveel", "enkele", "enkelen", "zoveelste", "hoeveelste",
 	"laatste", "laatsten", "ieder", "iedere", "allemaal", "alles", "al", "zekere", "ander", "andere", "gene", "enig", "enige", "verscheidene",
@@ -27,7 +27,7 @@ let quantifiers = [ "alle", "sommige", "sommigen", "allen", "weinig", "weinige",
 	"drieërlei", "drieërhande", "velerlei", "velerhande", "menigerlei", "menigerhande", "enigerlei", "enigerhande", "generlei", "generhande" ];
 
 let reflexivePronouns = [ "mezelf", "mijzelf", "jezelf", "jouzelf", "zichzelf", "haarzelf", "hemzelf", "onszelf", "julliezelf",
-	"henzelf", "hunzelf", "zich" ];
+	"henzelf", "hunzelf", "uzelf", "zich" ];
 
 let reciprocalPronouns = [ "mekaar", "elkaar", "elkander", "mekander" ];
 

--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -1,0 +1,161 @@
+let transitionWords = require( "./transitionWords.js" )().singleWords;
+
+/**
+ * Returns an array with exceptions for the keyword suggestion researcher.
+ * @returns {Array} The array filled with exceptions.
+ */
+
+let articles = [ "de", "het", "een" ];
+let numerals = [ "eén", "één", "twee", "drie", "vier", "vijf", "zes", "zeven", "acht", "negen", "tien", "elf", "twaalf", "dertien",
+	"veertien", "vijftien", "zestien", "zeventien", "achttien", "negentien", "twintig", "eerste", "tweede", "derde", "vierde",
+	"vijfde", "zesde", "zevende", "achtste", "negende", "tiende", "elfde", "twaalfde", "dertiende", "veertiende", "vijftiende",
+	"zestiende", "zeventiende", "achttiende", "negentiende", "twinstigste", "honderd", "honderden", "duizend", "duizenden", "miljoen",
+	"miljoenen", "biljoen", "biljoenen" ];
+
+// 'Het' is already included in the list of articles.
+let personalPronounsNominative = [ "ik", "jij", "hij", "ze", "we", "wij", "jullie", "zij" ];
+let personalPronounsAccusative = [ "mij", "jou", "hem", "haar", "hen", "hun" ];
+let demonstrativePronouns = [ "dit", "dat", "deze", "die" ];
+
+// What to do with 'zijn', since it is also a verb?
+let possessivePronouns = [ "mijn", "mijne", "jouw", "jouwe", "zijne", "hare", "ons", "onze", "hunne" ];
+let quantifiers = [ "alle", "sommige", "sommigen", "allen", "weinig", "weinige", "weinigen", "veel", "vele", "velen", "geen", "beetje",
+	"elke", "elk", "genoeg", "meer", "meest", "meeste", "meesten", "paar", "zoveel", "enkele", "enkelen", "zoveelste", "hoeveelste",
+	"laatste", "laatsten", "ieder", "iedere", "allemaal", "alles", "al", "zekere", "ander", "andere", "gene", "enig", "enige", "verscheidene",
+	"verschillende", "voldoende", "wat", "allerlei", "allerhande", "enerlei", "enerhande", "beiderlei", "beiderhande", "tweeërlei", "tweeërhande",
+	"drieërlei", "drieërhande", "velerlei", "velerhande", "menigerlei", "menigerhande", "enigerlei", "enigerhande", "generlei", "generhande" ];
+let reflexivePronouns = [ "mezelf", "mijzelf", "jezelf", "jouzelf", "zichzelf", "haarzelf", "hemzelf", "onszelf", "julliezelf",
+	"henzelf", "hunzelf", "zich" ];
+let reciprocalPronouns = [ "mekaar", "elkaar", "elkander", "mekander" ];
+let indefinitePronouns = [ "iedereen", "ieder", "eenieder", "alleman", "allen", "alles", "iemand", "niemand", "iets",
+	"niets", "menigeen" ];
+let indefinitePronounsPossessive  = [ "ieders", "aller", "iedereens", "eenieders" ];
+
+let interrogativePronouns = [ "welke", "welk", "wat", "wie", "wiens", "wier" ];
+let interrogativeAdverbs = [ "hoe", "waarom", "waar", "hoezo", "wanneer", "hoeveel" ];
+let pronominalAdverbs = [ "daaraan", "daarachter", "daaraf", "daarbij", "daarbinnen", "daarboven", "daarbuiten", "daardoor", "daardoorheen",
+	"daarheen", "daarin", "daarjegens", "daarmede", "daarmee", "daarna", "daarnaar", "daarnaartoe", "daarnaast", "daarom", "daaromtrent",
+	"daaronder", "daarop", "daarover", "daaroverheen", "daarrond", "daartegen", "daartoe", "daartussen", "daartussenuit", "daaruit", "daarvan",
+	"daarvandaan", "daarvoor", "eraan", "erachter", "erachteraan", "eraf", "erbij", "erbinnen", "erboven", "erbuiten", "erdoor", "erdoorheen",
+	"erheen", "erin", "erjegens", "ermede", "ermee", "erna", "ernaar", "ernaartoe", "ernaast", "erom", "eromtrent", "eronder", "eronderdoor",
+	"erop", "eropaf", "eropuit", "erover", "eroverheen", "errond", "ertegen", "ertegenaan", "ertoe", "ertussen", "ertussenuit", "eruit", "ervan",
+	"ervandaan", "ervandoor", "ervoor", "hieraan", "hierachter", "hieraf", "hierbij", "hierbinnen", "hierboven", "hierbuiten", "hierdoor",
+	"hierdoorheen", "hierheen", "hierin", "hierjegens", "hierlangs", "hiermede", "hiermee", "hierna", "hiernaar", "hiernaartoe", "hiernaast",
+	"hierom", "hieromheen", "hieromtrent", "hieronder", "hierop", "hierover", "hieroverheen", "hierrond", "hiertegen", "hiertoe", "hiertussen",
+	"hiertussenuit", "hieruit", "hiervan", "hiervandaan", "hiervoor", "vandaan", "waaraan", "waarachter", "waaraf", "waarbij", "waarboven",
+	"waarbuiten", "waardoor", "waardoorheen", "waarheen", "waarin", "waarjegens", "waarmede", "waarmee", "waarna", "waarnaar", "waarnaartoe",
+	"waarnaast", "waaronder", "waarop", "waarover", "waaroverheen", "waarrond", "waartegen", "waartegenin", "waartoe", "waartussen",
+	"waartussenuit", "waaruit", "waarvan", "waarvandaan", "waarvoor" ];
+let locativeAdverbs = [ "daar", "hier", "ginder", "daarginds", "ginds", "ver", "veraf", "ergens", "nergens", "overal", "dichtbij",
+	"nabij", "kortbij" ];
+let filteredPassiveAuxiliaries = [ "word", "wordt", "werd", "werden", "ben", "bent", "is", "was", "waren" ];
+let infinitivePassiveAuxiliaries = [ "worden", "zijn" ];
+let otherAuxiliaries = [ "heb", "hebt", "heeft", "hebben", "hadden", "had", "kun", "kan", "kunt", "kunnen", "kon", "konden", "mag",
+	"mogen", "mocht", "mochten", "dien", "dient", "dienen", "diende", "dienden", "moet", "moeten", "moest", "moesten", "ga", "gaat",
+	"gaan", "ging", "gingen" ];
+
+// 'Vóórkomen' (appear) is not included, because we don't want to filter out 'voorkómen' (prevent).
+let copula = [ "blijken", "blijkt", "blijk", "bleek", "bleken", "gebleken", "dunken", "dunkt", "dunk", "dunkte", "dunkten",
+	"gedunkt", "heet", "heten", "heette", "heetten", "geheten", "lijkt", "lijk", "lijken", "geleken", "leek", "leken", "schijnen",
+	"schijn", "schijnt", "scheen", "schenen", "toescheen", "toeschijnt", "toeschijnen", "toeschijn", "toeschenen" ];
+
+let prepositions = [ "à", "aan", "aangaande", "achter", "behalve", "behoudens", "beneden", "benevens", "benoorden", "benoordoosten", "benoordwesten",
+	"beoosten", "betreffende", "bewesten", "bezijden", "bezuiden", "bezuidoosten", "bezuidwesten", "bij", "binnen", "blijkens", "boven", "bovenaan",
+	"buiten", "circa", "conform", "contra", "cum", "dankzij", "door", "gedurende", "gezien", "in", "ingevolge", "inzake", "jegens", "krachtens",
+	"langs", "luidens", "met", "middels", "mits", "na", "naar", "naast", "nabij", "namens", "nevens", "niettegenstaande", "nopens", "om",
+	"omstreeks", "omtrent", "ondanks", "onder", "onderaan", "ongeacht", "onverminderd", "op", "over", "overeenkomstig", "per", "plus", "post",
+	"richting", "rond", "rondom", "sedert", "sinds", "spijts", "staande", "te", "tegen", "tegenover", "ten", "ter", "tijdens", "tot", "tussen",
+	"uit", "uitgezonderd", "van", "vanaf", "vanuit", "vanwege", "versus", "via", "vis-à-vis", "volgens", "voor", "voorbij", "wegens", "zijdens",
+	"zonder" ];
+
+// Many prepositional adverbs are already listed as preposition.
+let prepositionalAdverbs = [ "af", "buiten", "door", "heen", "mee", "toe", "vandaan", "achterop", "onderin", "voorin", "bovenaan", "bovenop",
+	"buitenop", "onderaan", "achteraan", "onderop", "binnenin", "tevoren", "erin", "daarnaast" ];
+
+let coordinatingConjunctions = [ "en", "noch", "alsmede", "alsook", "maar", "doch", "of", "ofwel", "dan", "want", "dus" ];
+
+/* 'Zowel' and 'als' are part of 'zowel...als', 'evenmin' is part of 'evenmin...als', 'zomin' is part of 'zomin...als',
+ 'hetzij' is part of 'hetzij...hetzij'. */
+let correlativeConjunctions = [ "zowel", "als", "evenmin", "zomin", "hetzij" ];
+let subordinatingConjunctions = [ "omdat", "doordat", "aangezien", "vermits", "dewijl", "dorodien", "naardien", "nademaal", "overmits",
+	"wijl", "voordat", "eer", "eerdat", "aleer", "vooraleer", "alvorens", "tot", "totdat", "terwijl", "zolang", "zodra", "sinds", "sedert",
+	"toen", "nu", "nadat", "zodat", "opdat", "teneinde", "indien", "ingeval", "tenware", "hoewel", "alhoewel", "ofschoon", "hoezeer",
+	"behalve", "uitgezonderd", "zoverre", "zover", "naargelang", "naarmate", "alsof", "zoals", "evenals" ];
+
+// These verbs are frequently used in interviews to indicate questions and answers.
+// 'Claim','claims', 'state' and 'states' are not included, because these words are also nouns.
+let interviewVerbs = [ "zegt", "zei", "aldus", "vraagt", "vroeg", "denkt", "dacht", "stelt", "pleit", "pleitte" ];
+
+// These transition words were not included in the list for the transition word assessment for various reasons.
+let additionalTransitionWords = [ "absoluut", "zeker", "ongetwijfeld", "sowieso", "onmiddelijk", "meteen", "inclusief",
+	"direct", "ogenblikkelijk", "terstond", "namelijk", "natuurlijk", "vanzelfsprekend", "tegenwoordig", "gewoonlijk", "normaliter",
+	"doorgaans", "werkelijk", "daadwerkelijk", "inderdaad", "uiteindelijk", "waarachtig", "oprecht", "bijna", "meestal", "misschien",
+	"waarschijnlijk", "wellicht", "mogelijk", "vermoedelijk", "ongetwijfeld", "allicht", "aannemelijk", "oorspronkelijk", "aanvankelijk",
+	"allereerst", "initieel", "eigenlijk", "feitelijk", "wezenlijk", "juist", "reeds", "alvast", "bijv.", "vaak", "dikwijls", "veelal",
+	"geregeld", "menigmaal", "regelmatig", "veelvuldig", "eenvoudigweg", "simpelweg", "louter", "kortweg", "stomweg", "domweg", "zomaar",
+	"eventueel", "mogelijkerwijs", "eens", "weleens", "nooit", "ooit", "anders", "momenteel", "thans", "incidenteel", "trouwens", "elders",
+	"volgend", "recent", "onlangs", "recentelijk", "laatst", "zojuist", "relatief", "duidelijk", "overduidelijk", "klaarblijkelijk",
+	"nadrukkelijk", "ogenschijnlijk", "duidelijk", "kennelijk", "schijnbaar", "alweer", "continu", "herhaaldelijk" ];
+
+let intensifiers = [ "zeer", "erg", "redelijk", "flink", "beetje", "tikkeltje", "bijzonder", "ernstig", "enigszins",
+	"hoe", "zo", "wat", "tamelijk", "nogal", "vrij", "genoeg", "behoorlijk", "hard", "zwaar", "heel", "reuze", "buitengewoon",
+	"ontzettend", "vreselijk" ];
+
+// These verbs convey little meaning.
+let delexicalisedVerbs = [ "laten", "laat", "liet", "lieten", "komen", "kom", "komt", "kwam", "kwamen", "maken", "maakt",
+	"maak", "maakte", "maakten", "doen", "doe", "doet", "deed", "deden" ];
+
+/* These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
+Keyword combinations containing these adjectives/adverbs are fine. */
+let generalAdjectivesAdverbs = [ "nieuw", "nieuwe", "nieuwer", "nieuwere", "nieuwst", "nieuwste", "oud", "oude", "ouder", "oudere",
+	"oudst", "oudste", "vorig", "vorige", "goed", "goede", "beter", "betere", "best", "beste", "groot", "grote", "groter", "grotere",
+	"grootst", "grootste", "makkelijk", "makkelijke", "makkelijker", "makkelijkere", "makkelijkst", "makkelijste", "gemakkelijk",
+	"gemakkelijke", "gemakkelijker", "gemakkelijkere", "gemakkelijkst", "gemakkelijste", "simpel", "simpele", "simpeler", "simpeler",
+	"simpelst", "simpelste", "snel", "snelle", "sneller", "snellere", "snelst", "snelste", "ver", "verre", "verder", "verdere", "verst",
+	"verste", "lang", "lange", "langer", "langere", "langst", "langste", "hard", "harde", "harder", "hardere", "hardst", "hardste",
+	"weinig", "weinige", "minder", "mindere", "minst", "minste", "eigen", "laag", "lage", "lager", "lagere", "laagst", "laagste",
+	"hoog", "hoge", "hoger", "hogere", "hoogst", "hoogste", "klein", "kleine", "kleiner", "kleinere", "kleinst", "kleinste", "kort",
+	"korte", "korter", "kortere", "kortst", "kortste", "zekere", "herhaaldelijke", "directe", "ongeveer", "slecht", "slechte", "slechter",
+	"slechtere", "slechtst", "slechtste", "zulke", "zulk", "zo'n", "zulks", "er", "extreem" ];
+
+let interjections = [ "oh", "wauw", "hèhè", "hè", "hé", "au", "ai", "jaja", "welja", "jawel", "ssst", "heremijntijd", "hemeltjelief", "aha",
+	"er", "foei", "hmm", "nou", "nee", "tja", "nja", "okido", "ho", "halt", "komaan", "komop", "verrek", "nietwaar", "brr", "oef",
+	"ach", "och", "bah", "enfin", "afijn", "haha", "hihi", "hatsjie", "hatsjoe", "hm", "tring", "vroem", "boem", "hopla" ];
+
+// These words and abbreviations are frequently used in recipes in lists of ingredients.
+let recipeWords = [ "ml", "cl", "dl", "l", "tl", "el", "mg", "g", "gr", "kg", "ca", "theel", "min", "sec", "uur"  ];
+
+// 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
+let vagueNouns = [ "ding", "dingen", "manier", "manieren", "item", "items", "keer", "maal", "procent", "geval", "aspect", "persoon",
+	"personen", "deel" ];
+
+// 'No' is already included in the quantifier list.
+let miscellaneous = [ "niet", "wel", "ja", "nee", "neen", "oké", "oke", "okee", "ok", "niets", "zoiets", "%", "€" ];
+
+module.exports = function() {
+	return {
+		articles: articles,
+		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, possessivePronouns ),
+		prepositions: prepositions,
+		demonstrativePronouns: demonstrativePronouns,
+		conjunctions: coordinatingConjunctions.concat( subordinatingConjunctions ),
+		verbs: filteredPassiveAuxiliaries.concat( infinitivePassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs, delexicalisedVerbs ),
+		quantifiers: quantifiers,
+		relativePronouns: interrogativePronouns.concat( interrogativeAdverbs ),
+		passiveAuxiliaries: filteredPassiveAuxiliaries,
+		transitionWords: transitionWords.concat( additionalTransitionWords ),
+		miscellaneous: miscellaneous,
+		pronominalAdverbs: pronominalAdverbs,
+		interjections: interjections,
+		reflexivePronouns: reflexivePronouns,
+		reciprocalPronouns: reciprocalPronouns,
+		all: articles.concat( numerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, reciprocalPronouns,
+			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns,
+			indefinitePronounsPossessive, interrogativePronouns, interrogativeAdverbs,
+			pronominalAdverbs, locativeAdverbs, prepositionalAdverbs, filteredPassiveAuxiliaries, infinitivePassiveAuxiliaries,
+			otherAuxiliaries, copula, prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
+			transitionWords, additionalTransitionWords, intensifiers, delexicalisedVerbs, interjections, generalAdjectivesAdverbs,
+			recipeWords, vagueNouns, miscellaneous ),
+	};
+};
+

--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -5,7 +5,7 @@ let transitionWords = require( "./transitionWords.js" )().singleWords;
  * @returns {Array} The array filled with exceptions.
  */
 
-let articles = [ "de", "het", "een" ];
+let articles = [ "de", "het", "een", "der", "des", "den" ];
 
 let numerals = [ "eén", "één", "twee", "drie", "vier", "vijf", "zes", "zeven", "acht", "negen", "tien", "elf", "twaalf", "dertien",
 	"veertien", "vijftien", "zestien", "zeventien", "achttien", "negentien", "twintig", "eerste", "tweede", "derde", "vierde",
@@ -14,9 +14,9 @@ let numerals = [ "eén", "één", "twee", "drie", "vier", "vijf", "zes", "zeven"
 	"miljoenen", "biljoen", "biljoenen" ];
 
 // 'Het' is already included in the list of articles.
-let personalPronounsNominative = [ "ik", "jij", "hij", "ze", "we", "wij", "jullie", "zij" ];
+let personalPronounsNominative = [ "ik", "je", "jij", "hij", "ze", "we", "wij", "jullie", "zij" ];
 let personalPronounsAccusative = [ "mij", "jou", "hem", "haar", "hen", "hun" ];
-let demonstrativePronouns = [ "dit", "dat", "deze", "die" ];
+let demonstrativePronouns = [ "dit", "dat", "deze", "die", "zelf" ];
 
 // What to do with 'zijn', since it is also a verb?
 let possessivePronouns = [ "mijn", "mijne", "jouw", "jouwe", "zijne", "hare", "ons", "onze", "hunne" ];
@@ -106,15 +106,15 @@ let additionalTransitionWords = [ "absoluut", "zeker", "ongetwijfeld", "sowieso"
 	"geregeld", "menigmaal", "regelmatig", "veelvuldig", "eenvoudigweg", "simpelweg", "louter", "kortweg", "stomweg", "domweg", "zomaar",
 	"eventueel", "mogelijkerwijs", "eens", "weleens", "nooit", "ooit", "anders", "momenteel", "thans", "incidenteel", "trouwens", "elders",
 	"volgend", "recent", "onlangs", "recentelijk", "laatst", "zojuist", "relatief", "duidelijk", "overduidelijk", "klaarblijkelijk",
-	"nadrukkelijk", "ogenschijnlijk", "duidelijk", "kennelijk", "schijnbaar", "alweer", "continu", "herhaaldelijk" ];
+	"nadrukkelijk", "ogenschijnlijk", "duidelijk", "kennelijk", "schijnbaar", "alweer", "continu", "herhaaldelijk", "nog", "steeds" ];
 
 let intensifiers = [ "zeer", "erg", "redelijk", "flink", "beetje", "tikkeltje", "bijzonder", "ernstig", "enigszins",
-	"hoe", "zo", "wat", "tamelijk", "nogal", "vrij", "genoeg", "behoorlijk", "hard", "zwaar", "heel", "reuze", "buitengewoon",
+	"hoe", "zo", "wat", "tamelijk", "nogal", "vrij", "genoeg", "behoorlijk", "hard", "zwaar", "heel", "hele", "reuze", "buitengewoon",
 	"ontzettend", "vreselijk" ];
 
 // These verbs convey little meaning.
 let delexicalisedVerbs = [ "laten", "laat", "liet", "lieten", "komen", "kom", "komt", "kwam", "kwamen", "maken", "maakt",
-	"maak", "maakte", "maakten", "doen", "doe", "doet", "deed", "deden" ];
+	"maak", "maakte", "maakten", "doen", "doe", "doet", "deed", "deden", "vinden", "vindt", "vind", "vond", "vonden" ];
 
 /* These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
 Keyword combinations containing these adjectives/adverbs are fine. */
@@ -127,7 +127,7 @@ let generalAdjectivesAdverbs = [ "nieuw", "nieuwe", "nieuwer", "nieuwere", "nieu
 	"weinig", "weinige", "minder", "mindere", "minst", "minste", "eigen", "laag", "lage", "lager", "lagere", "laagst", "laagste",
 	"hoog", "hoge", "hoger", "hogere", "hoogst", "hoogste", "klein", "kleine", "kleiner", "kleinere", "kleinst", "kleinste", "kort",
 	"korte", "korter", "kortere", "kortst", "kortste", "zekere", "herhaaldelijke", "directe", "ongeveer", "slecht", "slechte", "slechter",
-	"slechtere", "slechtst", "slechtste", "zulke", "zulk", "zo'n", "zulks", "er", "extreem" ];
+	"slechtere", "slechtst", "slechtste", "zulke", "zulk", "zo'n", "zulks", "er", "extreem", "extreme", "bijbehorende", "bijbehorend" ];
 
 let interjections = [ "oh", "wauw", "hèhè", "hè", "hé", "au", "ai", "jaja", "welja", "jawel", "ssst", "heremijntijd", "hemeltjelief", "aha",
 	"er", "foei", "hmm", "nou", "nee", "tja", "nja", "okido", "ho", "halt", "komaan", "komop", "verrek", "nietwaar", "brr", "oef",
@@ -140,7 +140,7 @@ let vagueNouns = [ "ding", "dingen", "manier", "manieren", "item", "items", "kee
 	"personen", "deel" ];
 
 // 'No' is already included in the quantifier list.
-let miscellaneous = [ "niet", "wel", "ja", "nee", "neen", "oké", "oke", "okee", "ok", "niets", "zoiets", "%", "€" ];
+let miscellaneous = [ "niet", "wel", "ja", "nee", "neen", "oké", "oke", "okee", "ok", "niets", "zoiets", "%", "€", "euro" ];
 
 module.exports = function() {
 	return {

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -3,7 +3,7 @@ var notFilteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )()
 var transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
- * Returns an array with exceptions for the keyword suggestion researcher.
+ * Returns an array with exceptions for the prominent words researcher
  * @returns {Array} The array filled with exceptions.
  */
 

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -3,7 +3,7 @@ var infinitivePassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().
 var transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
- * Returns an array with exceptions for the keyword suggestion researcher.
+ * Returns an array with exceptions for the prominent words researcher
  * @returns {Array} The array filled with exceptions.
  */
 

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -1,5 +1,5 @@
 var filteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().filteredAuxiliaries;
-var notFilteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().infinitiveAuxiliaries;
+var infinitivePassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().infinitiveAuxiliaries;
 var transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
@@ -282,7 +282,7 @@ module.exports = function() {
 		interrogativeProAdverbs: interrogativeProAdverbs,
 		transitionWords: transitionWords.concat( additionalTransitionWords ),
 		// These verbs that should be filtered at the beginning of prominent word combinations.
-		beginningVerbs: otherAuxiliariesInfinitive.concat( notFilteredPassiveAuxiliaries,
+		beginningVerbs: otherAuxiliariesInfinitive.concat( infinitivePassiveAuxiliaries,
 			delexicalisedVerbsInfinitive, copulaInfinitive, interviewVerbsInfinitive ),
 		miscellaneous: miscellaneous,
 		interjections: interjections,
@@ -290,7 +290,7 @@ module.exports = function() {
 		reflexivePronouns: reflexivePronouns,
 		all: articles.concat( numerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, personalPronounsNominative,
 			personalPronounsAccusative, relativePronouns, quantifiers, indefinitePronouns, interrogativeProAdverbs,	pronominalAdverbs,
-			locativeAdverbs, adverbialGenitives, filteredPassiveAuxiliaries, notFilteredPassiveAuxiliaries, otherAuxiliaries,
+			locativeAdverbs, adverbialGenitives, filteredPassiveAuxiliaries, infinitivePassiveAuxiliaries, otherAuxiliaries,
 			otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive, transitionWords, additionalTransitionWords, intensifiers,
 			delexicalisedVerbs, delexicalisedVerbsInfinitive, interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous,

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -4,6 +4,7 @@ var WordCombination = require( "../values/WordCombination" );
 var normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 var germanFunctionWords = require( "../researches/german/functionWords.js" );
 var englishFunctionWords = require( "../researches/english/functionWords.js" );
+var dutchFunctionWords = require( "../researches/dutch/functionWords" );
 var countSyllables = require( "../stringProcessing/syllables/count.js" );
 var getLanguage = require( "../helpers/getLanguage.js" );
 
@@ -231,6 +232,12 @@ function filterCombinations( combinations, functionWords, locale ) {
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().reflexivePronouns );
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().interrogativeProAdverbs );
 			break;
+		case "nl":
+			combinations = filterFunctionWords( combinations, functionWords().verbs );
+			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().beginningVerbs );
+			combinations = filterFunctionWordsAtEnding( combinations, functionWords().reflexivePronouns );
+			combinations = filterFunctionWordsAtEnding( combinations, functionWords().interrogativeProAdverbs );
+			break;
 	}
 	return combinations;
 }
@@ -246,6 +253,9 @@ function getRelevantWords( text, locale ) {
 	switch( getLanguage( locale ) ) {
 		case "de":
 			functionWords = germanFunctionWords;
+			break;
+		case "nl":
+			functionWords = dutchFunctionWords;
 			break;
 		default:
 		case "en":

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -227,11 +227,6 @@ function filterCombinations( combinations, functionWords, locale ) {
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().verbs );
 			break;
 		case "de":
-			combinations = filterFunctionWords( combinations, functionWords().verbs );
-			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().beginningVerbs );
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().reflexivePronouns );
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().interrogativeProAdverbs );
-			break;
 		case "nl":
 			combinations = filterFunctionWords( combinations, functionWords().verbs );
 			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().beginningVerbs );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,7 +1042,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.1, concat-stream@~1.5.0, concat-stream@~1.5.1:
+concat-stream@^1.4.1, concat-stream@^1.4.6, concat-stream@~1.5.0, concat-stream@~1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -1050,7 +1050,7 @@ concat-stream@^1.4.1, concat-stream@~1.5.0, concat-stream@~1.5.1:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concat-stream@^1.4.6, concat-stream@~1.4.1:
+concat-stream@~1.4.1:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.4.10.tgz#acc3bbf5602cb8cc980c6ac840fa7d8603e3ef36"
   dependencies:
@@ -1067,6 +1067,12 @@ console-browserify@^1.1.0:
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
+console.table@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/console.table/-/console.table-0.8.0.tgz#69e91d2eabfcced9a0c877ea670b251c6bdbd35f"
+  dependencies:
+    easy-table "1.0.0"
 
 constants-browserify@~1.0.0:
   version "1.0.0"
@@ -1311,6 +1317,10 @@ eachr@^3.2.0:
   dependencies:
     editions "^1.1.1"
     typechecker "^4.3.0"
+
+easy-table@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/easy-table/-/easy-table-1.0.0.tgz#29db2d0855d36316e4382e5a3d85d9cb5fc93216"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Add prominent words for Dutch.

## Relevant technical choices:

* Add Dutch function words.
* Add Dutch to relevantWords.js.
* Add filters for Dutch.

## Test instructions

This PR can be tested by following these steps:

* Use Node to test: node ./examples/wordRelevance/index.js [txt filename] nl_NL

Fixes #1016 
