### PR TITLE
Remove relevant word combinations containing special characters

### DIFF
--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -124,8 +124,8 @@ function sortCombinations( wordCombinations ) {
  */
 function filterFunctionWordsAnywhere( wordCombinations, functionWords ) {
 	return wordCombinations.filter( function( combination ) {
-		return isEmpty (
-			intersection( functionWords, combination.getWords())
+		return isEmpty(
+			intersection( functionWords, combination.getWords() )
 		);
 	} );
 }

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -27,8 +27,8 @@ let densityUpperLimit = 0.03;
 let relevantWordLimit = 100;
 let wordCountLowerLimit = 200;
 
-// En dash, em dash, hyphen-minus, and hash.
-let specialCharacters = [ "–", "—", "-", "#", "%" ];
+// First four characters: en dash, em dash, hyphen-minus, and copyright sign.
+let specialCharacters = [ "–", "—", "-", "\u00a9", "#", "%", "/", "\\", "$", "€", "£", "*", "•", "|", "→", "←", "}", "{" ];
 
 /**
  * Returns the word combinations for the given text based on the combination size.
@@ -116,6 +116,21 @@ function sortCombinations( wordCombinations ) {
 }
 
 /**
+ * Filters word combinations containing certain function words at any position.
+ *
+ * @param {WordCombination[]} wordCombinations The word combinations to filter.
+ * @param {array} functionWords The list of function words.
+ * @returns {WordCombination[]} Filtered word combinations.
+ */
+function filterFunctionWordsAnywhere( wordCombinations, functionWords ) {
+	return wordCombinations.filter( function( combination ) {
+		return isEmpty (
+			intersection( functionWords, combination.getWords())
+		);
+	} );
+}
+
+/**
  * Filters word combinations beginning with certain function words.
  *
  * @param {WordCombination[]} wordCombinations The word combinations to filter.
@@ -157,20 +172,6 @@ function filterFunctionWords( wordCombinations, functionWords ) {
 }
 
 /**
- * Filters word combinations containing a special character.
- *
- * @param {WordCombination[]} wordCombinations The word combinations to filter.
- * @param {array} specialCharacters The list of special characters.
- * @returns {WordCombination[]} Filtered word combinations.
- */
-function filterSpecialCharacters( wordCombinations, specialCharacters ) {
-	return wordCombinations.filter( function( combination ) {
-		return isEmpty(
-			intersection( specialCharacters, combination.getWords() )
-		);
-	} );
-}
-/**
  * Filters word combinations with a length of one and a given syllable count.
  *
  * @param {WordCombination[]} wordCombinations The word combinations to filter.
@@ -210,7 +211,7 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
  * @returns {Array} The filtered list of word combination objects.
  */
 function filterCombinations( combinations, functionWords, locale ) {
-	combinations = filterFunctionWords( combinations, specialCharacters );
+	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
 	combinations = filterFunctionWords( combinations, functionWords().articles );
 	combinations = filterFunctionWords( combinations, functionWords().personalPronouns );
 	combinations = filterFunctionWords( combinations, functionWords().prepositions );
@@ -331,9 +332,10 @@ module.exports = {
 	calculateOccurrences: calculateOccurrences,
 	getRelevantCombinations: getRelevantCombinations,
 	sortCombinations: sortCombinations,
+	filterFunctionWordsAtEnding: filterFunctionWordsAtEnding,
 	filterFunctionWordsAtBeginning: filterFunctionWordsAtBeginning,
 	filterFunctionWords: filterFunctionWords,
-	filterSpecialCharacters: filterSpecialCharacters,
+	filterFunctionWordsAnywhere: filterFunctionWordsAnywhere,
 	filterOnSyllableCount: filterOnSyllableCount,
 	filterOnDensity: filterOnDensity,
 };

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -28,7 +28,7 @@ let relevantWordLimit = 100;
 let wordCountLowerLimit = 200;
 
 // First four characters: en dash, em dash, hyphen-minus, and copyright sign.
-let specialCharacters = [ "–", "—", "-", "\u00a9", "#", "%", "/", "\\", "$", "€", "£", "*", "•", "|", "→", "←", "}", "{" ];
+let specialCharacters = [ "–", "—", "-", "\u00a9", "#", "%", "/", "\\", "$", "€", "£", "*", "•", "|", "→", "←", "}", "{", "//", "||" ];
 
 /**
  * Returns the word combinations for the given text based on the combination size.

--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -7,7 +7,7 @@ let getRelevantCombinations = relevantWords.getRelevantCombinations;
 let sortCombinations = relevantWords.sortCombinations;
 let filterFunctionWordsAtBeginning = relevantWords.filterFunctionWordsAtBeginning;
 let filterFunctionWords = relevantWords.filterFunctionWords;
-let filterSpecialCharacters = relevantWords.filterSpecialCharacters;
+let filterFunctionWordsAnywhere = relevantWords.filterFunctionWordsAnywhere;
 let filterOnSyllableCount = relevantWords.filterOnSyllableCount;
 let filterOnDensity = relevantWords.filterOnDensity;
 let englishFunctionWords = require( "../../js/researches/english/functionWords.js" )().all;
@@ -254,7 +254,7 @@ describe( "filter special characters in word combinations", function() {
 			new WordCombination ( [ "book", "club"] )
 		];
 
-		let combinations  = filterSpecialCharacters( input, [ "–", "—", "-" ] );
+		let combinations  = filterFunctionWordsAnywhere( input, [ "–", "—", "-" ] );
 
 		expect( combinations ).toEqual( expected );
 	});


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Removes all relevant word combinations containing any of the following special characters if they are not part of a word: –, —, -, ©, #, %, /, \\, $, €, £, *, •, |, →, ←, }, {, //, ||. 

## Relevant technical choices:
- Once #1179 has been merged, the added function will also be used to filter combinations containing specific words and word categories.
- I've removed the uncalled `filterSpecialCharacters` function.

## Test instructions

This PR can be tested by following these steps:

* Use the browserified relevant words example. Don't forget to run a `grunt build:js`.
* Write a text containing the same sentence multiple times. Make sure this sentence contains one of the above special characters (surrounded by spaces, e.g. `word word % word word` not ` word 14% word word`).
* Check whether no combinations containing this special character are included in the prominent words table.

Fixes #1075 
