### PR TITLE
Move here a tooltip CSS rule from Yoast SEO

### DIFF
--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -225,3 +225,9 @@ button.yoast-tooltip {
 		margin-right: 4.5px;
 	}
 }
+
+/* Rule with higher specificity to hide the tooltips when necessary. */
+.yoast-tooltip.yoast-tooltip-hidden::before,
+.yoast-tooltip.yoast-tooltip-hidden::after {
+	display: none;
+}


### PR DESCRIPTION
Move a tooltips CSS rule from Yoast SEO `metabox.scss` to `_tooltips.scss` since it's a rule related to the tooltips functionality and not a specific implementation in the meta box.

Fixes #1048 
