### PR TITLE
Add English function words

### DIFF
--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -87,7 +87,7 @@ let prepositions = [ "à", "aan", "aangaande", "achter", "behalve", "behoudens",
 let prepositionalAdverbs = [ "af", "heen", "mee", "toe", "achterop", "onderin", "voorin", "bovenop",
 	"buitenop", "achteraan", "onderop", "binnenin", "tevoren" ];
 
-let coordinatingConjunctions = [ "en", "alsmede", "of", "ofwel" ];
+let coordinatingConjunctions = [ "en", "alsmede", "of", "ofwel", "en/of" ];
 
 /* 'Zowel' and 'als' are part of 'zowel...als', 'evenmin' is part of 'evenmin...als', 'zomin' is part of 'zomin...als',
  'hetzij' is part of 'hetzij...hetzij'. */

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -21,7 +21,7 @@ let personalPronounsAccusative = [ "me", "him", "us", "them" ];
 let demonstrativePronouns = [ "this", "that", "these", "those" ];
 let possessivePronouns = [ "my", "your", "his", "her", "its", "their", "our", "mine", "yours", "hers", "theirs", "ours" ];
 let quantifiers = [ "all", "some", "many", "lot", "lots", "ton", "tons", "bit", "no", "every", "enough", "little",
-	"much", "more", "most", "plenty", "several", "few", "fewer", "kind" ];
+	"much", "more", "most", "plenty", "several", "few", "fewer", "kind", "kinds" ];
 let reflexivePronouns = [ "myself", "yourself", "himself", "herself", "itself", "oneself", "ourselves", "yourselves", "themselves" ];
 let indefinitePronouns = [ "none", "nobody", "everyone", "everybody", "someone", "somebody", "anyone", "anybody", "nothing",
 	"everything", "something", "anything", "each", "other", "whatever", "whichever", "whoever", "whomever",
@@ -32,9 +32,8 @@ let indefinitePronounsPossessive  = [ "one's", "nobody's", "everyone's", "everyb
 
 let interrogativeDeterminers = [ "which", "what", "whose" ];
 let interrogativePronouns = [ "who", "whom" ];
-let interrogativeProAdverbs = [ "where", "how", "why", "whether", "wherever",
-	"whyever", "wheresoever", "whensoever", "howsoever", "whysoever",
-	"whatsoever", "whereso", "whomso", "whenso", "howso", "whyso", "whoso", "whatso" ];
+let interrogativeProAdverbs = [ "where", "how", "why", "whether", "wherever", "whyever", "wheresoever", "whensoever", "howsoever",
+	"whysoever", "whatsoever", "whereso", "whomso", "whenso", "howso", "whyso", "whoso", "whatso" ];
 let pronominalAdverbs = [ "therefor", "therein", "hereby", "hereto", "wherein", "therewith", "herewith", "wherewith", "thereby" ];
 let locativeAdverbs = [ "there", "here", "whither", "thither", "hither", "whence", "thence" ];
 let adverbialGenitives = [ "always", "once", "twice", "thrice" ];
@@ -44,9 +43,8 @@ let otherAuxiliaries = [ "can", "cannot", "can't", "could", "couldn't", "could'v
 	"would've", "may", "might", "must", "need", "needn't", "needs", "ought", "shall", "shalln't", "shan't", "should",
 	"shouldn't", "will", "won't", "i'll", "you'll", "he'll", "she'll", "it'll", "we'll", "they'll", "there's", "there're",
 	"there'll", "here's", "here're", "there'll" ];
-let copula = [ "appear", "appears", "appeared", "become", "becomes", "became", "come", "comes",
-	"came", "keep", "keeps", "kept", "remain", "remains", "remained", "stay",
-	"stays", "stayed", "turn", "turns", "turned" ];
+let copula = [ "appear", "appears", "appeared", "become", "becomes", "became", "come", "comes", "came", "keep", "keeps", "kept",
+	"remain", "remains", "remained", "stay", "stays", "stayed", "turn", "turns", "turned" ];
 
 // These verbs should only be included at the beginning of combinations.
 let continuousVerbs = [ "doing", "daring", "having", "appearing", "becoming", "coming", "keeping", "remaining", "staying",
@@ -57,16 +55,15 @@ let prepositions = [ "in", "from", "with", "under", "throughout", "atop", "for",
 	"above", "abreast", "absent", "across", "adjacent", "after", "against", "along", "alongside", "amid", "mid",
 	"among", "apropos", "apud", "around", "as", "astride", "at", "ontop", "afore", "tofore", "behind", "ahind",
 	"below", "ablow", "beneath", "neath", "beside", "between", "atween", "beyond", "ayond", "by", "chez",
-	"circa", "spite", "down", "except", "into", "less", "like", "minus", "near", "nearer",
-	"nearest", "anear", "notwithstanding", "off", "onto", "opposite", "out", "outen", "over", "past", "per", "pre", "qua",
-	"sans", "sauf", "sithence", "through", "thru", "truout", "toward", "underneath",
-	"up", "upon", "upside", "versus", "via", "vis-à-vis", "without", "ago", "apart", "aside", "aslant", "away", "withal",
-	"towards", "amidst", "amongst", "midst", "whilst" ];
+	"circa", "spite", "down", "except", "into", "less", "like", "minus", "near", "nearer", "nearest", "anear", "notwithstanding",
+	"off", "onto", "opposite", "out", "outen", "over", "past", "per", "pre", "qua", "sans", "sauf", "sithence", "through",
+	"thru", "truout", "toward", "underneath", "up", "upon", "upside", "versus", "via", "vis-à-vis", "without", "ago",
+	"apart", "aside", "aslant", "away", "withal", "towards", "amidst", "amongst", "midst", "whilst" ];
 
 // Many prepositional adverbs are already listed as preposition.
 let prepositionalAdverbs = [ "back", "within", "forward", "backward", "ahead" ];
 
-let coordinatingConjunctions = [ "and", "or", "yet" ];
+let coordinatingConjunctions = [ "and", "or", "and/or", "yet" ];
 
 // 'sooner' is part of 'no sooner...than', 'just' is part of 'just as...so',
 // 'Only' is part of 'not only...but also'.
@@ -75,11 +72,12 @@ let subordinatingConjunctions = [ "if", "even" ];
 
 // These verbs are frequently used in interviews to indicate questions and answers.
 // 'Claim','claims', 'state' and 'states' are not included, because these words are also nouns.
-let interviewVerbs = [ "say", "says", "said", "claimed", "ask", "asks", "asked", "stated",
-	"explain", "explains", "explained", "think", "thinks" ];
+let interviewVerbs = [ "say", "says", "said", "claimed", "ask", "asks", "asked", "stated", "explain", "explains", "explained",
+	"think", "thinks", "talks", "talked", "announces", "announced", "tells", "told", "discusses", "discussed", "suggests",
+	"suggested", "understands", "understood" ];
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
-let additionalTransitionWords = [ "again", "definitely", "eternally", "expressively",
+let additionalTransitionWords = [ "again", "definitely", "eternally", "expressively", "instead",
 	"expressly", "immediately", "including", "instantly", "namely", "naturally", "next", "notably", "now", "nowadays",
 	"ordinarily", "positively", "truly", "ultimately", "uniquely", "usually", "almost", "maybe",
 	"probably", "granted", "initially", "too", "actually", "already", "e.g", "i.e", "often", "regularly", "simply",
@@ -93,10 +91,10 @@ let intensifiers = [ "highly", "very", "really", "extremely", "absolutely", "com
  are not included, because these words could be relevant nouns.
 
  */
-let delexicalizedVerbs = [ "seem", "seems", "seemed", "let", "let's", "lets", "make", "makes",
-	"made", "want", "showed", "shown", "go", "goes", "went", "gone", "take", "takes", "took", "taken",
-	"put", "puts", "use", "used", "try", "tries", "tried", "mean", "means", "meant",
-	"called", "based", "add", "adds", "added", "contain", "contains", "contained" ];
+let delexicalizedVerbs = [ "seem", "seems", "seemed", "let", "let's", "lets", "make", "makes", "made", "want", "showed", "shown",
+	"go", "goes", "went", "gone", "take", "takes", "took", "taken",	"put", "puts", "use", "used", "try", "tries", "tried", "mean",
+	"means", "meant", "called", "based", "add", "adds", "added", "contain", "contains", "contained", "consist", "consists",
+	"consisted", "ensure", "ensures", "ensured" ];
 
 // These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
 // Keyword combinations containing these adjectives/adverbs are fine.
@@ -107,7 +105,9 @@ let generalAdjectivesAdverbs = [ "new", "newer", "newest", "old", "older", "olde
 	"short", "shorter", "shortest", "main", "actual", "nice", "nicer", "nicest", "real", "same", "able", "certain", "usual",
 	"so-called", "mainly", "mostly", "recent", "anymore", "complete", "lately", "possible", "commonly", "constantly",
 	"continually", "directly", "easily", "nearly", "slightly", "somewhere", "estimated", "latest", "different", "similar",
-	"widely", "bad", "worse", "worst", "great", "specific" ];
+	"widely", "bad", "worse", "worst", "great", "specific",  "available", "average", "awful", "awesome", "basic", "beautiful",
+	"busy", "current", "entire", "everywhere", "important", "major", "multiple", "normal", "necessary", "obvious", "partly",
+	"special", "last", "early", "earlier", "earliest", "young", "younger", "youngest", "" ];
 
 let interjections = [ "oh", "wow", "tut-tut", "tsk-tsk", "ugh", "whew", "phew", "yeah", "yea", "shh", "oops", "ouch", "aha",
 	"yikes" ];
@@ -121,11 +121,11 @@ let timeWords = [ "seconds", "minute", "minutes", "hour", "hours", "day", "days"
 
 // 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
 let vagueNouns = [ "thing", "things", "way", "ways", "matter", "case", "likelihood", "ones", "piece", "pieces", "stuff", "times",
-	"part", "parts", "percent", "instance", "instances", "aspect", "aspects", "item", "items", "idea", "theme",
-	"person" ];
+	"part", "parts", "percent", "instance", "instances", "aspect", "aspects", "item", "items", "idea", "theme", "person", "instance",
+	"instances", "detail", "details", "factor", "factors", "difference", "differences" ];
 
 // 'No' is already included in the quantifier list.
-let miscellaneous = [ "not", "yes", "sure", "top", "bottom", "ok", "okay", "amen", "aka", "etc", "etcetera" ];
+let miscellaneous = [ "not", "yes", "sure", "top", "bottom", "ok", "okay", "amen", "aka", "etc", "etcetera", "sorry", "please" ];
 
 let titlesPreceding = [ "ms", "mss", "mrs", "mr", "dr", "prof" ];
 

--- a/spec/researches/relevantWordsSpec.js
+++ b/spec/researches/relevantWordsSpec.js
@@ -1,17 +1,16 @@
-var relevantWordsResearch = require( "../../js/researches/relevantWords" );
-var Paper = require( "../../js/values/Paper" );
-var WordCombination = require( "../../js/values/WordCombination" );
-var functionWords = require( "../../js/researches/english/functionWords.js" )().all;
+let relevantWordsResearch = require( "../../js/researches/relevantWords" );
+let Paper = require( "../../js/values/Paper" );
+let WordCombination = require( "../../js/values/WordCombination" );
+let functionWords = require( "../../js/researches/english/functionWords.js" )().all;
 
 describe( "relevantWords research", function() {
 
 	it( "calls through to the string processing function", function() {
-		var input = "Here are a ton of syllables. Syllables are very important. I think the syllable combinations are even more important. Syllable combinations for the win!";
+		let input = "Here are a ton of syllables. Syllables are very important. I think the syllable combinations are even more important. Syllable combinations for the win!";
 		input = new Paper( input );
-		var expected = [
+		let expected = [
 			new WordCombination( [ "syllable", "combinations" ], 2, functionWords ),
 			new WordCombination( [ "syllables" ], 2, functionWords ),
-			new WordCombination( [ "important" ], 2, functionWords ),
 			new WordCombination( [ "syllable" ], 2, functionWords ),
 			new WordCombination( [ "combinations" ], 2, functionWords ),
 		];
@@ -19,7 +18,7 @@ describe( "relevantWords research", function() {
 		// Make sure our words aren't filtered by density.
 		spyOn( WordCombination.prototype, "getDensity" ).and.returnValue( 0.01 );
 
-		var words = relevantWordsResearch( input );
+		let words = relevantWordsResearch( input );
 
 		words.forEach( function( word ) {
 			delete( word._relevantWords );

--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -271,7 +271,6 @@ describe( "getRelevantWords", function() {
 			new WordCombination( [ "200", "words" ], 2, englishFunctionWords ),
 			new WordCombination( [ "200" ], 2, englishFunctionWords ),
 			new WordCombination( [ "syllables" ], 2, englishFunctionWords ),
-			new WordCombination( [ "important" ], 2, englishFunctionWords ),
 			new WordCombination( [ "syllable" ], 2, englishFunctionWords ),
 			new WordCombination( [ "combinations" ], 2, englishFunctionWords ),
 			new WordCombination( [ "text" ], 2, englishFunctionWords ),


### PR DESCRIPTION
## Summary

- Add more English transition words. See the issue for additions.
- Remove 'important' from tests, because that world will be filtered out from now on.
- Change `var` to `let`

Fixes #1092
