### PR TITLE
Improve two links text in the keyword stop word assessment

### DIFF
--- a/js/assessments/keywordStopWordsAssessment.js
+++ b/js/assessments/keywordStopWordsAssessment.js
@@ -18,9 +18,9 @@ var calculateStopWordsCountResult = function( stopWordCount, i18n ) {
 				"js-text-analysis",
 				/* Translators: %1$s opens a link to a Yoast article about stop words, %2$s closes the link */
 				"The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. " +
-				"Read %1$sthis article%2$s for more info.",
+				"%1$sLearn more about the stop words%2$s.",
 				"The focus keyword contains %3$d stop words. This may or may not be wise depending on the circumstances. " +
-				"Read %1$sthis article%2$s for more info.",
+				"%1$sLearn more about the stop words%2$s.",
 				stopWordCount
 			),
 		};

--- a/spec/assessments/keywordStopWordsSpec.js
+++ b/spec/assessments/keywordStopWordsSpec.js
@@ -23,7 +23,7 @@ describe( "A stop word in keyword assessment", function() {
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.hasScore() ).toEqual( true );
-		expect( assessment.getText() ).toEqual ( "The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. Read <a href='https://yoast.com/handling-stopwords/' target='_blank'>this article</a> for more info.");
+		expect( assessment.getText() ).toEqual ( "The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. <a href='https://yoast.com/handling-stopwords/' target='_blank'>Learn more about the stop words</a>.");
 	} );
 
 	it( "assesses multiple stop words in the keyword", function(){
@@ -33,7 +33,7 @@ describe( "A stop word in keyword assessment", function() {
 
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about", "before" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual ( "The focus keyword contains 2 stop words. This may or may not be wise depending on the circumstances. Read <a href='https://yoast.com/handling-stopwords/' target='_blank'>this article</a> for more info.");
+		expect( assessment.getText() ).toEqual ( "The focus keyword contains 2 stop words. This may or may not be wise depending on the circumstances. <a href='https://yoast.com/handling-stopwords/' target='_blank'>Learn more about the stop words</a>.");
 	} );
 } );
 


### PR DESCRIPTION
## Summary

Changes two links in the keyword stop word assessment to make them meaningful also when read out of context. Changes the text from:
`Read %1$sthis article%2$s for more info.`
to:
`%1$sLearn more about the stop words%2$s.`

## Test instructions
- build the JS on Yoast SEO
- edit a post, add a stop word (e.g. `the`) in your focus keyword field
- check the new link in the assessment result

before: 

<img width="605" alt="screen shot 2017-02-14 at 15 06 23" src="https://cloud.githubusercontent.com/assets/1682452/22932226/5f79b2fe-f2c7-11e6-8e77-15380ddfde35.png">

after:

<img width="630" alt="screen shot 2017-02-14 at 15 05 48" src="https://cloud.githubusercontent.com/assets/1682452/22932227/5f81afd6-f2c7-11e6-9735-76ac326c2e1e.png">


Fixes #516 
