### PR TITLE
Prominent word filter comparisons

### DIFF
--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -1,59 +1,59 @@
-var filteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().filteredAuxiliaries;
-var notFilteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().notFilteredAuxiliaries;
-var transitionWords = require( "./transitionWords.js" )().singleWords;
+let filteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().filteredAuxiliaries;
+let notFilteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().notFilteredAuxiliaries;
+let transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
  * Returns an object with exceptions for the prominent words researcher
  * @returns {Object} The object filled with exception arrays.
  */
 
-var articles = [ "the", "an", "a" ];
-var cardinalNumerals = [ "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen",
+let articles = [ "the", "an", "a" ];
+let cardinalNumerals = [ "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen",
 	"fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen", "twenty", "hundred", "hundreds", "thousand", "thousands",
 	"million", "million", "billion", "billions" ];
 
-var ordinalNumerals = [ "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth",
+let ordinalNumerals = [ "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth",
 	"eleventh", "twelfth", "thirteenth", "fourteenth", "fifteenth", "sixteenth", "seventeenth", "eighteenth",
 	"nineteenth", "twentieth" ];
 
-var personalPronounsNominative = [ "i", "you", "he", "she", "it", "we", "they" ];
-var personalPronounsAccusative = [ "me", "him", "her", "us", "them" ];
-var demonstrativePronouns = [ "this", "that", "these", "those" ];
-var possessivePronouns = [ "my", "your", "his", "her", "its", "their", "our", "mine", "yours", "hers", "theirs", "ours" ];
-var quantifiers = [ "all", "some", "many", "few", "lot", "lots", "ton", "tons", "bit", "no", "every", "enough", "little",
+let personalPronounsNominative = [ "i", "you", "he", "she", "it", "we", "they" ];
+let personalPronounsAccusative = [ "me", "him", "her", "us", "them" ];
+let demonstrativePronouns = [ "this", "that", "these", "those" ];
+let possessivePronouns = [ "my", "your", "his", "her", "its", "their", "our", "mine", "yours", "hers", "theirs", "ours" ];
+let quantifiers = [ "all", "some", "many", "few", "lot", "lots", "ton", "tons", "bit", "no", "every", "enough", "little",
 	"less", "much", "more", "most",	"plenty", "several", "few", "fewer", "kind" ];
-var reflexivePronouns = [ "myself", "yourself", "himself", "herself", "itself", "oneself", "ourselves", "yourselves", "themselves" ];
-var indefinitePronouns = [ "none", "nobody", "everyone", "everybody", "someone", "somebody", "anyone", "anybody", "nothing",
+let reflexivePronouns = [ "myself", "yourself", "himself", "herself", "itself", "oneself", "ourselves", "yourselves", "themselves" ];
+let indefinitePronouns = [ "none", "nobody", "everyone", "everybody", "someone", "somebody", "anyone", "anybody", "nothing",
 	"everything", "something", "anything", "each", "another", "other", "whatever", "whichever", "whoever", "whomever",
 	"whomsoever", "whosoever", "others", "neither", "both", "either", "any", "such" ];
-var indefinitePronounsPossessive  = [ "one's", "nobody's", "everyone's", "everybody's", "someone's", "somebody's", "anyone's",
+let indefinitePronounsPossessive  = [ "one's", "nobody's", "everyone's", "everybody's", "someone's", "somebody's", "anyone's",
 	"anybody's", "nothing's", "everything's", "something's", "anything's", "whoever's", "others'", "other's", "another's",
 	"neither's", "either's" ];
 
-var interrogativeDeterminers = [ "which", "what", "whose" ];
-var interrogativePronouns = [ "who", "whom" ];
-var interrogativeProAdverbs = [ "where", "whither", "whence", "how", "why", "whether", "wherever", "whomever", "whenever",
+let interrogativeDeterminers = [ "which", "what", "whose" ];
+let interrogativePronouns = [ "who", "whom" ];
+let interrogativeProAdverbs = [ "where", "whither", "whence", "how", "why", "whether", "wherever", "whomever", "whenever",
 	"however", "whyever", "whoever", "whatever", "wheresoever", "whomsoever", "whensoever", "howsoever", "whysoever", "whosoever",
 	"whatsoever", "whereso", "whomso", "whenso", "howso", "whyso", "whoso", "whatso" ];
-var pronominalAdverbs = [ "therefor", "therein", "hereby", "hereto", "wherein", "therewith", "herewith", "wherewith", "thereby" ];
-var locativeAdverbs = [ "there", "here", "whither", "thither", "hither", "whence", "thence", "hence" ];
-var adverbialGenitives = [ "always", "afterwards", "towards", "once", "twice", "thrice", "amidst", "amongst", "midst", "whilst" ];
-var otherAuxiliaries = [ "can", "cannot", "can't", "could", "couldn't", "could've", "dare", "dares", "dared", "do",
+let pronominalAdverbs = [ "therefor", "therein", "hereby", "hereto", "wherein", "therewith", "herewith", "wherewith", "thereby" ];
+let locativeAdverbs = [ "there", "here", "whither", "thither", "hither", "whence", "thence", "hence" ];
+let adverbialGenitives = [ "always", "afterwards", "towards", "once", "twice", "thrice", "amidst", "amongst", "midst", "whilst" ];
+let otherAuxiliaries = [ "can", "cannot", "can't", "could", "couldn't", "could've", "dare", "dares", "dared", "do",
 	"don't", "does", "doesn't", "did", "didn't", "done", "have", "haven't", "had", "hadn't", "has", "hasn't",
 	"i've", "you've", "we've", "they've", "i'd", "you'd", "he'd", "she'd", "it'd", "we'd", "they'd", "would", "wouldn't",
 	"would've", "may", "might", "must", "need", "needn't", "needs", "ought", "shall", "shalln't", "shan't", "should",
 	"shouldn't", "will", "won't", "i'll", "you'll", "he'll", "she'll", "it'll", "we'll", "they'll", "there's", "there're",
 	"there'll", "here's", "here're", "there'll" ];
-var copula = [ "appear", "appears", "appeared", "become", "becomes", "became", "come", "comes",
+let copula = [ "appear", "appears", "appeared", "become", "becomes", "became", "come", "comes",
 	"came", "keep", "keeps", "kept", "remain", "remains", "remained", "stay",
 	"stays", "stayed", "turn", "turns", "turned" ];
 
 // These verbs should only be included at the beginning of combinations.
-var continuousVerbs = [ "doing", "daring", "having", "appearing", "becoming", "coming", "keeping", "remaining", "staying",
+let continuousVerbs = [ "doing", "daring", "having", "appearing", "becoming", "coming", "keeping", "remaining", "staying",
 	"saying", "asking", "stating", "seeming", "letting", "making", "setting", "showing", "putting", "adding", "going", "using",
 	"trying", "containing" ];
 
-var prepositions = [ "in", "from", "with", "under", "throughout", "atop", "for", "on", "until", "of", "to", "aboard", "about",
+let prepositions = [ "in", "from", "with", "under", "throughout", "atop", "for", "on", "until", "of", "to", "aboard", "about",
 	"above", "abreast", "absent", "across", "adjacent", "after", "against", "along", "alongside", "amid", "midst", "mid",
 	"among", "apropos", "apud", "around", "as", "astride", "at", "ontop", "before", "afore", "tofore", "behind", "ahind",
 	"below", "ablow", "beneath", "neath", "beside", "besides", "between", "atween", "beyond", "ayond", "but", "by", "chez",
@@ -63,41 +63,41 @@ var prepositions = [ "in", "from", "with", "under", "throughout", "atop", "for",
 	"up", "upon", "upside", "versus", "via", "vis-à-vis", "without", "ago", "apart", "aside", "aslant", "away", "withal" ];
 
 // Many prepositional adverbs are already listed as preposition.
-var prepositionalAdverbs = [ "back", "within", "forward", "backward", "ahead" ];
+let prepositionalAdverbs = [ "back", "within", "forward", "backward", "ahead" ];
 
-var coordinatingConjunctions = [ "so", "and", "nor", "but", "or", "yet", "for" ];
+let coordinatingConjunctions = [ "so", "and", "nor", "but", "or", "yet", "for" ];
 
 // 'Rather' is part of 'rather...than', 'sooner' is part of 'no sooner...than', 'just' is part of 'just as...so',
 // 'Only' is part of 'not only...but also'.
-var correlativeConjunctions = [ "rather", "sooner", "just", "only" ];
-var subordinatingConjunctions = [ "after", "although", "when", "as", "if", "though", "because", "before", "even", "since", "unless",
+let correlativeConjunctions = [ "rather", "sooner", "just", "only" ];
+let subordinatingConjunctions = [ "after", "although", "when", "as", "if", "though", "because", "before", "even", "since", "unless",
 	"whereas", "while" ];
 
 // These verbs are frequently used in interviews to indicate questions and answers.
 // 'Claim','claims', 'state' and 'states' are not included, because these words are also nouns.
-var interviewVerbs = [ "say", "says", "said", "claimed", "ask", "asks", "asked", "stated",
+let interviewVerbs = [ "say", "says", "said", "claimed", "ask", "asks", "asked", "stated",
 	"explain", "explains", "explained", "think", "thinks" ];
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
-var additionalTransitionWords = [ "and", "or", "about", "absolutely", "again", "definitely", "eternally", "expressively",
+let additionalTransitionWords = [ "and", "or", "about", "absolutely", "again", "definitely", "eternally", "expressively",
 	"expressly", "extremely", "immediately", "including", "instantly", "namely", "naturally", "next", "notably", "now", "nowadays",
 	"ordinarily", "positively", "truly", "ultimately", "uniquely", "usually", "almost", "first", "second", "third", "maybe",
 	"probably", "granted", "initially", "overall", "too", "actually", "already", "e.g", "i.e", "often", "regularly", "simply",
 	"optionally", "perhaps", "sometimes", "likely", "never", "ever", "else", "inasmuch", "provided", "currently", "incidentally",
 	"elsewhere", "following", "particular", "recently", "relatively", "f.i", "clearly", "apparently" ];
 
-var intensifiers = [ "highly", "very", "really", "extremely", "absolutely", "completely", "totally", "utterly", "quite",
+let intensifiers = [ "highly", "very", "really", "extremely", "absolutely", "completely", "totally", "utterly", "quite",
 	"somewhat", "seriously", "fairly", "fully", "amazingly" ];
 
 // These verbs convey little meaning. 'Show', 'shows', 'uses', "meaning" are not included, because these words could be relevant nouns.
-var delexicalizedVerbs = [ "seem", "seems", "seemed", "let", "let's", "lets", "make", "makes",
+let delexicalizedVerbs = [ "seem", "seems", "seemed", "let", "let's", "lets", "make", "makes",
 	"made", "want", "showed", "shown", "go", "goes", "went", "gone", "take", "takes", "took", "taken", "set", "sets",
 	"put", "puts", "use", "used", "try", "tries", "tried", "mean", "means", "meant",
 	"called", "based", "add", "adds", "added", "contain", "contains", "contained" ];
 
 // These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
 // Keyword combinations containing these adjectives/adverbs are fine.
-var generalAdjectivesAdverbs = [ "new", "newer", "newest", "old", "older", "oldest", "previous", "good", "well", "better", "best",
+let generalAdjectivesAdverbs = [ "new", "newer", "newest", "old", "older", "oldest", "previous", "good", "well", "better", "best",
 	"big", "bigger", "biggest", "easy", "easier", "easiest", "fast", "faster", "fastest", "far", "hard", "harder", "hardest",
 	"least", "own", "large", "larger", "largest", "long", "longer", "longest", "low", "lower", "lowest", "high", "higher",
 	"highest", "regular", "simple", "simpler", "simplest", "small", "smaller", "smallest", "tiny", "tinier", "tiniest",
@@ -106,20 +106,20 @@ var generalAdjectivesAdverbs = [ "new", "newer", "newest", "old", "older", "olde
 	"continually", "directly", "easily", "nearly", "slightly", "somewhere", "estimated", "latest", "different", "similar",
 	"widely", "bad", "worse", "worst", "great" ];
 
-var interjections = [ "oh", "wow", "tut-tut", "tsk-tsk", "ugh", "whew", "phew", "yeah", "yea", "shh", "oops", "ouch", "aha",
+let interjections = [ "oh", "wow", "tut-tut", "tsk-tsk", "ugh", "whew", "phew", "yeah", "yea", "shh", "oops", "ouch", "aha",
 	"yikes" ];
 
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
-var recipeWords = [ "tbs", "tbsp", "spk", "lb", "qt", "pk", "bu", "oz", "pt", "mod", "doz", "hr", "f.g", "ml", "dl", "cl",
+let recipeWords = [ "tbs", "tbsp", "spk", "lb", "qt", "pk", "bu", "oz", "pt", "mod", "doz", "hr", "f.g", "ml", "dl", "cl",
 	"l", "mg", "g", "kg", "quart" ];
 
 // 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
-var vagueNouns = [ "thing", "things", "way", "ways", "matter", "case", "likelihood", "ones", "piece", "pieces", "stuff", "times",
+let vagueNouns = [ "thing", "things", "way", "ways", "matter", "case", "likelihood", "ones", "piece", "pieces", "stuff", "times",
 	"part", "parts", "percent", "instance", "instances", "aspect", "aspects", "item", "items", "idea", "theme",
 	"person" ];
 
 // 'No' is already included in the quantifier list.
-var miscellaneous = [ "not", "yes", "rid", "sure", "top", "bottom", "ok", "okay", "amen", "aka" ];
+let miscellaneous = [ "not", "yes", "rid", "sure", "top", "bottom", "ok", "okay", "amen", "aka" ];
 
 module.exports = function() {
 	return {

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -1,21 +1,21 @@
-var filteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().filteredAuxiliaries;
-var infinitivePassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().infinitiveAuxiliaries;
-var transitionWords = require( "./transitionWords.js" )().singleWords;
+let filteredPassiveAuxiliaries = require( "./passivevoice/auxiliaries.js" )().filteredAuxiliaries;
+let passiveAuxiliariesInfinitive = require( "./passivevoice/auxiliaries.js" )().infinitiveAuxiliaries;
+let transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
  * Returns an object with exceptions for the prominent words researcher
  * @returns {Object} The object filled with exception arrays.
  */
 
-var articles = [ "das", "dem", "den", "der", "des", "die", "ein", "eine", "einem", "einen", "einer", "eines" ];
+let articles = [ "das", "dem", "den", "der", "des", "die", "ein", "eine", "einem", "einen", "einer", "eines" ];
 
-var cardinalNumerals = [ "eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn", "elf", "zwölf",
+let cardinalNumerals = [ "eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn", "elf", "zwölf",
 	"zwoelf", "dreizehn", "vierzehn", "fünfzehn", "fuenfzehn", "sechzehn", "siebzehn", "achtzehn", "neunzehn",
 	"zwanzig", "hundert", "einhundert", "zweihundert", "dreihundert", "vierhundert", "fünfhundert",
 	"fuenfhundert", "sechshundert", "siebenhundert", "achthundert", "neunhundert", "tausend",
 	"million", "milliarde", "billion", "billiarde" ];
 
-var ordinalNumerals = [ "erste", "erster", "ersten", "erstem", "erstes", "zweite", "zweites", "zweiter", "zweitem", "zweiten",
+let ordinalNumerals = [ "erste", "erster", "ersten", "erstem", "erstes", "zweite", "zweites", "zweiter", "zweitem", "zweiten",
 	"dritte", "dritter", "drittes", "dritten", "drittem", "vierter", "vierten", "viertem", "viertes", "vierte",
 	"fünfte", "fünfter", "fünftes", "fünften", "fünftem", "fuenfte", "fuenfter", "fuenftem", "fuenften", "fuenftes",
 	"sechste", "sechster", "sechstes", "sechsten", "sechstem", "siebte", "siebter", "siebten", "siebtem", "siebtes",
@@ -29,22 +29,22 @@ var ordinalNumerals = [ "erste", "erster", "ersten", "erstem", "erstes", "zweite
 	"achtzehntes", "achtzehnte", "nehnzehnte", "nehnzehnter", "nehnzehntem", "nehnzehnten", "nehnzehntes", "zwanzigste",
 	"zwanzigster", "zwanzigstem", "zwanzigsten", "zwanzigstes" ];
 
-var personalPronounsNominative = [ "ich", "du", "er", "sie", "es", "wir", "ihr", "sie" ];
+let personalPronounsNominative = [ "ich", "du", "er", "sie", "es", "wir", "ihr", "sie" ];
 
-var personalPronounsAccusative = [ "mich", "dich", "ihn", "sie", "es", "uns", "euch" ];
+let personalPronounsAccusative = [ "mich", "dich", "ihn", "sie", "es", "uns", "euch" ];
 
-var personalPronounsDative = [ "mir", "dir", "ihm", "ihr", "uns", "euch", "ihnen" ];
+let personalPronounsDative = [ "mir", "dir", "ihm", "ihr", "uns", "euch", "ihnen" ];
 
-var demonstrativePronouns = [ "denen", "deren", "derer", "dessen", "diese", "diesem", "diesen", "dieser", "dieses",
+let demonstrativePronouns = [ "denen", "deren", "derer", "dessen", "diese", "diesem", "diesen", "dieser", "dieses",
 	"jene",	"jenem", "jenen", "jener", "jenes", "welch", "welcher", "welches", "derjenige", "desjenigen", "demjenigen",
 	"denjenigen", "diejenige", "derjenigen", "dasjenige", "diejenigen" ];
 
-var possessivePronouns = [ "mein", "meine", "meinem", "meiner", "meines", "dein", "deine", "deinem", "deiner",
+let possessivePronouns = [ "mein", "meine", "meinem", "meiner", "meines", "dein", "deine", "deinem", "deiner",
 	"deines", "deinen", "sein", "seine", "seinem", "seiner", "seines", "ihr", "ihre", "ihrem", "ihren", "ihrer", "ihres",
 	"unser", "unsere", "unserem", "unseren", "unserer", "unseres", "euer", "eure", "eurem", "euren", "eurer",
 	"eures", "einanders" ];
 
-var quantifiers = [ "manche", "manch", "viele", "viel", "vieler", "vielen", "vielem", "all", "alle", "aller", "alles",
+let quantifiers = [ "manche", "manch", "viele", "viel", "vieler", "vielen", "vielem", "all", "alle", "aller", "alles",
 	"allen", "allem", "allerlei", "solcherlei", "einige", "etliche", "manch", "wenige", "weniger", "wenigen",
 	"wenigem", "weniges", "wenig", "wenigerer", "wenigeren", "wenigerem", "wenigere", "wenigeres", "wenig",
 	"bisschen", "paar", "kein", "keines", "keinem", "keinen", "keine", "mehr", "mehrere", "nichts",
@@ -52,12 +52,12 @@ var quantifiers = [ "manche", "manch", "viele", "viel", "vieler", "vielen", "vie
 	"verschiedenen", "verschiedenem", "verschiedenes", "verschiedne", "verschiedner", "verschiednen", "verschiednem",
 	"verschiednes", "art", "arten", "sorte", "sorten" ];
 
-var reflexivePronouns = [ "sich" ];
+let reflexivePronouns = [ "sich" ];
 
-var reciprocalPronouns = [ "einander" ];
+let reciprocalPronouns = [ "einander" ];
 
 // "Welch", "welcher", and "welches" are already included in the demonstrativePronouns.
-var indefinitePronouns = [ "andere", "anderer", "anderem", "anderen", "anderes", "andren", "andern", "andrem",
+let indefinitePronouns = [ "andere", "anderer", "anderem", "anderen", "anderes", "andren", "andern", "andrem",
 	"anderm", "andre", "andrer", "andres", "beide", "beides", "beidem", "beider", "beiden", "etwas", "irgendetwas",
 	"irgendein", "irgendeinen", "irgendeinem", "irgendeines", "irgendeine", "irgendeiner", "irgendwas", "irgendwessen",
 	"irgendwer", "irgendwen", "irgendwem", "irgendwessen", "irgendwelche", "irgendwelcher", "irgendwelchem",
@@ -71,11 +71,11 @@ var indefinitePronouns = [ "andere", "anderer", "anderem", "anderen", "anderes",
 	"niemanden", "niemandem", "niemandes", "niemands", "nichts", "jeglicher", "jeglichen", 	"jeglichem", "jegliches",
 	"jegliche", "zweiter" ];
 
-var relativePronouns = [ "dessen", "deren", "derer", "denen" ];
+let relativePronouns = [ "dessen", "deren", "derer", "denen" ];
 
-var interrogativeProAdverbs =  [ "warum", "wie", "wo", "woher", "wohin", "wann" ];
+let interrogativeProAdverbs =  [ "warum", "wie", "wo", "woher", "wohin", "wann" ];
 
-var pronominalAdverbs = [ "dabei", "dadurch", "dafür", "dafuer", "dagegen", "dahinter", "damit", "danach", "daneben",
+let pronominalAdverbs = [ "dabei", "dadurch", "dafür", "dafuer", "dagegen", "dahinter", "damit", "danach", "daneben",
 	"daran", "darauf", "daraus", "darin", "darum", "darunter", "darüber", "darueber", "davon", "davor", "dazu",
 	"dazwischen", "hieran",	"hierauf", "hieraus", "hierbei", "hierdurch", "hierfuer", "hierfür", "hiergegen",
 	"hierhinter", "hierin",	"hiermit", "hiernach", "hierum", "hierunter", "hierueber", "hierüber", "hiervor",
@@ -83,9 +83,9 @@ var pronominalAdverbs = [ "dabei", "dadurch", "dafür", "dafuer", "dagegen", "da
 	"wogegen", "wohinter", "womit", "wonach", "woneben", "woran", "worauf", "woraus", "worin",	"worum", "worunter",
 	"worüber", "worueber", "wovon", "wovor", "wozu", "wozwischen" ];
 
-var locativeAdverbs = [ "da", "hier", "dorthin", "hierher", "dorther", "daher" ];
+let locativeAdverbs = [ "da", "hier", "dorthin", "hierher", "dorther", "daher" ];
 
-var adverbialGenitives = [ "allenfalls", "keinesfalls", "anderenfalls", "andernfalls", "andrenfalls",
+let adverbialGenitives = [ "allenfalls", "keinesfalls", "anderenfalls", "andernfalls", "andrenfalls",
 	"äußerstenfalls", "bejahendenfalls", "bestenfalls", "ebenfalls", "eintretendenfalls", "entgegengesetztenfalls",
 	"erforderlichenfalls", "gegebenenfalls", "geringstenfalls", "gleichfalls", "günstigenfalls", "günstigstenfalls",
 	"höchstenfalls", "jedenfalls", "möglichenfalls", "notfalls", "nötigenfalls", "notwendigenfalls",
@@ -93,7 +93,7 @@ var adverbialGenitives = [ "allenfalls", "keinesfalls", "anderenfalls", "andernf
 	"abends", "nachts", "keineswegs", "durchwegs", "geradenwegs", "geradeswegs", "geradewegs", "gradenwegs",
 	"halbwegs", "mittwegs", "unterwegs" ];
 
-var otherAuxiliaries = [ "habe", "hast", "hat", "habt", "habest", "habet", "hatte", "hattest", "hatten", "hätte", "haette",
+let otherAuxiliaries = [ "habe", "hast", "hat", "habt", "habest", "habet", "hatte", "hattest", "hatten", "hätte", "haette",
 	"hättest", "haettest", "hätten", "haetten", "haettet", "hättet", "hab", "bin", "bist", "ist", "sind", "sei", "seiest",
 	"seien", "seiet", "war", "warst", "waren", "wart", "wäre", "waere", "wärest", "waerest", "wärst", "waerst", "wären",
 	"waeren", "wäret", "waeret", "wärt", "waert", "seid", "darf", "darfst", "dürft", "duerft", "dürfe", "duerfe", "dürfest",
@@ -110,11 +110,11 @@ var otherAuxiliaries = [ "habe", "hast", "hat", "habt", "habest", "habet", "hatt
 	"lässt", "laesst", "läßt", "laeßt", "lasst", "laßt", "lassest", "lasset", "ließ", "ließest", "ließt", "ließen", "ließe",
 	"ließet", "liess", "liessest", "liesst", "liessen", "liesse", "liesset" ];
 
-var otherAuxiliariesInfinitive = [ "haben", "sein", "dürfen", "duerfen", "können", "koennen", "mögen", "moegen", "müssen", "muessen",
+let otherAuxiliariesInfinitive = [ "haben", "sein", "dürfen", "duerfen", "können", "koennen", "mögen", "moegen", "müssen", "muessen",
 	"sollen", "wollen", "lassen" ];
 
 // Forms from 'aussehen' with two parts, like 'sehe aus', are not included, because we remove words on an single word basis.
-var copula = [ "bleibe", "bleibst", "bleibt", "bleibest", "bleibet", "blieb", "bliebst", "bliebt", "blieben", "bliebe",
+let copula = [ "bleibe", "bleibst", "bleibt", "bleibest", "bleibet", "blieb", "bliebst", "bliebt", "blieben", "bliebe",
 	"bliebest", "bliebet", "heiße", "heißt", "heißest", "heißet", "heisse", "heisst", "heissest", "heisset", "hieß", "hießest",
 	"hießt", "hießen", "hieße", "hießet", "hiess", "hiessest", "hiesst", "hiessen",	"hiesse", "hiesset", "gelte", "giltst",
 	"gilt", "geltet", "gelte", "geltest", "galt", "galtest", "galtst", "galten", "galtet", "gälte", "gaelte", "gölte", "goelte",
@@ -125,9 +125,9 @@ var copula = [ "bleibe", "bleibst", "bleibt", "bleibest", "bleibet", "blieb", "b
 	"schient", "schiene", "schienest", "schienet", "erscheine", "erscheinst", "erscheint", "erscheinest",
 	"erscheinet", "erschien", "erschienst", "erschienen", "erschient", "erschiene", "erschienest", "erschienet" ];
 
-var copulaInfinitive = [ "bleiben", "heißen", "heissen", "gelten", "aussehen", "scheinen", "erscheinen" ];
+let copulaInfinitive = [ "bleiben", "heißen", "heissen", "gelten", "aussehen", "scheinen", "erscheinen" ];
 
-var prepositions = [ "a", "à", "ab", "abseits", "abzüglich", "abzueglich", "als", "am", "an", "anfangs", "angelegentlich",
+let prepositions = [ "a", "à", "ab", "abseits", "abzüglich", "abzueglich", "als", "am", "an", "anfangs", "angelegentlich",
 	"angesichts", "anhand", "anlässlich", "anlaesslich", "ans", "anstatt", "anstelle", "auf", "aufgrund", "aufs", "aufseiten",
 	"aus", "ausgangs", "ausgenommen", "ausschließlich", "ausschliesslich", "ausser", "außer", "außerhalb", "ausserhalb", "ausweislich",
 	"bar", "behufs", "bei", "beidseits", "beiderseits", "beim", "betreffs", "bezüglich", "bezueglich", "binnen", "bis", "contra",
@@ -146,32 +146,32 @@ var prepositions = [ "a", "à", "ab", "abseits", "abzüglich", "abzueglich", "al
 	"zuwider", "zuzüglich",	"zuzueglich", "zwecks", "zwischen" ];
 
 // Many coordinating conjunctions are already included in the transition words list.
-var coordinatingConjunctions = [ "und", "oder", "als", "umso" ];
+let coordinatingConjunctions = [ "und", "oder", "als", "umso" ];
 
 /*
 'Entweder' is part of 'entweder...oder', 'sowohl', 'auch' is part of 'sowohl als...auch', 'weder' and 'noch' are part of 'weder...noch',
  'nur' is part of 'nicht nur...sondern auch'.
  */
-var correlativeConjunctions = [ "entweder", "sowohl", "auch", "weder", "noch", "nur" ];
+let correlativeConjunctions = [ "entweder", "sowohl", "auch", "weder", "noch", "nur" ];
 
 // Many subordinating conjunctions are already included in the prepositions list, transition words list or pronominal adverbs list.
-var subordinatingConjunctions = [ "nun", "so", "gleichwohl" ];
+let subordinatingConjunctions = [ "nun", "so", "gleichwohl" ];
 
 /*
 These verbs are frequently used in interviews to indicate questions and answers. 'Frage' and 'fragen' are not included,
 because those words are also nouns.
  */
-var interviewVerbs = [ "sage", "sagst", "sagt", "sagest", "saget", "sagte", "sagtest", "sagte", "sagten", "sagtet", "gesagt",
+let interviewVerbs = [ "sage", "sagst", "sagt", "sagest", "saget", "sagte", "sagtest", "sagte", "sagten", "sagtet", "gesagt",
 	"fragst", "fragt", "fragest", "fraget", "fragte", "fragtest", "fragten", "fragtet", "gefragt", "erkläre", "erklärst", "erklärt",
 	"erklaere", "erklaerst", "erklaert", "erklärte", "erklärtest", "erklärte",	"erklärtet", "erklärten",
 	"erklaerte", "erklaertest", "erklaerte", "erklaertet", "erklaerten", "denke", "denkst", "denkt", "denkest", "denket",
 	"dachte", "dachtest", "dachten", "dachtet", "dächte", "dächtest", "dächten", "dächtet", "daechte", "daechtest", "daechten",
 	"daechtet", "finde", "findest", "findet", "gefunden" ];
 
-var interviewVerbsInfinitive = [ "sagen", "erklären", "erklaeren", "denken", "finden" ];
+let interviewVerbsInfinitive = [ "sagen", "erklären", "erklaeren", "denken", "finden" ];
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
-var additionalTransitionWords = [ "etwa", "absolut", "unbedingt", "wieder", "definitiv", "bestimmt", "immer", "äußerst", "aeußerst",
+let additionalTransitionWords = [ "etwa", "absolut", "unbedingt", "wieder", "definitiv", "bestimmt", "immer", "äußerst", "aeußerst",
 	"höchst", "hoechst", "sofort", "augenblicklich", "umgehend", "direkt", "unmittelbar", "nämlich", "naemlich", "natürlich", "natuerlich",
 	"besonders", "hauptsächlich", "hauptsaechlich", "jetzt", "eben", "heute", "heutzutage", "positiv", "eindeutig", "wirklich", "echt",
 	"wahrhaft", "ehrlich", "aufrichtig", "wahrhaft", "wahrheitsgemäß", "treu", "letztlich", "einmalig", "unübertrefflich", "normalerweise",
@@ -185,18 +185,18 @@ var additionalTransitionWords = [ "etwa", "absolut", "unbedingt", "wieder", "def
 	"unlaengst", "neuerdings", "neulich", "letztens", "neuerlich", "relativ", "verhältnismäßig", "verhaeltnismaessig", "deutlich", "klar",
 	"eindeutig", "offenbar", "anscheinend", "genau", "u.a", "damals", "zumindest" ];
 
-var intensifiers = [ "sehr", "recht", "überaus", "ueberaus", "ungemein", "weitaus", "einigermaßen", "einigermassen", "ganz",
+let intensifiers = [ "sehr", "recht", "überaus", "ueberaus", "ungemein", "weitaus", "einigermaßen", "einigermassen", "ganz",
 	"schwer", "tierisch", "ungleich", "voll", "ziemlich", "übelst", "uebelst", "stark", "volkommen", "durchaus", "gar" ];
 
 // These verbs convey little meaning.
-var delexicalizedVerbs = [ "geschienen", "meine", "meinst", "meint", "meinen", "meinest", "meinet", "meinte", "meintest", "meinten", "meintet",
+let delexicalizedVerbs = [ "geschienen", "meine", "meinst", "meint", "meinen", "meinest", "meinet", "meinte", "meintest", "meinten", "meintet",
 	"gemeint", "stehe", "stehst", "steht", "gehe", "gehst", "geht", "gegangen", "ging", "gingst", "gingen", "gingt" ];
 
-var delexicalizedVerbsInfinitive = [ "geschienen", "meinen", "tun", "machen", "stehen", "wissen", "gehen", "kommen" ];
+let delexicalizedVerbsInfinitive = [ "geschienen", "meinen", "tun", "machen", "stehen", "wissen", "gehen", "kommen" ];
 
 // These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
 // Keyword combinations containing these adjectives/adverbs are fine.
-var generalAdjectivesAdverbs = [ "einerlei", "egal", "neu", "neue", "neuer", "neuen", "neues", "neuem", "neuerer", "neueren", "neuerem", "neueres",
+let generalAdjectivesAdverbs = [ "einerlei", "egal", "neu", "neue", "neuer", "neuen", "neues", "neuem", "neuerer", "neueren", "neuerem", "neueres",
 	"neuere", "neuester", "neuster", "neuesten", "neusten", "neuestem", "neustem", "neuestes", "neustes", "neueste", "neuste", "alt",
 	"alter", "alten", "altem", "altes", "alte", "ältere", "älteren", "älterer", "älteres", "ältester", "ältesten", "ältestem", "ältestes",
 	"älteste", "aeltere", "aelteren", "aelterer", "aelteres", "aeltester", "aeltesten", "aeltestem", "aeltestes", "aelteste", "gut", "guter",
@@ -254,23 +254,23 @@ var generalAdjectivesAdverbs = [ "einerlei", "egal", "neu", "neue", "neuer", "ne
 	"vollsten", "vollstem", "vollste", "vollstes", "außen", "ganzer", "ganzen", "ganzem", "ganze", "ganzes", "gerne", "oben", "unten", "zurück",
 	"zurueck" ];
 
-var interjections = [  "ach", "aha", "oh", "au", "bäh", "baeh", "igitt", "huch", "hurra", "hoppla", "nanu", "oha", "olala", "pfui", "tja",
+let interjections = [  "ach", "aha", "oh", "au", "bäh", "baeh", "igitt", "huch", "hurra", "hoppla", "nanu", "oha", "olala", "pfui", "tja",
 	"uups", "wow", "grr", "äh", "aeh", "ähm", "aeh", "öhm", "oehm", "hm", "mei", "nun", "tja", "mhm", "okay", "richtig", "eijeijeijei" ];
 
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
-var recipeWords = [ "g", "el", "es", "tl", "wg", "be", "bd", "cl", "dl", "dag", "do", "gl", "gr", "kg", "kl", "cb", "ccm", "l", "ms", "mg",
+let recipeWords = [ "g", "el", "es", "tl", "wg", "be", "bd", "cl", "dl", "dag", "do", "gl", "gr", "kg", "kl", "cb", "ccm", "l", "ms", "mg",
 	"ml", "mi", "pk", "pr", "pp", "sc", "sp", "st", "sk", "ta", "tr", "cm", "mass" ];
 
-var timeWords = [ "sekunde", "sekunden", "minute", "minuten", "uhr", "uhren", "tag", "tages", "tags", "tage", "tagen", "woche", "wochen", "monat",
+let timeWords = [ "sekunde", "sekunden", "minute", "minuten", "uhr", "uhren", "tag", "tages", "tags", "tage", "tagen", "woche", "wochen", "monat",
 	"monate", "monats", "monaten", "jahr", "jahres", "jahrs", "jahre", "jahren" ];
 
-var vagueNouns = [ "ding", "dinge", "dinges", "dinger", "dingern", "dingen", "sache", "sachen", "weise", "weisen", "wahrscheinlichkeit",
+let vagueNouns = [ "ding", "dinge", "dinges", "dinger", "dingern", "dingen", "sache", "sachen", "weise", "weisen", "wahrscheinlichkeit",
 	"zeug", "zeuge", "zeuges", "zeugen", "mal", "einmal", "teil", "teile", "teiles", "teilen", "prozent", "prozents", "prozentes", "prozente",
 	"prozenten", "beispiel", "beispiele", "beispieles", "beispiels", "beispielen", "aspekt", "aspekte", "aspektes", "aspekts", "aspekten",
 	"idee", "ideen", "ahnung", "ahnungen", "thema", "themas", "themata", "themen", "fall", "falle", "falles", "falls", "fälle", "fällen",
 	"faelle", "faellen", "mensch", "menschen", "leute" ];
 
-var miscellaneous = [ "nix", "nixe", "nixes", "nixen", "usw.", "nicht", "amen", "ja", "nein", "euro", "prozent" ];
+let miscellaneous = [ "nix", "nixe", "nixes", "nixen", "usw.", "nicht", "amen", "ja", "nein", "euro", "prozent" ];
 
 module.exports = function() {
 	return {
@@ -286,7 +286,7 @@ module.exports = function() {
 		interrogativeProAdverbs: interrogativeProAdverbs,
 		transitionWords: transitionWords.concat( additionalTransitionWords ),
 		// These verbs that should be filtered at the beginning of prominent word combinations.
-		infinitives: otherAuxiliariesInfinitive.concat( infinitivePassiveAuxiliaries,
+		infinitives: otherAuxiliariesInfinitive.concat( passiveAuxiliariesInfinitive,
 			delexicalizedVerbsInfinitive, copulaInfinitive, interviewVerbsInfinitive ),
 		miscellaneous: miscellaneous,
 		interjections: interjections,
@@ -305,7 +305,7 @@ module.exports = function() {
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			reciprocalPronouns,	personalPronounsNominative,	personalPronounsAccusative, relativePronouns, quantifiers,
 			indefinitePronouns,	interrogativeProAdverbs, pronominalAdverbs, locativeAdverbs, adverbialGenitives,
-			filteredPassiveAuxiliaries,	infinitivePassiveAuxiliaries, otherAuxiliaries,
+			filteredPassiveAuxiliaries,	passiveAuxiliariesInfinitive, otherAuxiliaries,
 			otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive, transitionWords, additionalTransitionWords, intensifiers,
 			delexicalizedVerbs, delexicalizedVerbsInfinitive, interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous,

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -25,6 +25,8 @@ let personalPronounsNominative = [ "io", "tu", "egli", "esso", "lui", "ella", "e
 let personalPronounsAccusative = [ "mi", "ti", "lo", "si", "ci", "vi", "li", "me", "te", "se",
 	"glie", "glielo", "gliela", "glieli", "gliele", "gliene", "ce", "ve" ];
 
+let personalPronounsPrepositional = [ "sé" ];
+
 let demonstrativePronouns = [ "ciò", "codesto", "codesta", "codesti", "codeste", "colei", "colui", "coloro",
 	"costei", "costui", "costoro", "medesimo", "medesima", "medesimi", "medesime", "questo", "questa",
 	"questi", "queste", "quello", "quella", "quelli", "quelle", "quel", "quei", "quegli" ];
@@ -228,7 +230,7 @@ let miscellaneous = [ "sì", "no", "non", "€", "euro", "euros", "ecc.", "eccet
 module.exports = function() {
 	return {
 		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, possessivePronouns ),
+		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, possessivePronouns, personalPronounsPrepositional ),
 		prepositions: prepositions,
 		demonstrativePronouns: demonstrativePronouns,
 		conjunctions: coordinatingConjunctions.concat( subordinatingConjunctions, correlativeConjunctions ),
@@ -250,8 +252,8 @@ module.exports = function() {
 		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
 		generalAdjectivesAdverbsPreceding: generalAdjectivesAdverbsPreceding,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
-			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns,
-			interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers, interrogativeAdjectives,
+			personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional, quantifiers,
+			indefinitePronouns,	interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers, interrogativeAdjectives,
 			pronominalAdverbs, locativeAdverbs, filteredPassiveAuxiliaries, passiveAuxiliariesInfinitive,
 			otherAuxiliaries, otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive,

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -219,6 +219,8 @@ let delexicalizedVerbs = [ "hago", "haces", "hace", "hacemos", "hacéis", "hacen
 	"parezcamos", "parezcáis", "parezcan", "pareciera", "parecieras", "pareciéramos", "parecierais", "parecieran", "pareciese", "parecieses",
 	"pareciésemos", "parecieseis", "pareciesen", "pareciere", "parecieres", "pareciéremos", "pareciereis", "parecieren", "pareced", "parecido" ];
 
+let delexicalizedVerbsInfinitive = [ "hacer", "parecer" ];
+
 // These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
 // Keyword combinations containing these adjectives/adverbs are fine.
 let generalAdjectivesAdverbs = [ "ayer", "hoy", "mañana", "enfrente", "mal", "mejor", "peor", "más", "menos", "claro", "bueno", "nuevo",
@@ -265,7 +267,7 @@ module.exports = function() {
 		demonstrativePronouns: demonstrativePronouns,
 		conjunctions: coordinatingConjunctions.concat( subordinatingConjunctions, correlativeConjunctions ),
 		verbs: otherAuxiliaries.concat( copula, interviewVerbs, delexicalizedVerbs, otherAuxiliaries ),
-		infinitives: otherAuxiliariesInfinitive.concat( copulaInfinitive ),
+		infinitives: otherAuxiliariesInfinitive.concat( copulaInfinitive, delexicalizedVerbsInfinitive ),
 		quantifiers: quantifiers,
 		relativePronouns: interrogativeDeterminers.concat( interrogativePronouns, interrogativeProAdverbs ),
 		transitionWords: transitionWords.concat( additionalTransitionWords ),
@@ -283,7 +285,7 @@ module.exports = function() {
 			personalPronounsAccusative, quantifiers, indefinitePronouns, interrogativeDeterminers, interrogativePronouns,
 			interrogativeProAdverbs, locativeAdverbs, prepositionalAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, copula,
 			copulaInfinitive, prepositions,	coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
-			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, interjections, generalAdjectivesAdverbs,
-			recipeWords, vagueNouns, miscellaneous ),
+			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
+			interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous ),
 	};
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Add more function words categories for Spanish and Italian.

### General
Change `var` to `let` in English and German function words files.

### German
Change infinitivePassiveAuxiliaries to passiveAuxiliariesInfinitive

### Spanish
Add delexicalizedVerbsInfinitive

### Italian
Add personalPronounsPrepositional ('sé')


## Test instructions

This PR can be tested by following these steps:

* Use the browserified relevant words example.
* Set language to it_IT. 
* Write a sentence containing 'sé', and copy it multiple times.
* Make sure no word combinations starting or ending in 'sé' are included in the table.
* Set language to es_ES. 
* Write a sentence containing 'hacer' and/or 'parecer', and copy it multiple times.
* Make sure no word combinations ending in 'hacer'/'parecer' are included in the table.

Fixes #1184

*NB:* Branched from stories/MA/prominent-word-filters. Please merge #1179 first.