### PR TITLE
Changes the copy for 'keyword in headings' assessment result

### DIFF
--- a/js/assessments/seo/subheadingsKeywordAssessment.js
+++ b/js/assessments/seo/subheadingsKeywordAssessment.js
@@ -92,17 +92,10 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( score, subHeadings, i18n ) {
-		if ( score === this._config.scores.multipleMatches ) {
+		if ( score === this._config.scores.multipleMatches || score === this._config.scores.oneMatch ) {
 			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. " +
-					"While not a major ranking factor, this is beneficial." ), subHeadings.count, subHeadings.matches
-			);
-		}
-
-		if ( score === this._config.scores.oneMatch ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. " +
-					"While not a major ranking factor, this is beneficial." ), subHeadings.count, subHeadings.matches
+				i18n.dgettext( "js-text-analysis", "The focus keyword appears only in %2$d (out of %1$d) subheadings in your copy. " +
+					"Try to use it in at least one more subheading." ), subHeadings.count, subHeadings.matches
 			);
 		}
 

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -26,14 +26,13 @@ describe( "An assessment for matching keywords in subheadings", function(){
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The focus keyword appears in 1 (out of 1) subheadings in the copy. While not a major ranking factor, this is beneficial." );
+		expect( assessment.getText() ).toEqual ( "The focus keyword appears in 1 (out of 1) subheadings in your copy. Try to use it in at least one more subheading." );
 	} );
 	it( "assesses a string with subheadings and keywords", function(){
 		var mockPaper = new Paper();
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 10, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The focus keyword appears in 1 (out of 10) subheadings in the copy. While not a major ranking factor, this is beneficial." );
+		expect( assessment.getText() ).toEqual ( "The focus keyword appears in 1 (out of 10) subheadings in your copy. Try to use it in at least one more subheading." );
 	} );
 } );
-

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -26,13 +26,13 @@ describe( "An assessment for matching keywords in subheadings", function(){
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The focus keyword appears in 1 (out of 1) subheadings in your copy. Try to use it in at least one more subheading." );
+		expect( assessment.getText() ).toEqual ( "The focus keyword appears only in 1 (out of 1) subheadings in your copy. Try to use it in at least one more subheading." );
 	} );
 	it( "assesses a string with subheadings and keywords", function(){
 		var mockPaper = new Paper();
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 10, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The focus keyword appears in 1 (out of 10) subheadings in your copy. Try to use it in at least one more subheading." );
+		expect( assessment.getText() ).toEqual ( "The focus keyword appears only in 1 (out of 10) subheadings in your copy. Try to use it in at least one more subheading." );
 	} );
 } );


### PR DESCRIPTION
Changes the keyword copy to `The focus keyword appears only in {x} (out of {y}) subheadings in your copy. Try to use it in at least one more subheading.`

Fixes https://github.com/Yoast/wordpress-seo/issues/7133