### PR TITLE
Change ranges to include 0.5 keyword density

### DIFF
--- a/js/assessments/keywordDensityAssessment.js
+++ b/js/assessments/keywordDensityAssessment.js
@@ -6,6 +6,7 @@ var inRange = require( "../helpers/inRange.js" );
 
 var inRangeEndInclusive = inRange.inRangeEndInclusive;
 var inRangeStartInclusive = inRange.inRangeStartInclusive;
+var inRangeStartEndInclusive = inRange.inRangeStartEndInclusive;
 
 /**
  * Returns the scores and text for keyword density
@@ -49,7 +50,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}
 
-	if ( inRangeEndInclusive( roundedKeywordDensity, 0.5, 2.5 ) ) {
+	if ( inRangeStartEndInclusive( roundedKeywordDensity, 0.5, 2.5 ) ) {
 		score = 9;
 
 		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */

--- a/js/helpers/inRange.js
+++ b/js/helpers/inRange.js
@@ -1,5 +1,5 @@
 /**
- * Checks if `n` is between `start` and up to, but not including, `start`.
+ * Checks if `n` is between `start` and `end` but not including `start`.
  *
  * @param {number} number The number to check.
  * @param {number} start The start of the range.
@@ -23,19 +23,20 @@ function inRangeStartInclusive( number, start, end ) {
 }
 
 /**
- * Checks if `n` is between `start` and up to, but not including, `start`.
+ * Checks if `n` is between `start` and `end`, including both.
  *
  * @param {number} number The number to check.
  * @param {number} start The start of the range.
  * @param {number} end The end of the range.
  * @returns {boolean} Returns `true` if `number` is in the range, else `false`.
  */
-function inRange( number, start, end ) {
-	return inRangeEndInclusive( number, start, end );
+function inRangeStartEndInclusive( number, start, end ) {
+	return number >= start && number <= end;
 }
 
 module.exports = {
-	inRange: inRange,
+	inRange: inRangeEndInclusive,
 	inRangeStartInclusive: inRangeStartInclusive,
 	inRangeEndInclusive: inRangeEndInclusive,
+	inRangeStartEndInclusive: inRangeStartEndInclusive,
 };

--- a/spec/assessments/keywordDensitySpec.js
+++ b/spec/assessments/keywordDensitySpec.js
@@ -27,5 +27,10 @@ describe( "An assessment for the keywordDensity", function(){
 		expect( result.getScore() ).toBe( -10 );
 		expect( result.getText() ).toBe( "The keyword density is 3%, which is over the advised 2.5% maximum; the focus keyword was found 2 times.");
 
+		paper = new Paper( "string with the keyword  and keyword ", {keyword: "keyword"} );
+		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( 0.5 ), i18n );
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The keyword density is 0.5%, which is great; the focus keyword was found 2 times.");
+
 	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Fixes bug where the keyword density assessment would disappear when the density was 0.5%.

## Relevant technical choices:

* Introduces inRange function that includes both the start as well as the end of the range.

## Test instructions

This PR can be tested by following these steps:

* Write a text with a keyword density of 0.5%.
* Check whether the keyword density assessment/bullet is present.

Fixes #896 
