### PR TITLE
Make the mark buttons tooltips always visible.

### DIFF
--- a/css/_analysis.scss
+++ b/css/_analysis.scss
@@ -87,11 +87,6 @@ li.score:after {
 			&-active {
 				background-image: url(svg-icon-eye($color_marker_active));
 				background-color: #a4286a;
-
-				&.yoast-tooltip::before,
-				&.yoast-tooltip::after {
-					display: none;
-				}
 			}
 
 			&-disabled {


### PR DESCRIPTION
## Summary

Make the mark buttons tooltips always visible, even when the buttons are "active".

## Test instructions

You can test this on the browserified example or built the CSS on the Yoast SEO plugin and test there. Things to check:

Hovering or focusing a mark button, a tooltip appears and displays the text used for the aria label `Mark this result in the text`:

![screen shot 2017-01-17 at 14 11 32](https://cloud.githubusercontent.com/assets/1682452/22022062/a6df928e-dcc0-11e6-8de2-883a4acdf8cf.png)

After the button is clicked, it becomes "active", the aria label text changes in "Remove marks in the text" and the tooltip appears again on hover and focus, showing the updated text:

![screen shot 2017-01-17 at 14 11 41](https://cloud.githubusercontent.com/assets/1682452/22022143/f9db03b0-dcc0-11e6-9457-4b5ea1b7c53a.png)

Fixes #1037 
