### PR TITLE
Add setter for titleWidth

### DIFF
--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1226,11 +1226,12 @@ SnippetPreview.prototype.getTitleWidth = function() {
 
 /**
  * Allows to manually set the title width.
- * This may be useful in setups where the title field will not always be rendered on the page.
- * 
+ * This may be useful in setups where the title field will not always be rendered.
+ *
  * @param {Number} titleWidth The width of the title in pixels.
+ * @returns {void}
  */
-SnippetPreview.prototype.setTitleWidth = function(titleWidth) {
+SnippetPreview.prototype.setTitleWidth = function( titleWidth ) {
 	this.data.titleWidth = titleWidth;
 };
 

--- a/js/snippetPreview.js
+++ b/js/snippetPreview.js
@@ -1225,6 +1225,16 @@ SnippetPreview.prototype.getTitleWidth = function() {
 };
 
 /**
+ * Allows to manually set the title width.
+ * This may be useful in setups where the title field will not always be rendered on the page.
+ * 
+ * @param {Number} titleWidth The width of the title in pixels.
+ */
+SnippetPreview.prototype.setTitleWidth = function(titleWidth) {
+	this.data.titleWidth = titleWidth;
+};
+
+/**
  * Returns whether or not an app object is present.
  *
  * @returns {boolean} Whether or not there is an App object present.


### PR DESCRIPTION
Add a setter for the titleWidth as proposed in https://github.com/Yoast/YoastSEO.js/issues/1117. Refer to the discussion in this issue to learn why this is needed.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a setter for ``titleWidth`` to the snippet preview. This may be useful in setups where the title field will not always be rendered on the page.

## Relevant technical choices:

* This should not break anything, as it only adds functionality and does not modify anything existing. The method does no validation or advanced filtering, but only sets the value passed.

## Test instructions

This PR can be tested by following these steps:

* Given we have a SnippetPreview instance, the setter can be used as follows:
```
var snippetPreview = new SnippetPreview({ /** **/});
snippetPreview.setTitleWidth(123);
```

Fixes #1117 
