### PR TITLE
Only switch css classes when the mode is changes.

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -43,7 +43,7 @@ var defaults = {
 	},
 	addTrailingSlash: true,
 	metaDescriptionDate: "",
-	previewMode: "mobile",
+	previewMode: "desktop",
 
 };
 

--- a/js/snippetPreviewToggler.js
+++ b/js/snippetPreviewToggler.js
@@ -15,13 +15,15 @@ var minimumDesktopWidth = 640;
  * @param {string}    previewMode    The default preview mode.
  * @param {Element[]} previewToggles Array with toggle elements.
  *
- * @property {string}   previewMode    The current preview mode.
- * @propert {Element[]} previewToggles The array with toggle elements.
+ * @property {string}    previewMode    The current preview mode.
+ * @property {Element[]} previewToggles The array with toggle elements.
+ * @property {Element}   viewElement    The target element.
  * @constructor
  */
 var SnippetPreviewToggler = function( previewMode, previewToggles ) {
 	this.previewMode    = previewMode;
 	this.previewToggles = previewToggles;
+	this.viewElement     = document.getElementById( "snippet-preview-view" );
 };
 
 /**
@@ -124,14 +126,10 @@ SnippetPreviewToggler.prototype._setPreviewMode = function( previewMode, toggleE
 	this._removeActiveStates();
 	this._setActiveState( toggleElement );
 
-	if( previewMode === this.previewMode ) {
-		return;
+	if( this.previewMode !== previewMode ) {
+		domManipulation.removeClass( this.viewElement, previewModes[ this.previewMode ] );
+		domManipulation.addClass( this.viewElement, previewModes[ previewMode ] );
 	}
-
-	var viewElement = document.getElementById( "snippet-preview-view" );
-
-	domManipulation.removeClass( viewElement, previewModes[ this.previewMode ] );
-	domManipulation.addClass( viewElement, previewModes[ previewMode ] );
 
 	this.previewMode = previewMode;
 };

--- a/templates/snippetEditor.jst
+++ b/templates/snippetEditor.jst
@@ -3,7 +3,7 @@
 		<h3 class="snippet-editor__heading snippet-editor__heading-icon snippet-editor__heading-icon-eye"><%- i18n.snippetPreview %></h3>
 	<p class="screen-reader-text"><%- i18n.snippetPreviewDescription %></p>
 
-		<div id="snippet-preview-view" class="snippet-editor__view snippet-editor__view--mobile">
+		<div id="snippet-preview-view" class="snippet-editor__view">
 			<div class="snippet_container snippet_container__title snippet-editor__container" id="title_container">
 				<span class="screen-reader-text"><%- i18n.titleLabel %></span>
 				<span class="title" id="render_title_container">


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Remove a hardcoded class.

## Test instructions

This PR can be tested by following these steps:

* Check if the default mode is set to desktop and also uses the correct styling.
