### PR TITLE
Improves output of getLinks

### DIFF
--- a/js/researches/getLinks.js
+++ b/js/researches/getLinks.js
@@ -3,7 +3,7 @@
 var getAnchors = require( "../stringProcessing/getAnchorsFromText.js" );
 
 var map = require( "lodash/map" );
-var getFromAnchorTag = require( "../stringProcessing/url.js").getFromAnchorTag;
+var getFromAnchorTag = require( "../stringProcessing/url.js" ).getFromAnchorTag;
 
 /**
  * Checks a text for anchors and returns the number found.

--- a/js/researches/getLinks.js
+++ b/js/researches/getLinks.js
@@ -1,9 +1,9 @@
 /** @module analyses/getLinkStatistics */
 
-var getAnchors = require( "../stringProcessing/getAnchorsFromText.js" );
+let getAnchors = require( "../stringProcessing/getAnchorsFromText.js" );
 
-var map = require( "lodash/map" );
-var getFromAnchorTag = require( "../stringProcessing/url.js" ).getFromAnchorTag;
+let map = require( "lodash/map" );
+let url = require( "../stringProcessing/url.js" );
 
 /**
  * Checks a text for anchors and returns the number found.
@@ -12,8 +12,7 @@ var getFromAnchorTag = require( "../stringProcessing/url.js" ).getFromAnchorTag;
  * @returns {Array} An array with the anchors
  */
 module.exports = function( paper ) {
-	var anchors = getAnchors( paper.getText() );
-	return map( anchors, function( anchor ) {
-		return getFromAnchorTag( anchor );
-	} );
+	let anchors = getAnchors( paper.getText() );
+
+	return map( anchors, url.getFromAnchorTag );
 };

--- a/js/researches/getLinks.js
+++ b/js/researches/getLinks.js
@@ -2,6 +2,9 @@
 
 var getAnchors = require( "../stringProcessing/getAnchorsFromText.js" );
 
+var map = require( "lodash/map" );
+var getFromAnchorTag = require( "../stringProcessing/url.js").getFromAnchorTag;
+
 /**
  * Checks a text for anchors and returns the number found.
  *
@@ -9,5 +12,8 @@ var getAnchors = require( "../stringProcessing/getAnchorsFromText.js" );
  * @returns {Array} An array with the anchors
  */
 module.exports = function( paper ) {
-	return getAnchors( paper.getText() );
+	var anchors = getAnchors( paper.getText() );
+	return map( anchors, function( anchor ) {
+		return getFromAnchorTag( anchor );
+	} );
 };

--- a/spec/researches/getLinkSpec.js
+++ b/spec/researches/getLinkSpec.js
@@ -1,7 +1,7 @@
 let getLinks = require("../../js/researches/getLinks");
 let Paper = require( "../../js/values/Paper.js" );
 
-describe( "A test for getting the links from a test", function() {
+describe( "A test for getting the links from a text", function() {
 	it( "returns all links from the text", function(){
 		let mockPaper = new Paper( "This is a text with a <a href='http://yoast.com'>very nice</a> link" );
 		expect( getLinks( mockPaper ) ).toEqual( [ "http://yoast.com" ] );

--- a/spec/researches/getLinkSpec.js
+++ b/spec/researches/getLinkSpec.js
@@ -1,0 +1,15 @@
+let getLinks = require("../../js/researches/getLinks");
+let Paper = require( "../../js/values/Paper.js" );
+
+describe( "A test for getting the links from a test", function() {
+	it( "returns all links from the text", function(){
+		let mockPaper = new Paper( "This is a text with a <a href='http://yoast.com'>very nice</a> link" );
+		expect( getLinks( mockPaper ) ).toEqual( [ "http://yoast.com" ] );
+		mockPaper = new Paper( "This is a text with a <a href='http://yoast.com'>very nice</a> link, and a even <a href='https://yoast.com'>nicer</a> link." );
+		expect( getLinks( mockPaper ) ).toEqual( [ "http://yoast.com", "https://yoast.com" ] );
+	});
+	it( "returns an empty arry when there are no links", function() {
+		let mockPaper = new Paper( "This is a test text" );
+		expect( getLinks( mockPaper ) ).toEqual( [  ] );
+	});
+});


### PR DESCRIPTION
This improves the output of getLinks so it only outputs the links, not the complete anchor tags. For getting anchor tags we already have 'getAnchors'. 

required for https://github.com/Yoast/wordpress-seo-premium/pull/1031

This can be tested in WordPress by running `YoastSEO.app.researcher.getResearch( "getLinks" )` from the console. This should output a list of links in the text (without anchors).