### PR TITLE
Fixes incompatible includes in IE

### DIFF
--- a/js/stringProcessing/htmlParser.js
+++ b/js/stringProcessing/htmlParser.js
@@ -1,6 +1,9 @@
 // We use an external library, which can be found here: https://github.com/fb55/htmlparser2.
 let htmlparser = require( "htmlparser2" );
 
+
+let includes = require( "lodash/includes" );
+
 // The array containing the text parts without the blocks defined in inlineTags.
 let textArray;
 
@@ -23,7 +26,7 @@ let parser = new htmlparser.Parser( {
 	 * @returns {void}
 	 */
 	onopentag: function( tagName, nodeValue ) {
-		if ( inlineTags.includes( tagName ) ) {
+		if ( includes( inlineTags, tagName ) ) {
 			inScriptBlock = true;
 			return;
 		}
@@ -59,7 +62,7 @@ let parser = new htmlparser.Parser( {
 	 * @returns {void}
 	 */
 	onclosetag: function( tagName ) {
-		if( inlineTags.includes( tagName ) ) {
+		if( includes( inlineTags, tagName ) ) {
 			inScriptBlock = false;
 			return;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes includes incompatibility with Internet Explorer. 

## Relevant technical choices:

* Replaces `includes` with the includes function from lodash. Internet Explorer doesn't support includes and breaks the HTMLparser. 

## Test instructions

This PR can be tested by following these steps:
* Needs to be tested with Internet Explorer!
* Create a text with an HTML tag or use
`<h2>this sample text</h2>` 
* The console will show an error `SCRIPT438: Object doesn't support property or method 'includes'`
* Checkout this branch
* Use the same text and see the error isn't shown anymore in the HTMLparser. 
