### PR TITLE
Change recommended maximum sentence length for Italian to 25 words.

### DIFF
--- a/examples/browserified/example.js
+++ b/examples/browserified/example.js
@@ -18,6 +18,8 @@ var bindEvents = function( app ) {
 
 var setLocale = function() {
 	this.config.locale = document.getElementById( "locale" ).value;
+	this.initializeAssessors( this.config );
+	this.refresh();
 };
 
 window.onload = function() {

--- a/examples/browserified/example.js
+++ b/examples/browserified/example.js
@@ -19,6 +19,7 @@ var bindEvents = function( app ) {
 var setLocale = function() {
 	this.config.locale = document.getElementById( "locale" ).value;
 	this.initializeAssessors( this.config );
+	this.initAssessorPresenters();
 	this.refresh();
 };
 

--- a/js/app.js
+++ b/js/app.js
@@ -362,7 +362,6 @@ App.prototype.initializeSEOAssessor = function( args ) {
  * @returns {void}
  */
 App.prototype.initializeContentAssessor = function( args ) {
-	console.log( args );
 	if ( ! args.contentAnalysisActive ) {
 		return;
 	}

--- a/js/app.js
+++ b/js/app.js
@@ -362,6 +362,7 @@ App.prototype.initializeSEOAssessor = function( args ) {
  * @returns {void}
  */
 App.prototype.initializeContentAssessor = function( args ) {
+	console.log( args );
 	if ( ! args.contentAnalysisActive ) {
 		return;
 	}

--- a/js/app.js
+++ b/js/app.js
@@ -366,8 +366,8 @@ App.prototype.initializeContentAssessor = function( args ) {
 		return;
 	}
 
-	this.defaultContentAssessor = new ContentAssessor( this.i18n, { marker: this.config.marker } );
-	this.cornerStoneContentAssessor = new CornerstoneContentAssessor( this.i18n, { marker: this.config.marker } );
+	this.defaultContentAssessor = new ContentAssessor( this.i18n, { marker: this.config.marker, locale: this.config.locale }  );
+	this.cornerStoneContentAssessor = new CornerstoneContentAssessor( this.i18n, { marker: this.config.marker, locale: this.config.locale } );
 
 	// Set the content assessor
 	if ( isUndefined( args.contentAssessor ) ) {

--- a/js/config/content/combinedConfig.js
+++ b/js/config/content/combinedConfig.js
@@ -8,7 +8,6 @@ let configurations = {
 };
 
 module.exports = function( locale ) {
-	console.log( locale );
 	let language = getLanguage( locale );
 	if( configurations.hasOwnProperty( language ) ) {
 		return merge( defaultConfig, configurations[ language ] );

--- a/js/config/content/combinedConfig.js
+++ b/js/config/content/combinedConfig.js
@@ -1,4 +1,4 @@
-let merge = require( "lodash/merge" );
+let defaultsDeep = require( "lodash/defaultsDeep" );
 let getLanguage = require( "./../../helpers/getLanguage" );
 let defaultConfig = require( "./default" );
 let it = require( "./it" );
@@ -10,7 +10,7 @@ let configurations = {
 module.exports = function( locale ) {
 	let language = getLanguage( locale );
 	if( configurations.hasOwnProperty( language ) ) {
-		return merge( defaultConfig, configurations[ language ] );
+		return defaultsDeep( configurations[ language ], defaultConfig );
 	}
 
 	return defaultConfig;

--- a/js/config/content/combinedConfig.js
+++ b/js/config/content/combinedConfig.js
@@ -1,0 +1,18 @@
+let merge = require( "lodash/merge" );
+let getLanguage = require( "./../../helpers/getLanguage" );
+let defaultConfig = require( "./default" );
+let it = require( "./it" );
+
+let configurations = {
+	it: it,
+};
+
+module.exports = function( locale ) {
+	console.log( locale );
+	let language = getLanguage( locale );
+	if( configurations.hasOwnProperty( language ) ) {
+		return merge( defaultConfig, configurations[ language ] );
+	}
+
+	return defaultConfig;
+};

--- a/js/config/content/default.js
+++ b/js/config/content/default.js
@@ -1,0 +1,7 @@
+module.exports = {
+	sentenceLength: {
+		recommendedWordCount: 20,
+		slightlyTooMany: 25,
+		farTooMany: 30,
+	},
+};

--- a/js/config/content/it.js
+++ b/js/config/content/it.js
@@ -1,0 +1,5 @@
+module.exports = {
+	sentenceLength: {
+		recommendedWordCount: 25,
+	},
+};

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -33,10 +33,13 @@ let sum = require( "lodash/sum" );
  *
  * @constructor
  */
-let ContentAssessor = function( i18n, options ) {
+let ContentAssessor = function( i18n, options = {} ) {
 	Assessor.call( this, i18n, options );
+	let locale = "en_US";
+	if ( options.hasOwnProperty( "locale" ) ) {
+		locale = options.locale;
+	}
 
-	let locale = options.locale;
 
 	this._assessments = [
 

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -35,11 +35,7 @@ let sum = require( "lodash/sum" );
  */
 let ContentAssessor = function( i18n, options = {} ) {
 	Assessor.call( this, i18n, options );
-	let locale = "en_US";
-	if ( options.hasOwnProperty( "locale" ) ) {
-		locale = options.locale;
-	}
-
+	let locale = ( options.hasOwnProperty( "locale" ) ) ? options.locale : "en_US";
 
 	this._assessments = [
 

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -37,7 +37,6 @@ let ContentAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 
 	let locale = options.locale;
-	console.log( locale );
 
 	this._assessments = [
 

--- a/js/contentAssessor.js
+++ b/js/contentAssessor.js
@@ -1,13 +1,16 @@
-var Assessor = require( "./assessor.js" );
+let Assessor = require( "./assessor.js" );
 
-var fleschReadingEase = require( "./assessments/readability/fleschReadingEaseAssessment.js" );
-var paragraphTooLong = require( "./assessments/readability/paragraphTooLongAssessment.js" );
-var SentenceLengthInText = require( "./assessments/readability/sentenceLengthInTextAssessment.js" );
-var SubheadingDistributionTooLong = require( "./assessments/readability/subheadingDistributionTooLongAssessment.js" );
-var transitionWords = require( "./assessments/readability/transitionWordsAssessment.js" );
-var passiveVoice = require( "./assessments/readability/passiveVoiceAssessment.js" );
-var sentenceBeginnings = require( "./assessments/readability/sentenceBeginningsAssessment.js" );
-var textPresence = require( "./assessments/readability/textPresenceAssessment.js" );
+let fleschReadingEase = require( "./assessments/readability/fleschReadingEaseAssessment.js" );
+let paragraphTooLong = require( "./assessments/readability/paragraphTooLongAssessment.js" );
+let SentenceLengthInText = require( "./assessments/readability/sentenceLengthInTextAssessment.js" );
+let SubheadingDistributionTooLong = require( "./assessments/readability/subheadingDistributionTooLongAssessment.js" );
+let transitionWords = require( "./assessments/readability/transitionWordsAssessment.js" );
+let passiveVoice = require( "./assessments/readability/passiveVoiceAssessment.js" );
+let sentenceBeginnings = require( "./assessments/readability/sentenceBeginningsAssessment.js" );
+let textPresence = require( "./assessments/readability/textPresenceAssessment.js" );
+
+let contentConfiguration = require( "./config/content/combinedConfig.js" );
+
 /*
 	Temporarily disabled:
 
@@ -15,10 +18,10 @@ var textPresence = require( "./assessments/readability/textPresenceAssessment.js
 	var sentenceLengthInDescription = require( "./assessments/sentenceLengthInDescriptionAssessment.js" );
  */
 
-var scoreToRating = require( "./interpreters/scoreToRating" );
+let scoreToRating = require( "./interpreters/scoreToRating" );
 
-var map = require( "lodash/map" );
-var sum = require( "lodash/sum" );
+let map = require( "lodash/map" );
+let sum = require( "lodash/sum" );
 
 /**
  * Creates the Assessor
@@ -26,18 +29,22 @@ var sum = require( "lodash/sum" );
  * @param {object} i18n The i18n object used for translations.
  * @param {Object} options The options for this assessor.
  * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {string} options.locale The locale.
  *
  * @constructor
  */
-var ContentAssessor = function( i18n, options ) {
+let ContentAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
+
+	let locale = options.locale;
+	console.log( locale );
 
 	this._assessments = [
 
 		fleschReadingEase,
 		new SubheadingDistributionTooLong(),
 		paragraphTooLong,
-		new SentenceLengthInText(),
+		new SentenceLengthInText( contentConfiguration( locale ).sentenceLength ),
 		transitionWords,
 		passiveVoice,
 		textPresence,
@@ -91,8 +98,8 @@ ContentAssessor.prototype.calculatePenaltyPointsPartialSupport = function( ratin
  * @returns {boolean} True if fully supported.
  */
 ContentAssessor.prototype._allAssessmentsSupported = function() {
-	var numberOfAssessments = 8;
-	var applicableAssessments = this.getApplicableAssessments();
+	let numberOfAssessments = 8;
+	let applicableAssessments = this.getApplicableAssessments();
 	return applicableAssessments.length === numberOfAssessments;
 };
 
@@ -102,10 +109,10 @@ ContentAssessor.prototype._allAssessmentsSupported = function() {
  * @returns {number} The total penalty points for the results.
  */
 ContentAssessor.prototype.calculatePenaltyPoints = function() {
-	var results = this.getValidResults();
+	let results = this.getValidResults();
 
-	var penaltyPoints = map( results, function( result ) {
-		var rating = scoreToRating( result.getScore() );
+	let penaltyPoints = map( results, function( result ) {
+		let rating = scoreToRating( result.getScore() );
 
 		if ( this._allAssessmentsSupported() ) {
 			return this.calculatePenaltyPointsFullSupport( rating );
@@ -163,14 +170,14 @@ ContentAssessor.prototype._ratePenaltyPoints = function( totalPenaltyPoints ) {
  * @returns {number} The overall score.
  */
 ContentAssessor.prototype.calculateOverallScore = function() {
-	var results = this.getValidResults();
+	let results = this.getValidResults();
 
 	// If you have no content, you have a red indicator.
 	if ( results.length === 0 ) {
 		return 30;
 	}
 
-	var totalPenaltyPoints = this.calculatePenaltyPoints();
+	let totalPenaltyPoints = this.calculatePenaltyPoints();
 
 	return this._ratePenaltyPoints( totalPenaltyPoints );
 };

--- a/js/cornerstone/contentAssessor.js
+++ b/js/cornerstone/contentAssessor.js
@@ -29,10 +29,12 @@ let contentConfiguration = require( "./../config/content/combinedConfig.js" );
  *
  * @constructor
  */
-let CornerStoneContentAssessor = function( i18n, options ) {
+let CornerStoneContentAssessor = function( i18n, options = {} ) {
 	Assessor.call( this, i18n, options );
-
-	let locale = options.locale;
+	let locale = "en_US";
+	if ( options.hasOwnProperty( "locale" ) ) {
+		locale = options.locale;
+	}
 
 	this._assessments = [
 

--- a/js/cornerstone/contentAssessor.js
+++ b/js/cornerstone/contentAssessor.js
@@ -9,6 +9,9 @@ let transitionWords = require( "../assessments/readability/transitionWordsAssess
 let passiveVoice = require( "../assessments/readability/passiveVoiceAssessment.js" );
 let sentenceBeginnings = require( "../assessments/readability/sentenceBeginningsAssessment.js" );
 let textPresence = require( "../assessments/readability/textPresenceAssessment.js" );
+
+let contentConfiguration = require( "./../config/content/combinedConfig.js" );
+
 /*
  Temporarily disabled:
 
@@ -22,11 +25,15 @@ let textPresence = require( "../assessments/readability/textPresenceAssessment.j
  * @param {object} i18n The i18n object used for translations.
  * @param {Object} options The options for this assessor.
  * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {string} options.locale The locale.
  *
  * @constructor
  */
 let CornerStoneContentAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
+
+	let locale = options.locale;
+	console.log( locale );
 
 	this._assessments = [
 
@@ -41,6 +48,7 @@ let CornerStoneContentAssessor = function( i18n, options ) {
 		paragraphTooLong,
 		new SentenceLengthInText(
 			{
+				recommendedWordCount: contentConfiguration( locale ).sentenceLength.recommendedWordCount,
 				slightlyTooMany: 20,
 				farTooMany: 25,
 			}

--- a/js/cornerstone/contentAssessor.js
+++ b/js/cornerstone/contentAssessor.js
@@ -31,10 +31,7 @@ let contentConfiguration = require( "./../config/content/combinedConfig.js" );
  */
 let CornerStoneContentAssessor = function( i18n, options = {} ) {
 	Assessor.call( this, i18n, options );
-	let locale = "en_US";
-	if ( options.hasOwnProperty( "locale" ) ) {
-		locale = options.locale;
-	}
+	let locale = ( options.hasOwnProperty( "locale" ) ) ? options.locale : "en_US";
 
 	this._assessments = [
 

--- a/js/cornerstone/contentAssessor.js
+++ b/js/cornerstone/contentAssessor.js
@@ -33,7 +33,6 @@ let CornerStoneContentAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 
 	let locale = options.locale;
-	console.log( locale );
 
 	this._assessments = [
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Changes recommended maximum sentence length for Italian from 20 to 25 words, based on more in-depth research. 

## Test instructions

This PR can be tested by following these steps:

### In Wordpress
* Set the language to something that isn't Italian.
* Write a text with long sentences.
* The sentence length assessment should use a 20-word limit.
* Change the language to Italiano. 
* The sentence length assessment should use a 25-word limit, both for the regular as well as the cornerstone content assessor.

### In the browserified example
* Set the language to something that isn't Italian/use the default en_US
* Write a text with long sentences.
* The sentence length assessment should use a 20-word limit.
* Change the language to it_IT. 
* The sentence length assessment should use a 25-word limit.

Fixes #1153
