### PR TITLE
Add plural ordinal numbers and time words

### DIFF
--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -142,6 +142,10 @@ let interjections = [ "oh", "wauw", "hèhè", "hè", "hé", "au", "ai", "jaja", 
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
 let recipeWords = [ "ml", "cl", "dl", "l", "tl", "el", "mg", "g", "gr", "kg", "ca", "theel", "min", "sec", "uur" ];
 
+let timeWords = [ "seconde", "secondes", "seconden", "minuut", "minuten", "uur", "uren", "dag", "dagen", "week", "weken",
+	"maand", "maanden", "jaar", "jaren", "vandaag", "morgen", "overmorgen", "gisteren", "eergisteren",
+	"'s", "morgens", "avonds", "middags", "nachts" ];
+
 let vagueNouns = [ "ding", "dingen", "manier", "manieren", "item", "items", "keer", "maal", "procent", "geval", "aspect", "persoon",
 	"personen", "deel" ];
 
@@ -181,6 +185,7 @@ module.exports = function() {
 		intensifiers: intensifiers,
 		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
 		recipeWords: recipeWords,
+		timeWords: timeWords,
 		vagueNouns: vagueNouns,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, reciprocalPronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns,

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -116,6 +116,9 @@ let interjections = [ "oh", "wow", "tut-tut", "tsk-tsk", "ugh", "whew", "phew", 
 let recipeWords = [ "tbs", "tbsp", "spk", "lb", "qt", "pk", "bu", "oz", "pt", "mod", "doz", "hr", "f.g", "ml", "dl", "cl",
 	"l", "mg", "g", "kg", "quart" ];
 
+let timeWords = [ "seconds", "minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "month", "months",
+	"year", "years", "today", "tomorrow", "yesterday" ];
+
 // 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
 let vagueNouns = [ "thing", "things", "way", "ways", "matter", "case", "likelihood", "ones", "piece", "pieces", "stuff", "times",
 	"part", "parts", "percent", "instance", "instances", "aspect", "aspects", "item", "items", "idea", "theme",
@@ -152,6 +155,7 @@ module.exports = function() {
 		intensifiers: intensifiers,
 		recipeWords: recipeWords,
 		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
+		timeWords: timeWords,
 		vagueNouns: vagueNouns,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns, continuousVerbs,

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -21,7 +21,7 @@ let personalPronounsAccusative = [ "me", "him", "us", "them" ];
 let demonstrativePronouns = [ "this", "that", "these", "those" ];
 let possessivePronouns = [ "my", "your", "his", "her", "its", "their", "our", "mine", "yours", "hers", "theirs", "ours" ];
 let quantifiers = [ "all", "some", "many", "lot", "lots", "ton", "tons", "bit", "no", "every", "enough", "little",
-	"much", "more", "most",	"plenty", "several", "few", "fewer", "kind" ];
+	"much", "more", "most", "plenty", "several", "few", "fewer", "kind" ];
 let reflexivePronouns = [ "myself", "yourself", "himself", "herself", "itself", "oneself", "ourselves", "yourselves", "themselves" ];
 let indefinitePronouns = [ "none", "nobody", "everyone", "everybody", "someone", "somebody", "anyone", "anybody", "nothing",
 	"everything", "something", "anything", "each", "other", "whatever", "whichever", "whoever", "whomever",

--- a/js/researches/french/functionWords.js
+++ b/js/researches/french/functionWords.js
@@ -12,9 +12,11 @@ let cardinalNumerals = [ "deux", "trois", "quatre", "cinq", "six", "sept", "huit
 	"quatre-vingt", "quatre-vingt-dix", "cent", "mille", "million", "milliard" ];
 
 // 'premier' and 'première' are not included because of their secondary meanings ('prime minister', '[movie] premiere')
-let ordinalNumerals = [ "deuxième", "troisième",
-	"quatrième", "cinquième", "sixième", "septième", "huitième", "neuvième", "dixième", "onzième", "douzième", "treizième",
-	"quatorzième", "quinzième", "seizième", "dix-septième", "dix-huitième", "dix-neuvième", "vingtième" ];
+let ordinalNumerals = [ "second", "secondes", "deuxième", "deuxièmes", "troisième", "troisièmes", "quatrième", "quatrièmes", "cinquième",
+	"cinquièmes", "sixième", "sixièmes", "septième", "septièmes", "huitième", "huitièmes", "neuvième", "neuvièmes",
+	"dixième", "dixièmes", "onzième", "onzièmes", "douzième", "douzièmes", "treizième", "treizièmes", "quatorzième",
+	"quatorzièmes", "quinzième", "quinzièmes", "seizième", "seizièmes", "dix-septième", "dix-septièmes", "dix-huitième",
+	"dix-huitièmes", "dix-neuvième", "dix-neuvièmes", "vingtième", "vingtièmes" ];
 
 let personalPronounsNominative = [ "je", "tu", "il", "elle", "on", "nous", "vous", "ils", "elles" ];
 
@@ -153,7 +155,7 @@ let interviewVerbsInfinitive = [ "dire", "penser", "demander", "concéder", "con
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
 let additionalTransitionWords = [ "encore", "éternellement", "immédiatement", "compris", "comprenant", "inclus", "naturellement", "particulièrement",
-	"notablement", "actuellement", "maintenant", "aujourd'hui", "ordinairement", "généralement", "habituellement", "d'habitude", "vraiment",
+	"notablement", "actuellement", "maintenant", "ordinairement", "généralement", "habituellement", "d'habitude", "vraiment",
 	"finalement", "uniquement",	"peut-être", "initialement", "déjà", "c.-à-d", "souvent", "fréquemment", "régulièrement", "simplement",
 	"éventuellement", "quelquefois", "parfois", "probable", "plausible", "jamais", "toujours", "incidemment", "accidentellement", "récemment",
 	"dernièrement", "relativement", "clairement", "évidemment", "apparemment", "pourvu" ];
@@ -203,8 +205,8 @@ let interjections = [ "ah", "ha", "oh", "ho", "bis", "plouf", "vlan", "ciel", "p
 let recipeWords = [ "mg", "g", "kg", "ml", "dl", "cl", "l", "grammes", "gram", "once", "onces", "oz", "lbs", "càc", "cc", "càd", "càs", "càt",
 	"cd", "cs", "ct" ];
 
-let timeWords = [ "seconde", "secondes", "minute", "minutes", "heure", "heures", "journée", "journées", "semaine", "semaines", "mois", "année",
-	"années" ];
+let timeWords = [ "minute", "minutes", "heure", "heures", "journée", "journées", "semaine", "semaines", "mois", "année",
+	"années", "aujourd'hui", "demain", "hier", "après-demain", "avant-hier" ];
 
 let vagueNouns = [ "chose", "choses", "façon", "façons", "pièce", "pièces", "truc", "trucs", "fois", "cas", "aspect", "aspects", "objet",
 	"objets", "idée", "idées", "thème", "thèmes", "sujet", "sujets", "personnes", "manière", "manières", "sorte", "sortes" ];

--- a/js/researches/french/functionWords.js
+++ b/js/researches/french/functionWords.js
@@ -54,7 +54,7 @@ let locativeAdverbs = [ "là", "ici", "voici" ];
 // 'Vins' is not included because it also means 'wines'.
 let otherAuxiliaries = [ "a", "a-t-elle", "a-t-il", "a-t-on", "ai", "ai-je", "aie", "as", "as-tu", "aura", "aurai", "auraient", "aurais", "aurait",
 	"auras", "aurez", "auriez", "aurons", "auront", "avaient", "avais", "avait", "avez", "avez-vous", "aviez", "avions", "avons", "avons-nous",
-	"ayez",	"ayons", "eu", "eûmes", "eurent", "eus", "eut", "eûtes", "j'ai", "j'aurai", "j'avais", "j'eus", "ont", "ont-elles", "ont-ils", "vais",
+	"ayez", "ayons", "eu", "eûmes", "eurent", "eus", "eut", "eûtes", "j'ai", "j'aurai", "j'avais", "j'eus", "ont", "ont-elles", "ont-ils", "vais",
 	"vas", "va", "allons", "allez", "vont", "vais-je", "vas-tu", "va-t-il", "va-t-elle", "va-t-on", "allons-nous", "allez-vous", "vont-elles",
 	"vont-ils", "allé", "allés", "j'allai", "allai", "allas", "alla", "allâmes", "allâtes", "allèrent", "j'allais", "allais", "allait", "allions",
 	"alliez", "allaient", "j'irai", "iras", "ira", "irons", "irez", "iront", "j'aille", "aille", "ailles", "aillent", "j'allasse", "allasse",
@@ -156,7 +156,7 @@ let interviewVerbsInfinitive = [ "dire", "penser", "demander", "concéder", "con
 // These transition words were not included in the list for the transition word assessment for various reasons.
 let additionalTransitionWords = [ "encore", "éternellement", "immédiatement", "compris", "comprenant", "inclus", "naturellement", "particulièrement",
 	"notablement", "actuellement", "maintenant", "ordinairement", "généralement", "habituellement", "d'habitude", "vraiment",
-	"finalement", "uniquement",	"peut-être", "initialement", "déjà", "c.-à-d", "souvent", "fréquemment", "régulièrement", "simplement",
+	"finalement", "uniquement", "peut-être", "initialement", "déjà", "c.-à-d", "souvent", "fréquemment", "régulièrement", "simplement",
 	"éventuellement", "quelquefois", "parfois", "probable", "plausible", "jamais", "toujours", "incidemment", "accidentellement", "récemment",
 	"dernièrement", "relativement", "clairement", "évidemment", "apparemment", "pourvu" ];
 

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -81,9 +81,8 @@ let adverbialGenitives = [ "allenfalls", "keinesfalls", "anderenfalls", "andernf
 	"äußerstenfalls", "bejahendenfalls", "bestenfalls", "eintretendenfalls", "entgegengesetztenfalls",
 	"erforderlichenfalls", "gegebenenfalls", "geringstenfalls", "gleichfalls", "günstigenfalls", "günstigstenfalls",
 	"höchstenfalls", "möglichenfalls", "notfalls", "nötigenfalls", "notwendigenfalls",
-	"schlimmstenfalls", "vorkommendenfalls", "zutreffendenfalls", "morgens", "mittags",
-	"abends", "nachts", "keineswegs", "durchwegs", "geradenwegs", "geradeswegs", "geradewegs", "gradenwegs",
-	"halbwegs", "mittwegs", "unterwegs" ];
+	"schlimmstenfalls", "vorkommendenfalls", "zutreffendenfalls", "keineswegs", "durchwegs", "geradenwegs", "geradeswegs",
+	"geradewegs", "gradenwegs",	"halbwegs", "mittwegs", "unterwegs" ];
 
 let otherAuxiliaries = [ "habe", "hast", "hat", "habt", "habest", "habet", "hatte", "hattest", "hatten", "hätte", "haette",
 	"hättest", "haettest", "hätten", "haetten", "haettet", "hättet", "hab", "bin", "bist", "ist", "sind", "sei", "seiest",
@@ -247,8 +246,10 @@ let interjections = [  "ach", "aha", "oh", "au", "bäh", "baeh", "igitt", "huch"
 let recipeWords = [ "g", "el", "tl", "wg", "be", "bd", "cl", "dl", "dag", "do", "gl", "gr", "kg", "kl", "cb", "ccm", "l", "ms", "mg",
 	"ml", "mi", "pk", "pr", "pp", "sc", "sp", "st", "sk", "ta", "tr", "cm", "mass" ];
 
-let timeWords = [ "sekunde", "sekunden", "minute", "minuten", "uhr", "uhren", "tag", "tages", "tags", "tage", "tagen", "woche", "wochen", "monat",
-	"monate", "monats", "monaten", "jahr", "jahres", "jahrs", "jahre", "jahren" ];
+let timeWords = [ "sekunde", "sekunden", "minute", "minuten", "stunde", "stunden", "uhr", "tag", "tages", "tags",
+	"tage", "tagen", "woche", "wochen", "monat", "monate", "monates", "monats", "monaten", "jahr", "jahres", "jahrs",
+	"jahre", "jahren", "morgens", "mittags", "abends", "nachts", "heute", "gestern", "morgen", "vorgestern", "übermorgen",
+	"uebermorgen" ];
 
 let vagueNouns = [ "ding", "dinge", "dinges", "dinger", "dingern", "dingen", "sache", "sachen", "weise", "weisen", "wahrscheinlichkeit",
 	"zeug", "zeuge", "zeuges", "zeugen", "mal", "einmal", "teil", "teile", "teiles", "teilen", "prozent", "prozents", "prozentes", "prozente",

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -82,7 +82,7 @@ let adverbialGenitives = [ "allenfalls", "keinesfalls", "anderenfalls", "andernf
 	"erforderlichenfalls", "gegebenenfalls", "geringstenfalls", "gleichfalls", "günstigenfalls", "günstigstenfalls",
 	"höchstenfalls", "möglichenfalls", "notfalls", "nötigenfalls", "notwendigenfalls",
 	"schlimmstenfalls", "vorkommendenfalls", "zutreffendenfalls", "keineswegs", "durchwegs", "geradenwegs", "geradeswegs",
-	"geradewegs", "gradenwegs",	"halbwegs", "mittwegs", "unterwegs" ];
+	"geradewegs", "gradenwegs", "halbwegs", "mittwegs", "unterwegs" ];
 
 let otherAuxiliaries = [ "habe", "hast", "hat", "habt", "habest", "habet", "hatte", "hattest", "hatten", "hätte", "haette",
 	"hättest", "haettest", "hätten", "haetten", "haettet", "hättet", "hab", "bin", "bist", "ist", "sind", "sei", "seiest",

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -12,10 +12,15 @@ let cardinalNumerals = [ "due", "tre", "quattro", "cinque", "sette", "otto", "no
 	"duemila", "tremila", "quattromila", "cinquemila", "seimila", "settemila", "ottomila", "novemila",
 	"diecimila", "milione", "milioni", "miliardo", "miliardi" ];
 
-let ordinalNumerals = [ "seconda", "terza", "quarto", "quarta", "quinto", "quinta", "sesto", "sesta", "settimo", "settima",
-	"ottavo", "ottava", "nono", "nona", "decimo", "decima", "undicesimo", "undicesima", "dodicesimo", "dodicesima",
-	"tredicesimo", "tredicesima", "quattordicesimo", "quattordicesima", "quindicesimo", "quindicesima",
-	"sedicesimo", "sedicesima", "diciassettesimo", "diciassettesima", "diciannovesimo", "diciannovesima", "ventesimo", "ventesima" ];
+let ordinalNumerals = [ "prima", "primi", "prime", "secondo", "seconda", "secondi", "seconde", "terzo", "terza",
+	"terzi", "terze", "quarto", "quarta", "quarti", "quarte", "quinto", "quinta", "quinti", "quinte", "sesto", "sesta",
+	"sesti", "seste", "settimo", "settima", "settimi", "settime", "ottavo", "ottava", "ottavi", "ottave", "nono", "nona",
+	"noni", "none", "decimo", "decima", "decimi", "decime", "undicesimo", "undicesima", "undicesimi", "undicesime",
+	"dodicesimo", "dodicesima", "dodicesimi", "dodicesime", "tredicesimo", "tredicesima", "tredicesimi", "tredicesime",
+	"quattordicesimo", "quattordicesima", "quattordicesimi", "quattordicesime", "quindicesimo", "quindicesima",
+	"quindicesimi", "quindicesime", "sedicesimo", "sedicesima", "sedicesimi", "sedicesime", "diciassettesimo",
+	"diciassettesima", "diciassettesimi", "diciassettesime", "diciannovesimo", "diciannovesima", "diciannovesimi",
+	"diciannovesime", "ventesimo", "ventesima", "ventesimi", "ventesime" ];
 
 let personalPronounsNominative = [ "io", "tu", "egli", "esso", "lui", "ella", "essa", "lei", "noi", "voi",
 	"essi", "esse", "loro" ];
@@ -202,7 +207,7 @@ let interjections = [ "accidenti", "acciderba", "ah", "aah", "ahi", "ahia", "ahi
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
 let recipeWords = [ "cc", "g", "hg", "hl", "kg", "l", "prs", "pz", "q.b.", "qb", "ta", "tz" ];
 
-let timeWords = [ "secondi", "minuto", "minuti", "ora", "ore", "giorno", "giorni", "giornata", "giornate",
+let timeWords = [ "minuto", "minuti", "ora", "ore", "giorno", "giorni", "giornata", "giornate",
 	"settimana", "settimane", "mese", "mesi", "anno", "anni", "oggi", "domani", "ieri", "stamattina", "stanotte",
 	"stasera", "tardi" ];
 

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -251,7 +251,7 @@ module.exports = function() {
 		vagueNouns: vagueNouns,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional, quantifiers,
-			indefinitePronouns,	interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers,
+			indefinitePronouns, interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers,
 			pronominalAdverbs, locativeAdverbs, filteredPassiveAuxiliaries, passiveAuxiliariesInfinitive,
 			otherAuxiliaries, otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive,

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -13,7 +13,7 @@ let cardinalNumerals = [ "dos", "tres", "cuatro", "cinco", "seis", "siete", "och
 	"millones" ];
 
 let ordinalNumerals = [ "primera", "segunda", "tercera", "cuarto", "cuarta", "quinto", "quinta", "sexto", "sexta",
-	"septimo", "septima", "octavo", "octava", "noveno",	"novena", "décimo", "décima", "vigésimo", "vigésima", "primeros",
+	"septimo", "septima", "octavo", "octava", "noveno", "novena", "décimo", "décima", "vigésimo", "vigésima", "primeros",
 	"primeras", "segundos", "segundas", "terceros", "terceras", "cuartos", "cuartas", "quintos", "quintas", "sextos",
 	"sextas", "septimos", "septimas", "octavos", "octavas", "novenos", "novenas", "décimos", "décimas", "vigésimos",
 	"vigésimas" ];
@@ -59,8 +59,8 @@ let otherAuxiliaries = [ "he", "has", "ha", "hay", "hemos", "habéis", "han", "h
 	"habremos", "habréis", "habrán", "haya", "hayas", "hayamos", "hayáis", "hayan", "hubiera", "hubieras", "hubiéramos", "hubierais",
 	"hubieran", "hubiese", "hubieses", "hubiésemos", "hubieseis", "hubiesen", "hubiere", "hubieres", "hubiéremos", "hubiereis", "hubieren",
 	"habed", "habido", "debo", "debes", "debe", "debemos", "debéis", "deben", "debí", "debiste", "debió", "debimos", "debisteis",
-	"debieron",	"debía", "debías", "debíamos", "debíais", "debían", "debería", "deberías", "deberíamos", "deberíais", "deberían", "deberé",
-	"deberás",	"deberá", "deberemos", "deberéis", "deberán", "deba", "debas", "debamos", "debáis", "deban", "debiera", "debieras", "debiéramos",
+	"debieron", "debía", "debías", "debíamos", "debíais", "debían", "debería", "deberías", "deberíamos", "deberíais", "deberían", "deberé",
+	"deberás", "deberá", "deberemos", "deberéis", "deberán", "deba", "debas", "debamos", "debáis", "deban", "debiera", "debieras", "debiéramos",
 	"debierais", "debieran", "debiese", "debieses", "debiésemos", "debieseis", "debiesen", "debiere", "debieres", "debiéremos", "debiereis",
 	"debieren", "debed", "debido", "empiezo", "empiezas", "empieza", "empezáis", "empiezan", "empecé", "empezaste", "empezó",
 	"empezamos", "empezasteis", "empezaron", "empezaba", "empezabas", "empezábamos", "empezabais", "empezaban", "empezaría", "empezarías",
@@ -91,10 +91,10 @@ let otherAuxiliaries = [ "he", "has", "ha", "hay", "hemos", "habéis", "han", "h
 	"quedarán", "quede", "quedes", "quedemos", "quedéis", "queden", "quedara", "quedaras", "quedáramos", "quedarais", "quedaran", "quedase",
 	"quedases", "quedásemos", "quedaseis", "quedasen", "quedare", "quedares", "quedáremos", "quedareis", "quedaren", "quedad", "quedado",
 	"hallo", "hallas", "halla", "hallamos", "halláis", "hallan", "hallé", "hallaste", "halló", "hallasteis", "hallaron", "hallaba",
-	"hallabas",	"hallábamos", "hallabais", "hallaban", "hallaría", "hallarías", "hallaríamos", "hallaríais", "hallarían", "hallaré", "hallarás",
+	"hallabas", "hallábamos", "hallabais", "hallaban", "hallaría", "hallarías", "hallaríamos", "hallaríais", "hallarían", "hallaré", "hallarás",
 	"hallará", "hallaremos", "hallaréis", "hallarán", "halle", "halles", "hallemos", "halléis", "hallen", "hallara", "hallaras", "halláramos",
 	"hallarais", "hallaran", "hallase", "hallases", "hallásemos", "hallaseis", "hallasen", "hallare", "hallares", "halláremos", "hallareis",
-	"hallaren",	"hallad", "hallado", "vengo", "vienes", "viene", "venimos", "venis", "vienen", "vine", "viniste", "vino", "vinimos",
+	"hallaren", "hallad", "hallado", "vengo", "vienes", "viene", "venimos", "venis", "vienen", "vine", "viniste", "vino", "vinimos",
 	"vinisteis", "vinieron", "venía", "vanías", "verníamos", "veníais", "venían", "vendría", "vendrías", "vendríamos", "vendíais", "vendrían",
 	"vendré", "vendrás", "vendrá", "vendremos", "vendréis", "vendrán", "venga", "vengas", "vengamos", "vengáis", "vengan", "viniera", "vinieras",
 	"viniéramos", "vinierais", "vinieran", "viniese", "vinieses", "viniésemos", "vinieseis", "viniesen", "viniere", "vinieres", "viniéremos",
@@ -147,10 +147,10 @@ let otherAuxiliaries = [ "he", "has", "ha", "hay", "hemos", "habéis", "han", "h
 	"supiéramos", "supierais", "supieran", "supiese", "supieses", "supiésemos", "supieseis", "supiesen", "supiere", "supieres", "supiéremos",
 	"supiereis", "supieren", "sabed", "sabido", "suelo", "sueles", "suele", "solemos", "soléis", "suelen", "solí", "soliste", "solió",
 	"solimos", "solisteis", "solieron", "solía", "solías", "solíamos", "solíais", "solían", "solería", "solerías", "soleríamos", "soleríais",
-	"solerían",	"soleré", "solerás", "solerá", "soleremos", "soleréis", "solerán", "suela", "suelas", "solamos", "soláis", "suelan", "soliera",
-	"solieras",	"soliéramos", "solierais", "solieran", "soliese", "solieses", "soliésemos", "solieseis", "soliesen", "soliere", "solieres",
+	"solerían", "soleré", "solerás", "solerá", "soleremos", "soleréis", "solerán", "suela", "suelas", "solamos", "soláis", "suelan", "soliera",
+	"solieras", "soliéramos", "solierais", "solieran", "soliese", "solieses", "soliésemos", "solieseis", "soliesen", "soliere", "solieres",
 	"soliéremos", "soliereis", "solieren", "soled", "solido", "necesito", "necesitas", "necesitamos", "necesitáis", "necesitan",
-	"necesité",	"necesitaste", "necesitó", "necesitasteis", "necesitaron", "necesitaba", "necesitabas", "necesitábamos", "necesitabais",
+	"necesité", "necesitaste", "necesitó", "necesitasteis", "necesitaron", "necesitaba", "necesitabas", "necesitábamos", "necesitabais",
 	"necesitaban", "necesitaría", "necesitarías", "necesitaríamos", "necesitaríais", "necesitarían", "necesitaré", "necesitarás", "necesitará",
 	"necesitaremos", "necesitaréis", "necesitarán", "necesite", "necesites", "necesitemos", "necesitéis", "necesiten", "necesitara",
 	"necesitaras", "necesitáramos", "necesitarais", "necesitaran", "necesitase", "necesitases", "necesitásemos", "necesitaseis", "necesitasen",
@@ -174,7 +174,7 @@ let copulaInfinitive = [ "estar", "ser" ];
 let prepositions = [ "a", "ante", "abajo", "adonde", "al", "allende", "alrededor", "amén", "antes", "arriba", "aun",
 	"bajo", "cabe", "cabo", "con", "contigo", "contra", "de", "dejante", "del", "dentro", "desde", "donde", "durante", "en",
 	"encima", "entre", "excepto", "fuera", "hacia", "hasta", "incluso", "mediante", "más", "opuesto", "par", "para", "próximo",
-	"salvo", "según", "sin",	"so", "sobre", "tras", "versus", "vía" ];
+	"salvo", "según", "sin", "so", "sobre", "tras", "versus", "vía" ];
 
 let prepositionalAdverbs = [ "cerca" ];
 
@@ -193,7 +193,7 @@ let interviewVerbs = [ "apunto", "apunta", "confieso", "confiesa", "confesaba", 
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
 let additionalTransitionWords = [ "básicamente", "esencialmente", "primeramente", "siempre", "nunca", "ahora",
-	"quizá", "acaso", "inclusive", "probablemente", "verdaderamente", "seguramente", "jamás", "obviamente",	"indiscutiblement",
+	"quizá", "acaso", "inclusive", "probablemente", "verdaderamente", "seguramente", "jamás", "obviamente", "indiscutiblement",
 	"inmediatamente", "previamente" ];
 
 let intensifiers = [ "muy", "tan", "completamente", "suficiente", "tal", "tales" ];
@@ -281,7 +281,7 @@ module.exports = function() {
 			personalPronounsNominative, personalPronounsComitative, personalPronounsPrepositional,
 			personalPronounsAccusative, quantifiers, indefinitePronouns, interrogativeDeterminers, interrogativePronouns,
 			interrogativeProAdverbs, locativeAdverbs, prepositionalAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, copula,
-			copulaInfinitive, prepositions,	coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
+			copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
 			interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous ),
 	};

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -12,9 +12,11 @@ let cardinalNumerals = [ "dos", "tres", "cuatro", "cinco", "seis", "siete", "och
 	"catorce", "quince", "dieciseis", "diecisiete", "dieciocho", "diecinueve", "veinte",  "cien", "centena", "mil", "millon",
 	"millones" ];
 
-let ordinalNumerals = [ "primera", "segunda", "tercera", "cuarto", "cuarta",
-	"quinto", "quinta", "sexto", "sexta", "septimo", "septima", "octavo", "octava", "noveno",
-	"novena", "décimo", "décima", "vigésimo", "vigésima" ];
+let ordinalNumerals = [ "primera", "segunda", "tercera", "cuarto", "cuarta", "quinto", "quinta", "sexto", "sexta",
+	"septimo", "septima", "octavo", "octava", "noveno",	"novena", "décimo", "décima", "vigésimo", "vigésima", "primeros",
+	"primeras", "segundos", "segundas", "terceros", "terceras", "cuartos", "cuartas", "quintos", "quintas", "sextos",
+	"sextas", "septimos", "septimas", "octavos", "octavas", "novenos", "novenas", "décimos", "décimas", "vigésimos",
+	"vigésimas" ];
 
 let personalPronounsNominative = [ "yo", "tú", "él", "ella", "ello", "nosotros", "nosotras", "vosotros", "vosotras",
 	"ustedes", "ellos", "ellas" ];
@@ -211,7 +213,7 @@ let delexicalizedVerbsInfinitive = [ "hacer", "parecer" ];
 
 // These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
 // Keyword combinations containing these adjectives/adverbs are fine.
-let generalAdjectivesAdverbs = [ "ayer", "hoy", "mañana", "enfrente", "mejor", "peor", "menos", "claro", "bueno", "nuevo",
+let generalAdjectivesAdverbs = [ "enfrente", "mejor", "peor", "menos", "claro", "bueno", "nuevo",
 	"nueva", "nuevos", "nuevas", "viejo", "viejos", "vieja", "viejas", "anterior", "grande", "gran", "grandes", "mayores", "fácil",
 	"fáciles", "rápido", "rápida", "rápidos", "rápidas", "lejos", "lejas", "difícil", "difíciles", "propio", "propios", "propia", "propias",
 	"largo", "larga", "largos", "largas", "bajos", "baja", "bajas", "alto", "alta", "altos", "altas", "regular", "regulares", "normal",
@@ -239,6 +241,9 @@ let interjections = [ "ah", "eh", "ejem", "ele", "achís", "adiós", "agur", "aj
 
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
 let recipeWords = [ "kg", "mg", "gr", "g", "km", "m", "l", "ml", "cl" ];
+
+let timeWords = [ "minuto", "minutos", "hora", "horas", "día", "días", "semana", "semanas", "mes", "meses", "año", "años",
+	"hoy", "mañana", "ayer" ];
 
 // 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
 let vagueNouns = [ "cosa", "cosas", "manera", "maneras", "caso", "casos", "pieza", "piezas", "vez", "veces", "parte", "partes", "porcentaje",
@@ -270,6 +275,7 @@ module.exports = function() {
 		prepositionalAdverbs: prepositionalAdverbs,
 		intensifiers: intensifiers,
 		recipeWords: recipeWords,
+		timeWords: timeWords,
 		vagueNouns: vagueNouns,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsComitative, personalPronounsPrepositional,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Adds plural ordinal numbers for Spanish, Italian, and French and time words for English, Dutch, and Spanish. Includes minor additions to time words in German and French.

Fixes #1186
Fixes #1168 