### PR TITLE
Add Italian to transition word assessment and add Italian tests

### DIFF
--- a/js/assessments/transitionWordsAssessment.js
+++ b/js/assessments/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ let Mark = require( "../values/Mark.js" );
 let marker = require( "../markers/addMark.js" );
 
 let getLanguageAvailability = require( "../helpers/getLanguageAvailability.js" );
-let availableLanguages = [ "en", "de", "es", "fr", "nl" ];
+let availableLanguages = [ "en", "de", "es", "fr", "nl", "it" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/js/helpers/getTransitionWords.js
+++ b/js/helpers/getTransitionWords.js
@@ -8,6 +8,8 @@ let transitionWordsSpanish = require( "../researches/spanish/transitionWords.js"
 let twoPartTransitionWordsSpanish = require( "../researches/spanish/twoPartTransitionWords.js" );
 let transitionWordsDutch = require( "../researches/dutch/transitionWords.js" )().allWords;
 let twoPartTransitionWordsDutch = require( "../researches/dutch/twoPartTransitionWords.js" );
+let transitionWordsItalian = require( "../researches/italian/transitionWords.js" )().allWords;
+let twoPartTransitionWordsItalian = require( "../researches/italian/twoPartTransitionWords.js" );
 
 let getLanguage = require( "./getLanguage.js" );
 
@@ -32,6 +34,11 @@ module.exports = function( locale ) {
 			return {
 				transitionWords: transitionWordsDutch,
 				twoPartTransitionWords: twoPartTransitionWordsDutch,
+			};
+		case "it":
+			return {
+				transitionWords: transitionWordsItalian,
+				twoPartTransitionWords: twoPartTransitionWordsItalian,
 			};
 		default:
 		case "en":

--- a/js/researches/italian/transitionWords.js
+++ b/js/researches/italian/transitionWords.js
@@ -1,6 +1,6 @@
 /** @module config/transitionWords */
 
-var singleWords = [ "abbastanza", "acciocché", "adesso", "affinché", "allora", "almeno", "alquanto", "altrettanto",
+let singleWords = [ "abbastanza", "acciocché", "adesso", "affinché", "allora", "almeno", "alquanto", "altrettanto",
 	"altrimenti", "analogamente", "anche", "ancora", "analogamente", "antecedentemente", "anzi", "anzitutto",
 	"apertamente", "appena", "assai", "attualmente", "benché", "beninteso", "bensì", "brevemente", "bruscamente",
 	"casomai", "celermente", "certamente", "certo", "chiaramente", "ciononostante", "cioé", "comparabilmente", "come",
@@ -29,7 +29,7 @@ var singleWords = [ "abbastanza", "acciocché", "adesso", "affinché", "allora",
 	"talmente", "terzo", "totalmente", "tranne", "tuttavia", "ugualmente", "ulteriormente", "ultimamente", "veramente",
 	"verosimilmente", "visto" ];
 
-var multipleWords = [ "a breve", "a causa", "a causa di", "a condizione che", "a conseguenza", "a conti fatti",
+let multipleWords = [ "a breve", "a causa", "a causa di", "a condizione che", "a conseguenza", "a conti fatti",
 	"a differenza di", "a differenza del", "a differenza della", "a differenza dei", "a differenza degli",
 	"a differenza delle", "a dire il vero", "a dire la verità", "a dirla tutta", "a dispetto di", "a lungo",
 	"a lungo termine", "a maggior ragione", "a meno che non", "a parte", "a patto che", "a prescindere", "a prima vista",

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -246,6 +246,29 @@ describe("a test for finding transition words from a string", function() {
 		expect(result.transitionWordSentences).toBe(0);
 	});
 
+	it("returns 1 when a transition word is found in a sentence (Italian)", function () {
+		// Transition word: in conclusione.
+		mockPaper = new Paper("In conclusione, possiamo dire che il risultato è ottimo.", { locale: 'it_IT'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+
+	it("returns 1 when a two-part transition word is found in a sentence (Italian)", function () {
+		// Transition word: no ... ma.
+		mockPaper = new Paper("No, non credo che sia una buona idea ma possiamo sempre verificare caso per caso.", { locale: 'it_IT'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(1);
+	});
+
+	it("returns 0 when no transition words are present in a sentence (Italian)", function () {
+		mockPaper = new Paper("Uno, due, tre.", { locale: 'it_IT'} );
+		result = transitionWordsResearch(mockPaper);
+		expect(result.totalSentences).toBe(1);
+		expect(result.transitionWordSentences).toBe(0);
+	});
+
 	it("defaults to English in case of a bogus locale", function () {
 		// Transition word: because.
 		mockPaper = new Paper("Because of a bogus locale.", { locale: 'xx_YY'} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Introduce transition words assessment for Italian.

## Test instructions

This PR can be tested in the browserified standalone by following these steps:

* Set locale to it_IT.
* Write an Italian sentence containing a one or two-part transition word (see #1128 for transition words) .
* Hit the mark transition word sentences button.

Fixes #1130
