### PR TITLE
Fixed issue 1103 and added functions filterStartingWith and filterEndsWith

### DIFF
--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -199,6 +199,54 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
 }
 
 /**
+ * Filters combinations based on whether they start with a specified string or not.
+ *
+ * @param {WordCombination[]} wordCombinations The array of WordCombinations to filter.
+ * @param {string} str The string the WordCombinations that need to be filtered out start with.
+ * @param {string[]} exceptions The array of strings containing exceptions to not filter.
+ * @returns {WordCombination[]} The filtered array of WordCombinations.
+ */
+function filterStartingWith( wordCombinations, str, exceptions ) {
+	wordCombinations = wordCombinations.filter( function( combination ) {
+		let combinationstr = combination.getCombination();
+		for ( let i = 0; i < exceptions.length; i++ ) {
+			if ( combinationstr.startsWith( exceptions[ i ] ) ) {
+				return true;
+			}
+		}
+		if ( combinationstr.startsWith( str ) ) {
+			return false;
+		}
+		return true;
+	} );
+	return wordCombinations;
+}
+
+/**
+ * Filters combinations based on whether they end with a specified string or not.
+ *
+ * @param {WordCombination[]} wordCombinations The array of WordCombinations to filter.
+ * @param {string} str The string the WordCombinations that need to be filtered out end with.
+ * @param {string[]} exceptions The array of strings containing exceptions to not filter.
+ * @returns {WordCombination[]} The filtered array of WordCombinations.
+ */
+function filterEndingWith( wordCombinations, str, exceptions ) {
+	wordCombinations = wordCombinations.filter( function( combination ) {
+		let combinationstr = combination.getCombination();
+		for ( let i = 0; i < exceptions.length; i++ ) {
+			if ( combinationstr.endsWith( exceptions[ i ] ) ) {
+				return true;
+			}
+		}
+		if ( combinationstr.endsWith( str ) ) {
+			return false;
+		}
+		return true;
+	} );
+	return wordCombinations;
+}
+
+/**
  * Filters the list of word combination objects.
  * Word combinations with specific parts of speech at the beginning and/or end, as well as one-syllable single words, are removed.
  *
@@ -226,6 +274,7 @@ function filterCombinations( combinations, functionWords, locale ) {
 			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().passiveAuxiliaries );
 			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().reflexivePronouns );
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().verbs );
+			combinations = filterEndingWith( combinations, "'s", [] );
 			break;
 		case "es":
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().verbs );
@@ -322,4 +371,6 @@ module.exports = {
 	filterSpecialCharacters: filterSpecialCharacters,
 	filterOnSyllableCount: filterOnSyllableCount,
 	filterOnDensity: filterOnDensity,
+	filterStartingWith: filterStartingWith,
+	filterEndingWith: filterEndingWith
 };

--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -10,6 +10,8 @@ let filterFunctionWords = relevantWords.filterFunctionWords;
 let filterSpecialCharacters = relevantWords.filterSpecialCharacters;
 let filterOnSyllableCount = relevantWords.filterOnSyllableCount;
 let filterOnDensity = relevantWords.filterOnDensity;
+let filterEndingWith = relevantWords.filterEndingWith;
+let filterStartingWith = relevantWords.filterStartingWith;
 let englishFunctionWords = require( "../../js/researches/english/functionWords.js" )().all;
 
 describe( "getWordCombinations", function() {
@@ -261,7 +263,7 @@ describe( "filter special characters in word combinations", function() {
 } );
 
 describe( "filter single words based on syllable count", function() {
-	it ( "filters one-syllable single words", function() {
+	it (  "filters one-syllable single words" , function() {
 		let input = [
 			new WordCombination ( [ "book" ] ),
 			new WordCombination ( [ "a", "book" ] ),
@@ -277,6 +279,40 @@ describe( "filter single words based on syllable count", function() {
 		expect( combinations ).toEqual( expected );
 	});
 } );
+
+describe("filter word combinations based on what string it starts with but with specified exceptions", function(){
+	it ( "filters word combinations that start with you but not word combinations that start with you are" , function(){
+		let input = [
+			new WordCombination (["you","do","you"]),
+			new WordCombination (["you","are","awesome"]),
+			new WordCombination (["who","are","you"]),
+		];
+		let expected = [
+			new WordCombination (["you","are","awesome"]),
+			new WordCombination (["who","are","you"]),
+		];
+		let combinations = filterStartingWith(input, "you", ["you are"]);
+		expect( combinations ).toEqual( expected );
+	});
+	
+});
+
+describe("filter word combinations based on what string it end with but with specified exceptions", function(){
+	it ( "filters word combinations that end with you but not word combinations that start with are you" , function(){
+		let input = [
+			new WordCombination (["you","do","you"]),
+			new WordCombination (["you","are","awesome"]),
+			new WordCombination (["who","are","you"]),
+		];
+		let expected = [
+			new WordCombination (["you","are","awesome"]),
+			new WordCombination (["who","are","you"]),
+		];
+		let combinations = filterEndingWith(input, "you", ["are you"]);
+		expect( combinations ).toEqual( expected );
+	});
+	
+});
 
 describe( "getRelevantWords", function() {
 	it( "uses the default (English) function words in case of a unknown locale", function() {


### PR DESCRIPTION


## Summary

This PR can be summarized in the following changelog entry:
Added functions filterStartingWith and FilterEndsWith which can be used in the future
Used filterEndsWith to filter out all WordCombinations that end with `'s`, and with that, I fixed issue #1103 

## Test instructions

This PR can be tested by following these steps:

* Pass a text to `filterCombinations` containing words that end in `'s`
* If the filtered Combinations still contain combinations ending in words that end in `'s` the pr does not work, if it did not contain any, the pr works correctly

Fixes #1103 