### PR TITLE
Introduce sentence beginnings assessment for Italian

### DIFF
--- a/js/assessments/sentenceBeginningsAssessment.js
+++ b/js/assessments/sentenceBeginningsAssessment.js
@@ -13,7 +13,7 @@ let marker = require( "../markers/addMark.js" );
 let maximumConsecutiveDuplicates = 2;
 
 let getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
-let availableLanguages = [ "en", "de", "es", "fr", "nl" ];
+let availableLanguages = [ "en", "de", "es", "fr", "nl", "it" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/js/helpers/getFirstWordExceptions.js
+++ b/js/helpers/getFirstWordExceptions.js
@@ -3,6 +3,7 @@ let firstWordExceptionsGerman = require( "../researches/german/firstWordExceptio
 let firstWordExceptionsSpanish = require( "../researches/spanish/firstWordExceptions.js" );
 let firstWordExceptionsFrench = require( "../researches/french/firstWordExceptions.js" );
 let firstWordExceptionsDutch = require( "../researches/dutch/firstWordExceptions.js" );
+let firstWordExceptionsItalian = require( "../researches/italian/firstWordExceptions.js" );
 
 let getLanguage = require( "./getLanguage.js" );
 
@@ -16,6 +17,8 @@ module.exports = function( locale ) {
 			return firstWordExceptionsSpanish;
 		case "nl":
 			return firstWordExceptionsDutch;
+		case "it":
+			return firstWordExceptionsItalian;
 		default:
 		case "en":
 			return firstWordExceptionsEnglish;

--- a/js/researches/italian/firstWordExceptions.js
+++ b/js/researches/italian/firstWordExceptions.js
@@ -1,0 +1,19 @@
+/**
+ * Returns an array with exceptions for the sentence beginning researcher.
+ * @returns {Array} The array filled with exceptions.
+ */
+module.exports = function() {
+	return [
+		// Definite articles:
+		"il", "lo", "la", "i", "gli", "le",
+		// Indefinite articles:
+		"uno", "un", "una",
+		// Numbers 1-10 ('uno' is already included above):
+		"due", "tre", "quattro", "cinque", "sei", "sette", "otto", "nove", "dieci",
+		// Demonstrative pronouns:
+		"questo", "questa", "quello", "quella", "questi", "queste", "quelli", "quelle", "codesto", "codesti", "codesta",
+		"codeste",
+	];
+};
+
+

--- a/spec/helpers/getFirstWordExceptionsSpec.js
+++ b/spec/helpers/getFirstWordExceptionsSpec.js
@@ -21,6 +21,10 @@ describe("a test for getting the correct first word exception array", function()
 		expect(firstWordExceptions("nl_NL")()).toEqual([ 'de', 'het', 'een', 'één', 'eén', 'twee', 'drie', 'vier', 'vijf', 'zes', 'zeven', 'acht', 'negen', 'tien', 'dit', 'dat', 'die', 'deze' ]);
 	});
 
+	it("returns the Italian first word exception array in case of it_IT locale", function () {
+		expect(firstWordExceptions("it_IT")()).toEqual([ 'il', 'lo', 'la', 'i', 'gli', 'le', 'uno', 'un', 'una', 'due', 'tre', 'quattro', 'cinque', 'sei', 'sette', 'otto', 'nove', 'dieci', 'questo', 'questa', 'quello', 'quella', 'questi', 'queste', 'quelli', 'quelle', 'codesto', 'codesti', 'codesta', 'codeste' ]);
+	});
+
 	it("returns the English first word exception array in case of empty locale", function () {
 		expect(firstWordExceptions("")()).toEqual([ 'the', 'a', 'an', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'this', 'that', 'these', 'those' ]);
 	});

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -138,6 +138,27 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for two sentences in Italian starting with different words.", function() {
+		let mockPaper = new Paper( "Volare, oh oh. Cantare, oh oh oh oh.", { locale: 'it_IT'} );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "volare" );
+		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 1 );
+		expect( sentenceBeginnings( mockPaper )[1].word ).toBe( "cantare" );
+		expect( sentenceBeginnings( mockPaper )[1].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Italian starting with the same word.", function() {
+		let mockPaper = new Paper( "E che dici di stare lassù. E volavo, volavo felice più in alto del sole ed ancora più su.", { locale: 'it_IT'} );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "e" );
+		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Italian all starting with one of the exception words.", function() {
+		let mockPaper = new Paper( "Una musica dolce. Una musica brutal. Una musica de cine.", { locale: 'it_IT'} );
+		expect( sentenceBeginnings( mockPaper )[0].word ).toBe( "una musica" );
+		expect( sentenceBeginnings( mockPaper )[0].count ).toBe( 3 );
+	} );
+
+
 	it( "returns an object with English sentence beginnings in lists", function() {
 		let mockPaper = new Paper( "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" );
 		expect( sentenceBeginnings( mockPaper )[ 0 ].word ).toBe( "item", { locale: 'en_US'} );


### PR DESCRIPTION
## Summary

- Add Italian first word exceptions.
- Implement sentence beginnings assessment for Italian.

This PR can be summarized in the following changelog entry: Introduces sentence beginnings assessment for Italian.

Fixes #1115