### PR TITLE
Add filter for one-character words

### DIFF
--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -354,5 +354,5 @@ module.exports = {
 	filterFunctionWords: filterFunctionWords,
 	filterFunctionWordsAnywhere: filterFunctionWordsAnywhere,
 	filterOnDensity: filterOnDensity,
-	filterOnWordLength: filterOneCharacterWords,
+	filterOneCharacterWords: filterOneCharacterWords,
 };

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -115,6 +115,18 @@ function sortCombinations( wordCombinations ) {
 }
 
 /**
+ * Filters word combinations that consist of a single one-character word.
+ *
+ * @param {WordCombination[]} wordCombinations The word combinations to filter.
+ * @returns {WordCombination[]} Filtered word combinations.
+ */
+function filterOneCharacterWords( wordCombinations ) {
+	return wordCombinations.filter( function( combination ) {
+		return ! ( combination.getLength() === 1 && combination.getWords()[ 0 ].length <= 1 );
+	} );
+}
+
+/**
  * Filters word combinations containing certain function words at any position.
  *
  * @param {WordCombination[]} wordCombinations The word combinations to filter.
@@ -197,6 +209,7 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
  */
 function filterCombinations( combinations, functionWords, locale ) {
 	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
+	combinations = filterOneCharacterWords( combinations );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().transitionWords );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().adverbialGenitives );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().personalPronouns );
@@ -341,4 +354,5 @@ module.exports = {
 	filterFunctionWords: filterFunctionWords,
 	filterFunctionWordsAnywhere: filterFunctionWordsAnywhere,
 	filterOnDensity: filterOnDensity,
+	filterOnWordLength: filterOneCharacterWords,
 };

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -120,7 +120,7 @@ function sortCombinations( wordCombinations ) {
  * @param {WordCombination[]} wordCombinations The word combinations to filter.
  * @returns {WordCombination[]} Filtered word combinations.
  */
-function filterOneCharacterWords( wordCombinations ) {
+function filterOneCharacterWordCombinations( wordCombinations ) {
 	return wordCombinations.filter( function( combination ) {
 		return ! ( combination.getLength() === 1 && combination.getWords()[ 0 ].length <= 1 );
 	} );
@@ -209,7 +209,7 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
  */
 function filterCombinations( combinations, functionWords, locale ) {
 	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
-	combinations = filterOneCharacterWords( combinations );
+	combinations = filterOneCharacterWordCombinations( combinations );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().transitionWords );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().adverbialGenitives );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().personalPronouns );
@@ -354,5 +354,5 @@ module.exports = {
 	filterFunctionWords: filterFunctionWords,
 	filterFunctionWordsAnywhere: filterFunctionWordsAnywhere,
 	filterOnDensity: filterOnDensity,
-	filterOneCharacterWords: filterOneCharacterWords,
+	filterOneCharacterWordCombinations: filterOneCharacterWordCombinations,
 };

--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -8,7 +8,7 @@ let sortCombinations = relevantWords.sortCombinations;
 let filterFunctionWordsAtBeginning = relevantWords.filterFunctionWordsAtBeginning;
 let filterFunctionWords = relevantWords.filterFunctionWords;
 let filterFunctionWordsAnywhere = relevantWords.filterFunctionWordsAnywhere;
-let filterOnSyllableCount = relevantWords.filterOnSyllableCount;
+let filterOneCharacterWords = relevantWords.filterOneCharacterWords;
 let filterOnDensity = relevantWords.filterOnDensity;
 let englishFunctionWords = require( "../../js/researches/english/functionWords.js" )().all;
 
@@ -259,6 +259,29 @@ describe( "filter special characters in word combinations", function() {
 		expect( combinations ).toEqual( expected );
 	});
 } );
+
+describe( "filter one-letter words in word combinations", function() {
+	it ( "filters word combinations containing one-letter words", function() {
+		let input = [
+			new WordCombination ( [ "C" ] ),
+			new WordCombination ( [ "C", "book" ] ),
+			new WordCombination ( [ "book", "C", "club"] ),
+			new WordCombination ( [ "book" ] ),
+			new WordCombination ( [ "book", "club"] )
+		];
+		let expected = [
+			new WordCombination ( [ "C", "book" ] ),
+			new WordCombination ( [ "book", "C", "club"] ),
+			new WordCombination ( [ "book" ] ),
+			new WordCombination ( [ "book", "club"] )
+		];
+
+		let combinations  = filterOneCharacterWords( input );
+
+		expect( combinations ).toEqual( expected );
+	});
+} );
+
 
 describe( "getRelevantWords", function() {
 	it( "uses the default (English) function words in case of a unknown locale", function() {

--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -8,7 +8,7 @@ let sortCombinations = relevantWords.sortCombinations;
 let filterFunctionWordsAtBeginning = relevantWords.filterFunctionWordsAtBeginning;
 let filterFunctionWords = relevantWords.filterFunctionWords;
 let filterFunctionWordsAnywhere = relevantWords.filterFunctionWordsAnywhere;
-let filterOneCharacterWords = relevantWords.filterOneCharacterWords;
+let filterOneCharacterWordCombinations = relevantWords.filterOneCharacterWordCombinations;
 let filterOnDensity = relevantWords.filterOnDensity;
 let englishFunctionWords = require( "../../js/researches/english/functionWords.js" )().all;
 
@@ -276,7 +276,7 @@ describe( "filter one-letter words in word combinations", function() {
 			new WordCombination ( [ "book", "club"] )
 		];
 
-		let combinations  = filterOneCharacterWords( input );
+		let combinations  = filterOneCharacterWordCombinations( input );
 
 		expect( combinations ).toEqual( expected );
 	});


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Adds a filter for word combinations that consist of a single one-character word.

## Test instructions

This PR can be tested by following these steps:

* Use the browserified relevant words example.
* Set language to one of the supported languages.
* Write a text containing words with a single letter.
* Make sure these single-letter words are not included in the table (except in combinations)

Fixes #1200 
