### PR TITLE
Change page title to snippet title

### DIFF
--- a/js/assessments/seo/pageTitleWidthAssessment.js
+++ b/js/assessments/seo/pageTitleWidthAssessment.js
@@ -87,25 +87,25 @@ class PageTitleWidthAssesment extends Assessment {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
 			return i18n.dgettext(
 				"js-text-analysis",
-				"The page title is too short. Use the space to add keyword variations or create compelling call-to-action copy."
+				"The snippet title is too short. Use the space to add keyword variations or create compelling call-to-action copy."
 			);
 		}
 
 		if ( inRange( pageTitleWidth, this._config.minLength, this._config.maxLength ) ) {
 			return i18n.dgettext(
 				"js-text-analysis",
-				"The page title has a nice length."
+				"The snippet title has a nice length."
 			);
 		}
 
 		if ( pageTitleWidth > this._config.maxLength ) {
 			return i18n.dgettext(
 				"js-text-analysis",
-				"The page title is wider than the viewable limit."
+				"The snippet title is wider than the viewable limit."
 			);
 		}
 
-		return i18n.dgettext( "js-text-analysis", "Please create a page title." );
+		return i18n.dgettext( "js-text-analysis", "Please create a snippet title." );
 	}
 
 }

--- a/js/assessments/seo/pageTitleWidthAssessment.js
+++ b/js/assessments/seo/pageTitleWidthAssessment.js
@@ -87,25 +87,25 @@ class PageTitleWidthAssesment extends Assessment {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
 			return i18n.dgettext(
 				"js-text-analysis",
-				"The snippet title is too short. Use the space to add keyword variations or create compelling call-to-action copy."
+				"The SEO title is too short. Use the space to add keyword variations or create compelling call-to-action copy."
 			);
 		}
 
 		if ( inRange( pageTitleWidth, this._config.minLength, this._config.maxLength ) ) {
 			return i18n.dgettext(
 				"js-text-analysis",
-				"The snippet title has a nice length."
+				"The SEO title has a nice length."
 			);
 		}
 
 		if ( pageTitleWidth > this._config.maxLength ) {
 			return i18n.dgettext(
 				"js-text-analysis",
-				"The snippet title is wider than the viewable limit."
+				"The SEO title is wider than the viewable limit."
 			);
 		}
 
-		return i18n.dgettext( "js-text-analysis", "Please create a snippet title." );
+		return i18n.dgettext( "js-text-analysis", "Please create an SEO title." );
 	}
 
 }

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -6,44 +6,44 @@ var i18n = factory.buildJed();
 
 let pageTitleLengthAssessment = new PageTitleLengthAssessment();
 
-describe( "the page title length assessment", function() {
-	it( "should assess a paper without a page title", function() {
+describe( "the snippet title length assessment", function() {
+	it( "should assess a paper without a snippet title", function() {
 		var paper = new Paper( "" );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toEqual( 1 );
-		expect( result.getText() ).toEqual( "Please create a page title." );
+		expect( result.getText() ).toEqual( "Please create a snippet title." );
 	});
 
-	it( "should assess a paper with a page title that's under the recommended value", function() {
+	it( "should assess a paper with a snippet title that's under the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 9 ), i18n );
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "The page title is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
+		expect( result.getText() ).toEqual( "The snippet title is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
 
 	});
 
-	it( "should assess a paper with a page title that's in range of the recommended value", function() {
+	it( "should assess a paper with a snippet title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 450 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The page title has a nice length." );
+		expect( result.getText() ).toEqual( "The snippet title has a nice length." );
 
 	});
 
-	it( "should assess a paper with a page title that's in range of the recommended value", function() {
+	it( "should assess a paper with a snippet title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The page title has a nice length." );
+		expect( result.getText() ).toEqual( "The snippet title has a nice length." );
 
 	});
 
-	it( "should assess a paper with a page title that's longer than the recommended value", function() {
+	it( "should assess a paper with a snippet title that's longer than the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "The page title is wider than the viewable limit." );
+		expect( result.getText() ).toEqual( "The snippet title is wider than the viewable limit." );
 
 	});
 });

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -6,44 +6,44 @@ var i18n = factory.buildJed();
 
 let pageTitleLengthAssessment = new PageTitleLengthAssessment();
 
-describe( "the snippet title length assessment", function() {
-	it( "should assess a paper without a snippet title", function() {
+describe( "the SEO title length assessment", function() {
+	it( "should assess a paper without a SEO title", function() {
 		var paper = new Paper( "" );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toEqual( 1 );
-		expect( result.getText() ).toEqual( "Please create a snippet title." );
+		expect( result.getText() ).toEqual( "Please create an SEO title." );
 	});
 
-	it( "should assess a paper with a snippet title that's under the recommended value", function() {
+	it( "should assess a paper with a SEO title that's under the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 9 ), i18n );
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "The snippet title is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
+		expect( result.getText() ).toEqual( "The SEO title is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
 
 	});
 
-	it( "should assess a paper with a snippet title that's in range of the recommended value", function() {
+	it( "should assess a paper with a SEO title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 450 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The snippet title has a nice length." );
+		expect( result.getText() ).toEqual( "The SEO title has a nice length." );
 
 	});
 
-	it( "should assess a paper with a snippet title that's in range of the recommended value", function() {
+	it( "should assess a paper with a SEO title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The snippet title has a nice length." );
+		expect( result.getText() ).toEqual( "The SEO title has a nice length." );
 
 	});
 
-	it( "should assess a paper with a snippet title that's longer than the recommended value", function() {
+	it( "should assess a paper with a SEO title that's longer than the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "The snippet title is wider than the viewable limit." );
+		expect( result.getText() ).toEqual( "The SEO title is wider than the viewable limit." );
 
 	});
 });


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Change "page title" to "snippet title" in the snippet title feedback string.


Fixes #120
