### PR TITLE
Dt/countsentences spec

### DIFF
--- a/js/stringProcessing/countSentences.js
+++ b/js/stringProcessing/countSentences.js
@@ -12,9 +12,7 @@ module.exports = function( text ) {
 	var sentences = getSentences( text );
 	var sentenceCount = 0;
 	for ( var i = 0; i < sentences.length; i++ ) {
-		if ( sentences[ i ] !== "" && sentences[ i ] !== " " ) {
-			sentenceCount++;
-		}
+		sentenceCount++;
 	}
 	return sentenceCount;
 };

--- a/spec/stringProcessing/countSentencesSpec.js
+++ b/spec/stringProcessing/countSentencesSpec.js
@@ -3,6 +3,8 @@ var sentenceCount = require("../../js/stringProcessing/countSentences.js");
 describe("Counting of sentences", function(){
 	it("returns the number of sentences in a string", function(){
 		expect( sentenceCount( "First sentence. Second sentence. 3rd sentence." ) ).toBe( 3 );
+		expect( sentenceCount( "" ) ).toBe( 0 );
+
 
 		// These don't work yet because of the repeated sentence terminators, but they aren't important right now.
 		// expect( sentenceCount( "First sentence.. Second sentence. 3rd sentence." ) ).toBe( 3 );

--- a/spec/stringProcessing/countSentencesSpec.js
+++ b/spec/stringProcessing/countSentencesSpec.js
@@ -5,7 +5,6 @@ describe("Counting of sentences", function(){
 		expect( sentenceCount( "First sentence. Second sentence. 3rd sentence." ) ).toBe( 3 );
 		expect( sentenceCount( "<p></p>" ) ).toBe( 0 );
 
-
 		// These don't work yet because of the repeated sentence terminators, but they aren't important right now.
 		// expect( sentenceCount( "First sentence.. Second sentence. 3rd sentence." ) ).toBe( 3 );
 		// expect( sentenceCount( "First sentence!!! Second sentence. 3rd sentence." ) ).toBe( 3 );

--- a/spec/stringProcessing/countSentencesSpec.js
+++ b/spec/stringProcessing/countSentencesSpec.js
@@ -3,7 +3,7 @@ var sentenceCount = require("../../js/stringProcessing/countSentences.js");
 describe("Counting of sentences", function(){
 	it("returns the number of sentences in a string", function(){
 		expect( sentenceCount( "First sentence. Second sentence. 3rd sentence." ) ).toBe( 3 );
-		expect( sentenceCount( "" ) ).toBe( 0 );
+		expect( sentenceCount( "<p></p>" ) ).toBe( 0 );
 
 
 		// These don't work yet because of the repeated sentence terminators, but they aren't important right now.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
N/A

## Relevant technical choices:

* Since we already do an isEmpty check in the getSentences, there never was a completely empty sentence. The if statement used to check this can be removed, since it will always be true. 

## Test instructions

This PR can be tested by following these steps:

* Make sure tests pass.