### PR TITLE
Add shortlinks for stopwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwards.
 
+## 1.11.0: February 14th, 2017
+
+## Added
+* Adds prominent words for Spanish.
+* Adds getLinks to the researcher, this function retrieves the URLs of the links from the text.
+
+## Changed
+* Improves feedback text for subheading too long assessment.
+
 ## 1.10.0: January 31st, 2017
 
 ## Added

--- a/js/assessments/keywordStopWordsAssessment.js
+++ b/js/assessments/keywordStopWordsAssessment.js
@@ -44,7 +44,7 @@ var keywordHasStopWordsAssessment = function( paper, researcher, i18n ) {
 	assessmentResult.setScore( stopWordsResult.score );
 	assessmentResult.setText( i18n.sprintf(
 		stopWordsResult.text,
-		"<a href='https://yoast.com/handling-stopwords/' target='_blank'>",
+		"<a href='https://yoa.st/stopwords/' target='_blank'>",
 		"</a>",
 		stopWords.length
 	) );

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "index.js",
   "license": "GPL-3.0",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Yoast/YoastSEO.js"

--- a/spec/assessments/keywordStopWordsSpec.js
+++ b/spec/assessments/keywordStopWordsSpec.js
@@ -23,7 +23,7 @@ describe( "A stop word in keyword assessment", function() {
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.hasScore() ).toEqual( true );
-		expect( assessment.getText() ).toEqual ( "The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. <a href='https://yoast.com/handling-stopwords/' target='_blank'>Learn more about the stop words</a>.");
+		expect( assessment.getText() ).toEqual ( "The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/stopwords/' target='_blank'>Learn more about the stop words</a>.");
 	} );
 
 	it( "assesses multiple stop words in the keyword", function(){
@@ -33,7 +33,7 @@ describe( "A stop word in keyword assessment", function() {
 
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about", "before" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual ( "The focus keyword contains 2 stop words. This may or may not be wise depending on the circumstances. <a href='https://yoast.com/handling-stopwords/' target='_blank'>Learn more about the stop words</a>.");
+		expect( assessment.getText() ).toEqual ( "The focus keyword contains 2 stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/stopwords/' target='_blank'>Learn more about the stop words</a>.");
 	} );
 } );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
n/a

## Relevant technical choices:

* Changes links to shortlinks 

## Test instructions

This PR can be tested by following these steps:

* Make sure the stopword assessment is shown (add a stopword to the keyword). 
The link should be a shortlink. 

Fixes #https://github.com/Yoast/wordpress-seo/issues/6673

*When merging, please update the changelog
