### PR TITLE
Add abbreviations for titles

### DIFF
--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -153,7 +153,7 @@ let miscellaneous = [ "wel", "ja", "neen", "oké", "oke", "okee", "ok", "zoiets"
 
 let titlesPreceding = [ "mevr", "dhr", "mr", "dr", "prof" ];
 
-let titlesFollowing = [ "jr", "sen" ];
+let titlesFollowing = [ "jr", "sr" ];
 
 /*
 Exports all function words concatenated, and specific word categories and category combinations

--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -151,6 +151,10 @@ let vagueNouns = [ "ding", "dingen", "manier", "manieren", "item", "items", "kee
 
 let miscellaneous = [ "wel", "ja", "neen", "oké", "oke", "okee", "ok", "zoiets", "€", "euro" ];
 
+let titlesPreceding = [ "mevr", "dhr", "mr", "dr", "prof" ];
+
+let titlesFollowing = [ "jr", "sen" ];
+
 /*
 Exports all function words concatenated, and specific word categories and category combinations
 to be used as filters for the prominent words.
@@ -187,6 +191,8 @@ module.exports = function() {
 		recipeWords: recipeWords,
 		timeWords: timeWords,
 		vagueNouns: vagueNouns,
+		titlesPreceding: titlesPreceding,
+		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, reciprocalPronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns,
 			indefinitePronounsPossessive, relativePronouns, interrogativeProAdverbs,
@@ -194,7 +200,7 @@ module.exports = function() {
 			otherAuxiliaries, otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions,
 			correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
-			interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous ),
+			interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing ),
 	};
 };
 

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -127,9 +127,9 @@ let vagueNouns = [ "thing", "things", "way", "ways", "matter", "case", "likeliho
 // 'No' is already included in the quantifier list.
 let miscellaneous = [ "not", "yes", "sure", "top", "bottom", "ok", "okay", "amen", "aka", "etc", "etcetera" ];
 
-let titlesPreceding = [ "ms", "mss", "mr", "dr", "prof" ];
+let titlesPreceding = [ "ms", "mss", "mrs", "mr", "dr", "prof" ];
 
-let titlesFollowing = [ "jr", "sen" ];
+let titlesFollowing = [ "jr", "sr" ];
 
 module.exports = function() {
 	return {

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -127,6 +127,10 @@ let vagueNouns = [ "thing", "things", "way", "ways", "matter", "case", "likeliho
 // 'No' is already included in the quantifier list.
 let miscellaneous = [ "not", "yes", "sure", "top", "bottom", "ok", "okay", "amen", "aka", "etc", "etcetera" ];
 
+let titlesPreceding = [ "ms", "mss", "mr", "dr", "prof" ];
+
+let titlesFollowing = [ "jr", "sen" ];
+
 module.exports = function() {
 	return {
 		articles: articles,
@@ -157,12 +161,14 @@ module.exports = function() {
 		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
 		timeWords: timeWords,
 		vagueNouns: vagueNouns,
+		titlesPreceding: titlesPreceding,
+		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns, continuousVerbs,
 			indefinitePronounsPossessive, interrogativeDeterminers, interrogativePronouns, interrogativeProAdverbs,
 			pronominalAdverbs, locativeAdverbs, adverbialGenitives, prepositionalAdverbs, filteredPassiveAuxiliaries, notFilteredPassiveAuxiliaries,
 			otherAuxiliaries, copula, prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, interjections, generalAdjectivesAdverbs,
-			recipeWords, vagueNouns, miscellaneous ),
+			recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing ),
 	};
 };

--- a/js/researches/french/functionWords.js
+++ b/js/researches/french/functionWords.js
@@ -213,9 +213,9 @@ let vagueNouns = [ "chose", "choses", "façon", "façons", "pièce", "pièces", 
 
 let miscellaneous = [ "ne", "oui", "d'accord", "amen", "euro", "euros", "etc" ];
 
-let titlesPreceding = [ "mme", "mmes", "mlle", "mlles", "mm" ];
+let titlesPreceding = [ "mme", "mmes", "mlle", "mlles", "mm", "dr", "pr" ];
 
-let titlesFollowing = [ "jr", "sen" ];
+let titlesFollowing = [ "jr", "sr" ];
 
 module.exports = function() {
 	return {

--- a/js/researches/french/functionWords.js
+++ b/js/researches/french/functionWords.js
@@ -213,6 +213,10 @@ let vagueNouns = [ "chose", "choses", "façon", "façons", "pièce", "pièces", 
 
 let miscellaneous = [ "ne", "oui", "d'accord", "amen", "euro", "euros", "etc" ];
 
+let titlesPreceding = [ "mme", "mmes", "mlle", "mlles", "mm" ];
+
+let titlesFollowing = [ "jr", "sen" ];
+
 module.exports = function() {
 	return {
 		articles: articles,
@@ -243,11 +247,14 @@ module.exports = function() {
 		recipeWords: recipeWords,
 		timeWords: timeWords,
 		vagueNouns: vagueNouns,
+		titlesPreceding: titlesPreceding,
+		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, relativePronouns, quantifiers, indefinitePronouns, interrogativeProAdverbs,
 			pronominalAdverbs, locativeAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, interrogativeAdjectives, copula, copulaInfinitive,
 			prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive, interjections,
-			generalAdjectivesAdverbs, generalAdjectivesAdverbsPreceding, recipeWords, vagueNouns, miscellaneous, timeWords ),
+			generalAdjectivesAdverbs, generalAdjectivesAdverbsPreceding, recipeWords, vagueNouns, miscellaneous, timeWords,
+			titlesPreceding, titlesFollowing ),
 	};
 };

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -259,6 +259,10 @@ let vagueNouns = [ "ding", "dinge", "dinges", "dinger", "dingern", "dingen", "sa
 
 let miscellaneous = [ "nix", "nixe", "nixes", "nixen", "usw.", "amen", "ja", "nein", "euro" ];
 
+let titlesPreceding = [ "fr", "hr", "dr", "prof" ];
+
+let titlesFollowing = [ "jr", "sen" ];
+
 module.exports = function() {
 	return {
 		articles: articles,
@@ -290,6 +294,8 @@ module.exports = function() {
 		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
 		timeWords: timeWords,
 		vagueNouns: vagueNouns,
+		titlesPreceding: titlesPreceding,
+		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			reciprocalPronouns, personalPronounsNominative, personalPronounsAccusative, quantifiers,
 			indefinitePronouns, interrogativeProAdverbs, pronominalAdverbs, locativeAdverbs, adverbialGenitives,
@@ -297,6 +303,6 @@ module.exports = function() {
 			otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive, transitionWords, additionalTransitionWords, intensifiers,
 			delexicalizedVerbs, delexicalizedVerbsInfinitive, interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous,
-			timeWords ),
+			timeWords, titlesPreceding, titlesFollowing ),
 	};
 };

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -261,7 +261,7 @@ let miscellaneous = [ "nix", "nixe", "nixes", "nixen", "usw.", "amen", "ja", "ne
 
 let titlesPreceding = [ "fr", "hr", "dr", "prof" ];
 
-let titlesFollowing = [ "jr", "sen" ];
+let titlesFollowing = [ "jr", "jun", "sen", "sr" ];
 
 module.exports = function() {
 	return {

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -217,7 +217,9 @@ let vagueNouns = [ "aspetto", "aspetti", "caso", "casi", "cose", "idea", "idee",
 
 let miscellaneous = [ "sì", "no", "non", "€", "euro", "euros", "ecc", "eccetera" ];
 
-let titlesPreceding = [ "sig.na", "sig.ra", "sig", "sigg", "dr", "dr.ssa", "dott", "dott.ssa" ];
+let titlesPreceding = [ "sig.na", "sig.ra", "sig", "sigg", "dr", "dr.ssa", "dott", "dott.ssa", "prof", "prof.ssa", "gent", "gent.mo",
+	"gent.mi", "gent.ma", "gent.me", "egr", "egr.i", "egr.ia", "egr.ie", "preg.mo", "preg.mo", "preg.ma", "preg.me", "ill", "ill.mo",
+	"ill.mi", "ill.ma", "ill.me", "cav", "on", "spett" ];
 
 /*
  Exports all function words concatenated, and specific word categories and category combinations

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -217,9 +217,7 @@ let vagueNouns = [ "aspetto", "aspetti", "caso", "casi", "cose", "idea", "idee",
 
 let miscellaneous = [ "sì", "no", "non", "€", "euro", "euros", "ecc", "eccetera" ];
 
-let titlesPreceding = [ "sig.na", "sig.ra", "sig", "sigg" ];
-
-let titlesFollowing = [ "jr", "sen" ];
+let titlesPreceding = [ "sig.na", "sig.ra", "sig", "sigg", "dr", "dr.ssa", "dott", "dott.ssa" ];
 
 /*
  Exports all function words concatenated, and specific word categories and category combinations
@@ -254,7 +252,6 @@ module.exports = function() {
 		generalAdjectivesAdverbsPreceding: generalAdjectivesAdverbsPreceding,
 		vagueNouns: vagueNouns,
 		titlesPreceding: titlesPreceding,
-		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional, quantifiers,
 			indefinitePronouns, interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers,
@@ -263,7 +260,7 @@ module.exports = function() {
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
 			interjections, generalAdjectivesAdverbs, generalAdjectivesAdverbsPreceding, recipeWords, vagueNouns, miscellaneous, timeWords,
-			titlesPreceding, titlesFollowing ),
+			titlesPreceding ),
 	};
 };
 

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -217,6 +217,10 @@ let vagueNouns = [ "aspetto", "aspetti", "caso", "casi", "cose", "idea", "idee",
 
 let miscellaneous = [ "sì", "no", "non", "€", "euro", "euros", "ecc", "eccetera" ];
 
+let titlesPreceding = [ "sig.na", "sig.ra", "sig", "sigg" ];
+
+let titlesFollowing = [ "jr", "sen" ];
+
 /*
  Exports all function words concatenated, and specific word categories and category combinations
  to be used as filters for the prominent words.
@@ -249,6 +253,8 @@ module.exports = function() {
 		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
 		generalAdjectivesAdverbsPreceding: generalAdjectivesAdverbsPreceding,
 		vagueNouns: vagueNouns,
+		titlesPreceding: titlesPreceding,
+		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional, quantifiers,
 			indefinitePronouns, interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers,
@@ -256,7 +262,8 @@ module.exports = function() {
 			otherAuxiliaries, otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 			subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
-			interjections, generalAdjectivesAdverbs, generalAdjectivesAdverbsPreceding, recipeWords, vagueNouns, miscellaneous, timeWords ),
+			interjections, generalAdjectivesAdverbs, generalAdjectivesAdverbsPreceding, recipeWords, vagueNouns, miscellaneous, timeWords,
+			titlesPreceding, titlesFollowing ),
 	};
 };
 

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -253,7 +253,7 @@ let miscellaneous = [ "no", "euros" ];
 
 let titlesPreceding = [ "sra", "sras", "srta", "sr", "sres", "dra", "dr", "profa", "prof" ];
 
-let titlesFollowing = [ "jr", "sen" ];
+let titlesFollowing = [ "jr", "sr" ];
 
 module.exports = function() {
 	return {

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -251,6 +251,10 @@ let vagueNouns = [ "cosa", "cosas", "manera", "maneras", "caso", "casos", "pieza
 
 let miscellaneous = [ "no", "euros" ];
 
+let titlesPreceding = [ "sra", "sras", "srta", "sr", "sres", "dra", "dr", "profa", "prof" ];
+
+let titlesFollowing = [ "jr", "sen" ];
+
 module.exports = function() {
 	return {
 		articles: articles,
@@ -277,12 +281,14 @@ module.exports = function() {
 		recipeWords: recipeWords,
 		timeWords: timeWords,
 		vagueNouns: vagueNouns,
+		titlesPreceding: titlesPreceding,
+		titlesFollowing: titlesFollowing,
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsComitative, personalPronounsPrepositional,
 			personalPronounsAccusative, quantifiers, indefinitePronouns, interrogativeDeterminers, interrogativePronouns,
 			interrogativeProAdverbs, locativeAdverbs, prepositionalAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, copula,
 			copulaInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
 			transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
-			interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous ),
+			interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing ),
 	};
 };

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -222,6 +222,8 @@ function filterCombinations( combinations, functionWords, locale ) {
 	combinations = filterFunctionWords( combinations, functionWords().intensifiers );
 	combinations = filterFunctionWords( combinations, functionWords().quantifiers );
 	combinations = filterFunctionWordsAtEnding( combinations, functionWords().ordinalNumerals );
+	combinations = filterFunctionWordsAtEnding( combinations, functionWords().titlesPreceding );
+	combinations = filterFunctionWordsAtBeginning( combinations, functionWords().titlesFollowing );
 	switch( getLanguage( locale ) ) {
 		case "en":
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().continuousVerbs );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Adds filters for titles such as 'Ms', 'jr' etc. for English, Dutch, German, French, Italian and Spanish.


## Test instructions

This PR can be tested by following these steps:

* Run `\grunt build:js\`.
* Use the browserified relevant words example.
* Set language to one of the supported languages.
* Write/paste a text with one of the added titles (e.g. 'Ms'/'Mr' English, 'Mevr'/'Dhr' for Dutch).
* Make sure no unexpected word combinations including these titles are included in the table.



Fixes #1199 
