### PR TITLE
Add specs for getSentences.js

### DIFF
--- a/js/stringProcessing/getSentences.js
+++ b/js/stringProcessing/getSentences.js
@@ -260,11 +260,6 @@ function getSentencesFromTokens( tokens ) {
 				}
 				break;
 
-			case "newline":
-				tokenSentences.push( currentSentence );
-				currentSentence = "";
-				break;
-
 			case "block-start":
 				currentSentence += token.src;
 				break;

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -177,6 +177,10 @@ describe("Get sentences from text", function(){
 			{
 				input: "This is 255.255.255.255 complete sentence",
 				expected: [ "This is 255.255.255.255 complete sentence" ]
+			},
+			{
+				input: "This is an IP (127.0.0.1) 1 sentence",
+				expected: "This is an IP (127.0.0.1) 1 sentence"
 			}
 		];
 

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -180,7 +180,7 @@ describe("Get sentences from text", function(){
 			},
 			{
 				input: "This is an IP (127.0.0.1) 1 sentence",
-				expected: "This is an IP (127.0.0.1) 1 sentence"
+				expected: [ "This is an IP (127.0.0.1) 1 sentence" ]
 			}
 		];
 


### PR DESCRIPTION
## Summary

Adds spec for getSentences.js

## Relevant technical choices:

* Removed the newline case. We split on newlines before sending data, so this case is never reached. 

## Test instructions

This PR can be tested by following these steps:

* Make sure you don't get errors with newlines. 

