### PR TITLE
Tooltip multiline compat for Edge and better alignment.

### DIFF
--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -11,13 +11,13 @@ button.yoast-tooltip {
 	display: none;
 	position: absolute;
 	z-index: 1000000;
-	padding: 5px 8px;
+	padding: 6px 8px 5px;
 	border-radius: 3px;
 	opacity: 0;
 	color: #fff;
 	background: rgba(0,0,0,0.8);
 	text-shadow: none;
-	font: normal normal 11px/1.5 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	font: normal normal 11px/1.45454545 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	text-align: center;
 	white-space: pre;
 	text-decoration: none;
@@ -185,6 +185,9 @@ button.yoast-tooltip {
 }
 
 .yoast-tooltip-multiline::after {
+	/* Microsoft Edge doesn't support max-content. */
+	width: 999px;
+	/* Modern browsers. */
 	width: max-content;
 	max-width: 250px;
 	border-collapse: separate;

--- a/css/_tooltips.scss
+++ b/css/_tooltips.scss
@@ -186,7 +186,7 @@ button.yoast-tooltip {
 
 .yoast-tooltip-multiline::after {
 	/* Microsoft Edge doesn't support max-content. */
-	width: 999px;
+	width: 250px;
 	/* Modern browsers. */
 	width: max-content;
 	max-width: 250px;


### PR DESCRIPTION
Fixes the lack of support for`width: max-content` in Microsoft Edge. This means in this browser, the actual multiline tooltip width will be the same as `max-width`, while in modern browsers it is allowed to be _less_ than that.

Improves a bit the vertical alignment of the text. See before and after:

![ezgif-2-6ec6135fec](https://user-images.githubusercontent.com/1682452/28115038-9d4ce794-6703-11e7-860b-3d3cd9173498.gif)

Fixes #1183 
Fixes #1189 