### PR TITLE
Fix maximum allowed statements eslint error in relevantWords.js

### DIFF
--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -163,23 +163,22 @@ to be used as filters for the prominent words.
 module.exports = function() {
 	return {
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtBeginning: passiveAuxiliariesInfinitive.concat( otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
+		filteredAtBeginning: [].concat( passiveAuxiliariesInfinitive, otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
 
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtEnding: ordinalNumerals.concat( generalAdjectivesAdverbs ),
+		filteredAtEnding: [].concat( ordinalNumerals, generalAdjectivesAdverbs ),
 
 		// These word categories are filtered at the beginning and ending of word combinations.
-		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, reflexivePronouns, interjections,
+		filteredAnywhere: [].concat( transitionWords, personalPronounsNominative, personalPronounsAccusative, reflexivePronouns, interjections,
 			cardinalNumerals, filteredPassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs, indefinitePronouns,
 			correlativeConjunctions, subordinatingConjunctions, interrogativeProAdverbs, relativePronouns, locativeAdverbs, miscellaneous,
 			prepositionalAdverbs, pronominalAdverbs, recipeWords, timeWords, vagueNouns, reciprocalPronouns, possessivePronouns ),
 
 		// This export contains all of the above words.
-
-		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, reciprocalPronouns,
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, reciprocalPronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns,
 			indefinitePronounsPossessive, relativePronouns, interrogativeProAdverbs,
 			pronominalAdverbs, locativeAdverbs, prepositionalAdverbs, filteredPassiveAuxiliaries, passiveAuxiliariesInfinitive,

--- a/js/researches/dutch/functionWords.js
+++ b/js/researches/dutch/functionWords.js
@@ -162,37 +162,23 @@ to be used as filters for the prominent words.
 
 module.exports = function() {
 	return {
-		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative ),
-		possessivePronouns: possessivePronouns,
-		prepositions: prepositions,
-		demonstrativePronouns: demonstrativePronouns,
-		coordinatingConjunctions: coordinatingConjunctions,
-		conjunctionsFilteredEverywhere: correlativeConjunctions.concat( subordinatingConjunctions ),
-		verbs: filteredPassiveAuxiliaries.concat( otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs ),
-		infinitives: passiveAuxiliariesInfinitive.concat( otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
-		quantifiers: quantifiers,
-		relativePronouns: relativePronouns,
-		interrogatives: interrogativeProAdverbs,
-		passiveAuxiliaries: filteredPassiveAuxiliaries,
-		transitionWords: transitionWords.concat( additionalTransitionWords ),
-		miscellaneous: miscellaneous,
-		pronominalAdverbs: pronominalAdverbs,
-		interjections: interjections,
-		reflexivePronouns: reflexivePronouns,
-		reciprocalPronouns: reciprocalPronouns,
-		cardinalNumerals: cardinalNumerals,
-		ordinalNumerals: ordinalNumerals,
-		indefinitePronouns: indefinitePronouns.concat( indefinitePronounsPossessive ),
-		locativeAdverbs: locativeAdverbs,
-		prepositionalAdverbs: prepositionalAdverbs,
-		intensifiers: intensifiers,
-		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
-		recipeWords: recipeWords,
-		timeWords: timeWords,
-		vagueNouns: vagueNouns,
-		titlesPreceding: titlesPreceding,
-		titlesFollowing: titlesFollowing,
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtBeginning: passiveAuxiliariesInfinitive.concat( otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
+
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: ordinalNumerals.concat( generalAdjectivesAdverbs ),
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, reflexivePronouns, interjections,
+			cardinalNumerals, filteredPassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs, indefinitePronouns,
+			correlativeConjunctions, subordinatingConjunctions, interrogativeProAdverbs, relativePronouns, locativeAdverbs, miscellaneous,
+			prepositionalAdverbs, pronominalAdverbs, recipeWords, timeWords, vagueNouns, reciprocalPronouns, possessivePronouns ),
+
+		// This export contains all of the above words.
+
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns, reciprocalPronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns,
 			indefinitePronounsPossessive, relativePronouns, interrogativeProAdverbs,

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -134,21 +134,21 @@ let titlesFollowing = [ "jr", "sr" ];
 module.exports = function() {
 	return {
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtEnding: ordinalNumerals.concat( continuousVerbs, generalAdjectivesAdverbs ),
+		filteredAtEnding: [].concat( ordinalNumerals, continuousVerbs, generalAdjectivesAdverbs ),
 
 		// These word categories are filtered at the beginning and ending of word combinations.
-		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
 			quantifiers, possessivePronouns ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: transitionWords.concat( adverbialGenitives, personalPronounsNominative, personalPronounsAccusative,
+		filteredAnywhere: [].concat( transitionWords, adverbialGenitives, personalPronounsNominative, personalPronounsAccusative,
 			reflexivePronouns, interjections, cardinalNumerals, filteredPassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs,
 			delexicalizedVerbs, indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeDeterminers,
 			interrogativePronouns, interrogativeProAdverbs, locativeAdverbs, miscellaneous, prepositionalAdverbs, pronominalAdverbs,
 			recipeWords, timeWords, vagueNouns ),
 
 		// This export contains all of the above words.
-		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns, continuousVerbs,
 			indefinitePronounsPossessive, interrogativeDeterminers, interrogativePronouns, interrogativeProAdverbs,
 			pronominalAdverbs, locativeAdverbs, adverbialGenitives, prepositionalAdverbs, filteredPassiveAuxiliaries, notFilteredPassiveAuxiliaries,

--- a/js/researches/english/functionWords.js
+++ b/js/researches/english/functionWords.js
@@ -133,36 +133,21 @@ let titlesFollowing = [ "jr", "sr" ];
 
 module.exports = function() {
 	return {
-		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative ),
-		possessivePronouns: possessivePronouns,
-		prepositions: prepositions,
-		demonstrativePronouns: demonstrativePronouns,
-		coordinatingConjunctions: coordinatingConjunctions,
-		conjunctionsFilteredEverywhere: correlativeConjunctions.concat( subordinatingConjunctions ),
-		verbs: filteredPassiveAuxiliaries.concat( otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs ),
-		continuousVerbs: notFilteredPassiveAuxiliaries.concat( continuousVerbs ),
-		quantifiers: quantifiers,
-		interrogatives: interrogativeDeterminers.concat( interrogativePronouns, interrogativeProAdverbs ),
-		passiveAuxiliaries: filteredPassiveAuxiliaries,
-		transitionWords: transitionWords.concat( additionalTransitionWords ),
-		miscellaneous: miscellaneous,
-		pronominalAdverbs: pronominalAdverbs,
-		interjections: interjections,
-		reflexivePronouns: reflexivePronouns,
-		cardinalNumerals: cardinalNumerals,
-		ordinalNumerals: ordinalNumerals,
-		indefinitePronouns: indefinitePronouns.concat( indefinitePronounsPossessive ),
-		locativeAdverbs: locativeAdverbs,
-		adverbialGenitives: adverbialGenitives,
-		prepositionalAdverbs: prepositionalAdverbs,
-		intensifiers: intensifiers,
-		recipeWords: recipeWords,
-		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
-		timeWords: timeWords,
-		vagueNouns: vagueNouns,
-		titlesPreceding: titlesPreceding,
-		titlesFollowing: titlesFollowing,
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: ordinalNumerals.concat( continuousVerbs, generalAdjectivesAdverbs ),
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+			quantifiers, possessivePronouns ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: transitionWords.concat( adverbialGenitives, personalPronounsNominative, personalPronounsAccusative,
+			reflexivePronouns, interjections, cardinalNumerals, filteredPassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs,
+			delexicalizedVerbs, indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeDeterminers,
+			interrogativePronouns, interrogativeProAdverbs, locativeAdverbs, miscellaneous, prepositionalAdverbs, pronominalAdverbs,
+			recipeWords, timeWords, vagueNouns ),
+
+		// This export contains all of the above words.
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, quantifiers, indefinitePronouns, continuousVerbs,
 			indefinitePronounsPossessive, interrogativeDeterminers, interrogativePronouns, interrogativeProAdverbs,

--- a/js/researches/french/functionWords.js
+++ b/js/researches/french/functionWords.js
@@ -219,36 +219,24 @@ let titlesFollowing = [ "jr", "sr" ];
 
 module.exports = function() {
 	return {
-		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, personalPronounsStressed ),
-		possessivePronouns: possessivePronouns,
-		prepositions: prepositions,
-		demonstrativePronouns: demonstrativePronouns,
-		coordinatingConjunctions: coordinatingConjunctions,
-		conjunctionsFilteredEverywhere: correlativeConjunctions.concat( subordinatingConjunctions ),
-		verbs: copula.concat( interviewVerbs, otherAuxiliaries, delexicalizedVerbs ),
-		quantifiers: quantifiers,
-		relativePronouns: relativePronouns,
-		interrogatives: interrogativeProAdverbs.concat( interrogativeAdjectives ),
-		transitionWords: transitionWords.concat( additionalTransitionWords ),
-		// These verbs that should be filtered at the beginning of prominent word combinations.
-		infinitives: otherAuxiliariesInfinitive.concat( delexicalizedVerbsInfinitive, copulaInfinitive, interviewVerbsInfinitive ),
-		miscellaneous: miscellaneous,
-		interjections: interjections,
-		pronominalAdverbs: pronominalAdverbs,
-		reflexivePronouns: reflexivePronouns,
-		cardinalNumerals: cardinalNumerals,
-		ordinalNumerals: ordinalNumerals,
-		indefinitePronouns: indefinitePronouns,
-		locativeAdverbs: locativeAdverbs,
-		intensifiers: intensifiers,
-		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
-		generalAdjectivesAdverbsPreceding: generalAdjectivesAdverbsPreceding,
-		recipeWords: recipeWords,
-		timeWords: timeWords,
-		vagueNouns: vagueNouns,
-		titlesPreceding: titlesPreceding,
-		titlesFollowing: titlesFollowing,
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: ordinalNumerals.concat( otherAuxiliariesInfinitive, delexicalizedVerbsInfinitive, copulaInfinitive,
+			interviewVerbsInfinitive, generalAdjectivesAdverbsPreceding ),
+
+		// These word categories are filtered at the beginning of word combinations.
+		filteredAtBeginning: generalAdjectivesAdverbs,
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+			quantifiers, possessivePronouns ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, personalPronounsStressed,
+			reflexivePronouns, interjections, cardinalNumerals, copula, interviewVerbs, otherAuxiliaries, delexicalizedVerbs,
+			indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeAdjectives, relativePronouns,
+			locativeAdverbs, miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns ),
+
+		// This export contains all of the above words.
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, relativePronouns, quantifiers, indefinitePronouns, interrogativeProAdverbs,
 			pronominalAdverbs, locativeAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, interrogativeAdjectives, copula, copulaInfinitive,

--- a/js/researches/french/functionWords.js
+++ b/js/researches/french/functionWords.js
@@ -220,24 +220,24 @@ let titlesFollowing = [ "jr", "sr" ];
 module.exports = function() {
 	return {
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtEnding: ordinalNumerals.concat( otherAuxiliariesInfinitive, delexicalizedVerbsInfinitive, copulaInfinitive,
+		filteredAtEnding: [].concat( ordinalNumerals, otherAuxiliariesInfinitive, delexicalizedVerbsInfinitive, copulaInfinitive,
 			interviewVerbsInfinitive, generalAdjectivesAdverbsPreceding ),
 
 		// These word categories are filtered at the beginning of word combinations.
 		filteredAtBeginning: generalAdjectivesAdverbs,
 
 		// These word categories are filtered at the beginning and ending of word combinations.
-		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
 			quantifiers, possessivePronouns ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, personalPronounsStressed,
+		filteredAnywhere: [].concat( transitionWords, personalPronounsNominative, personalPronounsAccusative, personalPronounsStressed,
 			reflexivePronouns, interjections, cardinalNumerals, copula, interviewVerbs, otherAuxiliaries, delexicalizedVerbs,
 			indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeAdjectives, relativePronouns,
 			locativeAdverbs, miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns ),
 
 		// This export contains all of the above words.
-		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, relativePronouns, quantifiers, indefinitePronouns, interrogativeProAdverbs,
 			pronominalAdverbs, locativeAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, interrogativeAdjectives, copula, copulaInfinitive,
 			prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs, interviewVerbsInfinitive,

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -266,23 +266,23 @@ let titlesFollowing = [ "jr", "jun", "sen", "sr" ];
 module.exports = function() {
 	return {
 		// These word categories are filtered at the beginning of word combinations.
-		filteredAtBeginning: otherAuxiliariesInfinitive.concat( passiveAuxiliariesInfinitive, delexicalizedVerbsInfinitive,
+		filteredAtBeginning: [].concat( otherAuxiliariesInfinitive, passiveAuxiliariesInfinitive, delexicalizedVerbsInfinitive,
 		copulaInfinitive, interviewVerbsInfinitive ),
 
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtEnding: ordinalNumerals.concat( generalAdjectivesAdverbs ),
+		filteredAtEnding: [].concat( ordinalNumerals, generalAdjectivesAdverbs ),
 
 		// These word categories are filtered at the beginning and ending of word combinations.
-		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: transitionWords.concat( adverbialGenitives, personalPronounsNominative, personalPronounsAccusative, personalPronounsDative,
+		filteredAnywhere: [].concat( transitionWords, adverbialGenitives, personalPronounsNominative, personalPronounsAccusative, personalPronounsDative,
 			reflexivePronouns, interjections, cardinalNumerals, copula, interviewVerbs, otherAuxiliaries, filteredPassiveAuxiliaries,
 			delexicalizedVerbs, indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeProAdverbs, locativeAdverbs,
 			miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns, reciprocalPronouns, possessivePronouns ),
 
 		// This export contains all of the above words.
-		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			reciprocalPronouns, personalPronounsNominative, personalPronounsAccusative, quantifiers,
 			indefinitePronouns, interrogativeProAdverbs, pronominalAdverbs, locativeAdverbs, adverbialGenitives,
 			filteredPassiveAuxiliaries, passiveAuxiliariesInfinitive, otherAuxiliaries,

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -265,37 +265,23 @@ let titlesFollowing = [ "jr", "jun", "sen", "sr" ];
 
 module.exports = function() {
 	return {
-		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, personalPronounsDative ),
-		possessivePronouns: possessivePronouns,
-		prepositions: prepositions,
-		demonstrativePronouns: demonstrativePronouns,
-		coordinatingConjunctions: coordinatingConjunctions,
-		conjunctionsFilteredEverywhere: correlativeConjunctions.concat( subordinatingConjunctions ),
-		verbs: copula.concat( interviewVerbs, otherAuxiliaries, filteredPassiveAuxiliaries, delexicalizedVerbs ),
-		quantifiers: quantifiers,
-		interrogatives: interrogativeProAdverbs,
-		transitionWords: transitionWords.concat( additionalTransitionWords ),
-		// These verbs that should be filtered at the beginning of prominent word combinations.
-		infinitives: otherAuxiliariesInfinitive.concat( passiveAuxiliariesInfinitive, delexicalizedVerbsInfinitive,
-			copulaInfinitive, interviewVerbsInfinitive ),
-		miscellaneous: miscellaneous,
-		interjections: interjections,
-		pronominalAdverbs: pronominalAdverbs,
-		reflexivePronouns: reflexivePronouns,
-		reciprocalPronouns: reciprocalPronouns,
-		cardinalNumerals: cardinalNumerals,
-		ordinalNumerals: ordinalNumerals,
-		indefinitePronouns: indefinitePronouns,
-		locativeAdverbs: locativeAdverbs,
-		adverbialGenitives: adverbialGenitives,
-		intensifiers: intensifiers,
-		recipeWords: recipeWords,
-		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
-		timeWords: timeWords,
-		vagueNouns: vagueNouns,
-		titlesPreceding: titlesPreceding,
-		titlesFollowing: titlesFollowing,
+		// These word categories are filtered at the beginning of word combinations.
+		filteredAtBeginning: otherAuxiliariesInfinitive.concat( passiveAuxiliariesInfinitive, delexicalizedVerbsInfinitive,
+		copulaInfinitive, interviewVerbsInfinitive ),
+
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: ordinalNumerals.concat( generalAdjectivesAdverbs ),
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: transitionWords.concat( adverbialGenitives, personalPronounsNominative, personalPronounsAccusative, personalPronounsDative,
+			reflexivePronouns, interjections, cardinalNumerals, copula, interviewVerbs, otherAuxiliaries, filteredPassiveAuxiliaries,
+			delexicalizedVerbs, indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeProAdverbs, locativeAdverbs,
+			miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns, reciprocalPronouns, possessivePronouns ),
+
+		// This export contains all of the above words.
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,
 			reciprocalPronouns, personalPronounsNominative, personalPronounsAccusative, quantifiers,
 			indefinitePronouns, interrogativeProAdverbs, pronominalAdverbs, locativeAdverbs, adverbialGenitives,

--- a/js/researches/german/functionWords.js
+++ b/js/researches/german/functionWords.js
@@ -276,10 +276,11 @@ module.exports = function() {
 		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: [].concat( transitionWords, adverbialGenitives, personalPronounsNominative, personalPronounsAccusative, personalPronounsDative,
-			reflexivePronouns, interjections, cardinalNumerals, copula, interviewVerbs, otherAuxiliaries, filteredPassiveAuxiliaries,
-			delexicalizedVerbs, indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeProAdverbs, locativeAdverbs,
-			miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns, reciprocalPronouns, possessivePronouns ),
+		filteredAnywhere: [].concat( transitionWords, adverbialGenitives, personalPronounsNominative, personalPronounsAccusative,
+			personalPronounsDative,	reflexivePronouns, interjections, cardinalNumerals, copula, interviewVerbs, otherAuxiliaries,
+			filteredPassiveAuxiliaries, delexicalizedVerbs, indefinitePronouns, correlativeConjunctions, subordinatingConjunctions,
+			interrogativeProAdverbs, locativeAdverbs, miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns,
+			reciprocalPronouns, possessivePronouns ),
 
 		// This export contains all of the above words.
 		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns, reflexivePronouns,

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -228,32 +228,24 @@ let titlesPreceding = [ "sig.na", "sig.ra", "sig", "sigg", "dr", "dr.ssa", "dott
 
 module.exports = function() {
 	return {
-		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, personalPronounsPrepositional ),
-		possessivePronouns: possessivePronouns,
-		prepositions: prepositions,
-		demonstrativePronouns: demonstrativePronouns,
-		coordinatingConjunctions: coordinatingConjunctions,
-		conjunctionsFilteredEverywhere: correlativeConjunctions.concat( subordinatingConjunctions ),
-		verbs: filteredPassiveAuxiliaries.concat( otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs ),
-		quantifiers: quantifiers,
-		interrogatives: interrogativeDeterminers.concat( interrogativePronouns, interrogativeAdverbs ),
-		transitionWords: transitionWords.concat( additionalTransitionWords ),
-		miscellaneous: miscellaneous,
-		pronominalAdverbs: pronominalAdverbs,
-		interjections: interjections,
-		infinitives: interviewVerbsInfinitive.concat( passiveAuxiliariesInfinitive, otherAuxiliariesInfinitive, copulaInfinitive,
-			delexicalizedVerbsInfinitive ),
-		cardinalNumerals: cardinalNumerals,
-		ordinalNumerals: ordinalNumerals,
-		indefinitePronouns: indefinitePronouns,
-		locativeAdverbs: locativeAdverbs,
-		intensifiers: intensifiers,
-		recipeWords: recipeWords,
-		generalAdjectivesAdverbs: generalAdjectivesAdverbs,
-		generalAdjectivesAdverbsPreceding: generalAdjectivesAdverbsPreceding,
-		vagueNouns: vagueNouns,
-		titlesPreceding: titlesPreceding,
+		// These word categories are filtered at the beginning of word combinations.
+		filteredAtBeginning: generalAdjectivesAdverbs,
+
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: ordinalNumerals.concat( interviewVerbsInfinitive, passiveAuxiliariesInfinitive, otherAuxiliariesInfinitive,
+			copulaInfinitive, delexicalizedVerbsInfinitive, generalAdjectivesAdverbsPreceding ),
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers,
+			possessivePronouns ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional,
+			interjections, cardinalNumerals, filteredPassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs,
+			indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeDeterminers, interrogativePronouns,
+			interrogativeAdverbs, locativeAdverbs, miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns ),
+
+		// This export contains all of the above words.
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional, quantifiers,
 			indefinitePronouns, interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers,

--- a/js/researches/italian/functionWords.js
+++ b/js/researches/italian/functionWords.js
@@ -232,21 +232,21 @@ module.exports = function() {
 		filteredAtBeginning: generalAdjectivesAdverbs,
 
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtEnding: ordinalNumerals.concat( interviewVerbsInfinitive, passiveAuxiliariesInfinitive, otherAuxiliariesInfinitive,
+		filteredAtEnding: [].concat( ordinalNumerals, interviewVerbsInfinitive, passiveAuxiliariesInfinitive, otherAuxiliariesInfinitive,
 			copulaInfinitive, delexicalizedVerbsInfinitive, generalAdjectivesAdverbsPreceding ),
 
 		// These word categories are filtered at the beginning and ending of word combinations.
-		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers,
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers, quantifiers,
 			possessivePronouns ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional,
+		filteredAnywhere: [].concat( transitionWords, personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional,
 			interjections, cardinalNumerals, filteredPassiveAuxiliaries, otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs,
 			indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeDeterminers, interrogativePronouns,
 			interrogativeAdverbs, locativeAdverbs, miscellaneous, pronominalAdverbs, recipeWords, timeWords, vagueNouns ),
 
 		// This export contains all of the above words.
-		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional, quantifiers,
 			indefinitePronouns, interrogativePronouns, interrogativeAdverbs, interrogativeDeterminers,
 			pronominalAdverbs, locativeAdverbs, filteredPassiveAuxiliaries, passiveAuxiliariesInfinitive,

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -262,20 +262,20 @@ module.exports = function() {
 		filteredAtBeginning: generalAdjectivesAdverbs,
 
 		// These word categories are filtered at the ending of word combinations.
-		filteredAtEnding: ordinalNumerals.concat( otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
+		filteredAtEnding: [].concat( ordinalNumerals, otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
 
 		// These word categories are filtered at the beginning and ending of word combinations.
-		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
 			quantifiers, possessivePronouns ),
 
 		// These word categories are filtered everywhere within word combinations.
-		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional,
+		filteredAnywhere: [].concat( transitionWords, personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional,
 			personalPronounsComitative, interjections, cardinalNumerals, otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs,
 			indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeDeterminers, interrogativePronouns,
 			interrogativeProAdverbs, locativeAdverbs, miscellaneous, prepositionalAdverbs, recipeWords, timeWords, vagueNouns ),
 
 		// This export contains all of the above words.
-		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsComitative, personalPronounsPrepositional,
 			personalPronounsAccusative, quantifiers, indefinitePronouns, interrogativeDeterminers, interrogativePronouns,
 			interrogativeProAdverbs, locativeAdverbs, prepositionalAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, copula,

--- a/js/researches/spanish/functionWords.js
+++ b/js/researches/spanish/functionWords.js
@@ -257,32 +257,24 @@ let titlesFollowing = [ "jr", "sr" ];
 
 module.exports = function() {
 	return {
-		articles: articles,
-		personalPronouns: personalPronounsNominative.concat( personalPronounsAccusative, personalPronounsPrepositional,
-			personalPronounsComitative ),
-		possessivePronouns: possessivePronouns,
-		prepositions: prepositions,
-		demonstrativePronouns: demonstrativePronouns,
-		coordinatingConjunctions: coordinatingConjunctions,
-		conjunctionsFilteredEverywhere: correlativeConjunctions.concat( subordinatingConjunctions ),
-		verbs: otherAuxiliaries.concat( copula, interviewVerbs, delexicalizedVerbs ),
-		infinitives: otherAuxiliariesInfinitive.concat( copulaInfinitive, delexicalizedVerbsInfinitive ),
-		quantifiers: quantifiers,
-		interrogatives: interrogativeDeterminers.concat( interrogativePronouns, interrogativeProAdverbs ),
-		transitionWords: transitionWords.concat( additionalTransitionWords ),
-		miscellaneous: miscellaneous,
-		interjections: interjections,
-		cardinalNumerals: cardinalNumerals,
-		ordinalNumerals: ordinalNumerals,
-		indefinitePronouns: indefinitePronouns,
-		locativeAdverbs: locativeAdverbs,
-		prepositionalAdverbs: prepositionalAdverbs,
-		intensifiers: intensifiers,
-		recipeWords: recipeWords,
-		timeWords: timeWords,
-		vagueNouns: vagueNouns,
-		titlesPreceding: titlesPreceding,
-		titlesFollowing: titlesFollowing,
+
+		// These word categories are filtered at the beginning of word combinations.
+		filteredAtBeginning: generalAdjectivesAdverbs,
+
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: ordinalNumerals.concat( otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive ),
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: articles.concat( prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+			quantifiers, possessivePronouns ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: transitionWords.concat( personalPronounsNominative, personalPronounsAccusative, personalPronounsPrepositional,
+			personalPronounsComitative, interjections, cardinalNumerals, otherAuxiliaries, copula, interviewVerbs, delexicalizedVerbs,
+			indefinitePronouns, correlativeConjunctions, subordinatingConjunctions, interrogativeDeterminers, interrogativePronouns,
+			interrogativeProAdverbs, locativeAdverbs, miscellaneous, prepositionalAdverbs, recipeWords, timeWords, vagueNouns ),
+
+		// This export contains all of the above words.
 		all: articles.concat( cardinalNumerals, ordinalNumerals, demonstrativePronouns, possessivePronouns,
 			personalPronounsNominative, personalPronounsComitative, personalPronounsPrepositional,
 			personalPronounsAccusative, quantifiers, indefinitePronouns, interrogativeDeterminers, interrogativePronouns,

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -249,11 +249,6 @@ function filterCombinations( combinations, functionWords, locale ) {
 			combinations = filterFunctionWords( combinations, functionWords().possessivePronouns );
 			break;
 		case "it":
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().infinitives );
-			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().generalAdjectivesAdverbsPreceding );
-			combinations = filterFunctionWords( combinations, functionWords().possessivePronouns );
-			break;
 		case "fr":
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().infinitives );
 			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().generalAdjectivesAdverbs );

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -204,63 +204,13 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
  *
  * @param {Array} combinations The list of word combination objects.
  * @param {Function} functionWords The function containing the lists of function words.
- * @param {string} locale The paper's locale.
  * @returns {Array} The filtered list of word combination objects.
  */
-function filterFunctionWords( combinations, functionWords, locale ) {
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().transitionWords );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().adverbialGenitives );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().personalPronouns );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().reflexivePronouns );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().interjections );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().cardinalNumerals );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().verbs );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().indefinitePronouns );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().conjunctionsFilteredEverywhere );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().interrogatives );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().relativePronouns );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().locativeAdverbs );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().miscellaneous );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().prepositionalAdverbs );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().pronominalAdverbs );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().recipeWords );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().timeWords );
-	combinations = filterFunctionWordsAnywhere( combinations, functionWords().vagueNouns );
-	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().articles );
-	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().prepositions );
-	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().coordinatingConjunctions );
-	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().demonstrativePronouns );
-	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().intensifiers );
-	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().quantifiers );
-	combinations = filterFunctionWordsAtEnding( combinations, functionWords().ordinalNumerals );
-	combinations = filterFunctionWordsAtEnding( combinations, functionWords().titlesPreceding );
-	combinations = filterFunctionWordsAtBeginning( combinations, functionWords().titlesFollowing );
-	switch( getLanguage( locale ) ) {
-		case "en":
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().continuousVerbs );
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().possessivePronouns );
-			break;
-		case "es":
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().infinitives );
-			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().possessivePronouns );
-			break;
-		case "it":
-		case "fr":
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().infinitives );
-			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().generalAdjectivesAdverbsPreceding );
-			combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().possessivePronouns );
-			break;
-		case "de":
-		case "nl":
-			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().infinitives );
-			combinations = filterFunctionWordsAtEnding( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWordsAnywhere( combinations, functionWords().reciprocalPronouns );
-			combinations = filterFunctionWordsAnywhere( combinations, functionWords().possessivePronouns );
-			break;
-	}
+function filterFunctionWords( combinations, functionWords ) {
+	combinations = filterFunctionWordsAnywhere( combinations, functionWords().filteredAnywhere );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().filteredAtBeginningAndEnding );
+	combinations = filterFunctionWordsAtEnding( combinations, functionWords().filteredAtEnding );
+	combinations = filterFunctionWordsAtBeginning( combinations, functionWords().filteredAtBeginning );
 	return combinations;
 }
 
@@ -270,13 +220,12 @@ function filterFunctionWords( combinations, functionWords, locale ) {
  *
  * @param {Array} combinations The list of word combination objects.
  * @param {Function} functionWords The function containing the lists of function words.
- * @param {string} locale The paper's locale.
  * @returns {Array} The filtered list of word combination objects.
  */
-function filterCombinations( combinations, functionWords, locale ) {
+function filterCombinations( combinations, functionWords ) {
 	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
 	combinations = filterOneCharacterWordCombinations( combinations );
-	combinations = filterFunctionWords( combinations, functionWords, locale );
+	combinations = filterFunctionWords( combinations, functionWords );
 	return combinations;
 }
 /**
@@ -338,7 +287,7 @@ function getRelevantWords( text, locale ) {
 		fiveWordCombinations
 	);
 
-	combinations = filterCombinations( combinations, functionWords, locale );
+	combinations = filterCombinations( combinations, functionWords );
 
 	forEach( combinations, function( combination ) {
 		combination.setRelevantWords( oneWordRelevanceMap );

--- a/js/stringProcessing/relevantWords.js
+++ b/js/stringProcessing/relevantWords.js
@@ -176,7 +176,7 @@ function filterFunctionWordsAtEnding( wordCombinations, functionWords ) {
  * @param {Array} functionWords The list of function words.
  * @returns {WordCombination[]} Filtered word combinations.
  */
-function filterFunctionWords( wordCombinations, functionWords ) {
+function filterFunctionWordsAtBeginningAndEnding( wordCombinations, functionWords ) {
 	wordCombinations = filterFunctionWordsAtBeginning( wordCombinations, functionWords );
 	wordCombinations = filterFunctionWordsAtEnding( wordCombinations, functionWords );
 	return wordCombinations;
@@ -199,17 +199,15 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
 }
 
 /**
- * Filters the list of word combination objects.
- * Word combinations with specific parts of speech at the beginning and/or end are removed.
+ * Filters the list of word combination objects based on the language-specific function word filters.
+ * Word combinations with specific parts of speech are removed.
  *
  * @param {Array} combinations The list of word combination objects.
  * @param {Function} functionWords The function containing the lists of function words.
  * @param {string} locale The paper's locale.
  * @returns {Array} The filtered list of word combination objects.
  */
-function filterCombinations( combinations, functionWords, locale ) {
-	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
-	combinations = filterOneCharacterWordCombinations( combinations );
+function filterFunctionWords( combinations, functionWords, locale ) {
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().transitionWords );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().adverbialGenitives );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().personalPronouns );
@@ -228,12 +226,12 @@ function filterCombinations( combinations, functionWords, locale ) {
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().recipeWords );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().timeWords );
 	combinations = filterFunctionWordsAnywhere( combinations, functionWords().vagueNouns );
-	combinations = filterFunctionWords( combinations, functionWords().articles );
-	combinations = filterFunctionWords( combinations, functionWords().prepositions );
-	combinations = filterFunctionWords( combinations, functionWords().coordinatingConjunctions );
-	combinations = filterFunctionWords( combinations, functionWords().demonstrativePronouns );
-	combinations = filterFunctionWords( combinations, functionWords().intensifiers );
-	combinations = filterFunctionWords( combinations, functionWords().quantifiers );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().articles );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().prepositions );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().coordinatingConjunctions );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().demonstrativePronouns );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().intensifiers );
+	combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().quantifiers );
 	combinations = filterFunctionWordsAtEnding( combinations, functionWords().ordinalNumerals );
 	combinations = filterFunctionWordsAtEnding( combinations, functionWords().titlesPreceding );
 	combinations = filterFunctionWordsAtBeginning( combinations, functionWords().titlesFollowing );
@@ -241,19 +239,19 @@ function filterCombinations( combinations, functionWords, locale ) {
 		case "en":
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().continuousVerbs );
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWords( combinations, functionWords().possessivePronouns );
+			combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().possessivePronouns );
 			break;
 		case "es":
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().infinitives );
 			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().generalAdjectivesAdverbs );
-			combinations = filterFunctionWords( combinations, functionWords().possessivePronouns );
+			combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().possessivePronouns );
 			break;
 		case "it":
 		case "fr":
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().infinitives );
 			combinations = filterFunctionWordsAtBeginning( combinations, functionWords().generalAdjectivesAdverbs );
 			combinations = filterFunctionWordsAtEnding( combinations, functionWords().generalAdjectivesAdverbsPreceding );
-			combinations = filterFunctionWords( combinations, functionWords().possessivePronouns );
+			combinations = filterFunctionWordsAtBeginningAndEnding( combinations, functionWords().possessivePronouns );
 			break;
 		case "de":
 		case "nl":
@@ -263,6 +261,22 @@ function filterCombinations( combinations, functionWords, locale ) {
 			combinations = filterFunctionWordsAnywhere( combinations, functionWords().possessivePronouns );
 			break;
 	}
+	return combinations;
+}
+
+/**
+ * Filters the list of word combination objects based on function word filters, a special character filter and
+ * a one-character filter.
+ *
+ * @param {Array} combinations The list of word combination objects.
+ * @param {Function} functionWords The function containing the lists of function words.
+ * @param {string} locale The paper's locale.
+ * @returns {Array} The filtered list of word combination objects.
+ */
+function filterCombinations( combinations, functionWords, locale ) {
+	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
+	combinations = filterOneCharacterWordCombinations( combinations );
+	combinations = filterFunctionWords( combinations, functionWords, locale );
 	return combinations;
 }
 /**
@@ -348,7 +362,7 @@ module.exports = {
 	sortCombinations: sortCombinations,
 	filterFunctionWordsAtEnding: filterFunctionWordsAtEnding,
 	filterFunctionWordsAtBeginning: filterFunctionWordsAtBeginning,
-	filterFunctionWords: filterFunctionWords,
+	filterFunctionWords: filterFunctionWordsAtBeginningAndEnding,
 	filterFunctionWordsAnywhere: filterFunctionWordsAnywhere,
 	filterOnDensity: filterOnDensity,
 	filterOneCharacterWordCombinations: filterOneCharacterWordCombinations,

--- a/spec/researches/dutch/functionWordsSpec.js
+++ b/spec/researches/dutch/functionWordsSpec.js
@@ -2,34 +2,10 @@ let functionWords = require( "../../../js/researches/dutch/functionWords.js" );
 
 describe('a test for the existence of the properties of functionWords', function() {
 	it('returns true for all of its properties', function() {
-		expect ( functionWords().hasOwnProperty('articles') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('personalPronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('possessivePronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('prepositions') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('demonstrativePronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('coordinatingConjunctions') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('conjunctionsFilteredEverywhere') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('verbs') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('infinitives') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('quantifiers') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('relativePronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('interrogatives') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('passiveAuxiliaries') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('transitionWords') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('miscellaneous') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('pronominalAdverbs') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('interjections') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('reflexivePronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('reciprocalPronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('cardinalNumerals') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('ordinalNumerals') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('indefinitePronouns') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('locativeAdverbs') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('prepositionalAdverbs') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('intensifiers') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('generalAdjectivesAdverbs') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('recipeWords') ).toBe( true );
-		expect ( functionWords().hasOwnProperty('vagueNouns') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginning') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginningAndEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAnywhere') ).toBe( true );
 		expect ( functionWords().hasOwnProperty('all') ).toBe( true );
 	});
 

--- a/spec/researches/english/functionWordsSpec.js
+++ b/spec/researches/english/functionWordsSpec.js
@@ -1,0 +1,14 @@
+let functionWords = require( "../../../js/researches/english/functionWords.js" );
+
+describe('a test for the existence of the properties of functionWords', function() {
+	it('returns true for all of its properties', function() {
+		expect ( functionWords().hasOwnProperty('filteredAtEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginningAndEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAnywhere') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('all') ).toBe( true );
+	});
+
+	it('returns false for a non-existing property', function() {
+		expect ( functionWords().hasOwnProperty('fakeProperty') ).toBe( false );
+	});
+});

--- a/spec/researches/french/functionWordsSpec.js
+++ b/spec/researches/french/functionWordsSpec.js
@@ -1,0 +1,15 @@
+let functionWords = require( "../../../js/researches/french/functionWords.js" );
+
+describe('a test for the existence of the properties of functionWords', function() {
+	it('returns true for all of its properties', function() {
+		expect ( functionWords().hasOwnProperty('filteredAtBeginning') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginningAndEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAnywhere') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('all') ).toBe( true );
+	});
+
+	it('returns false for a non-existing property', function() {
+		expect ( functionWords().hasOwnProperty('fakeProperty') ).toBe( false );
+	});
+});

--- a/spec/researches/german/functionWordsSpec.js
+++ b/spec/researches/german/functionWordsSpec.js
@@ -1,0 +1,15 @@
+let functionWords = require( "../../../js/researches/german/functionWords.js" );
+
+describe('a test for the existence of the properties of functionWords', function() {
+	it('returns true for all of its properties', function() {
+		expect ( functionWords().hasOwnProperty('filteredAtBeginning') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginningAndEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAnywhere') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('all') ).toBe( true );
+	});
+
+	it('returns false for a non-existing property', function() {
+		expect ( functionWords().hasOwnProperty('fakeProperty') ).toBe( false );
+	});
+});

--- a/spec/researches/italian/functionWordsSpec.js
+++ b/spec/researches/italian/functionWordsSpec.js
@@ -1,0 +1,15 @@
+let functionWords = require( "../../../js/researches/italian/functionWords.js" );
+
+describe('a test for the existence of the properties of functionWords', function() {
+	it('returns true for all of its properties', function() {
+		expect ( functionWords().hasOwnProperty('filteredAtBeginning') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginningAndEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAnywhere') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('all') ).toBe( true );
+	});
+
+	it('returns false for a non-existing property', function() {
+		expect ( functionWords().hasOwnProperty('fakeProperty') ).toBe( false );
+	});
+});

--- a/spec/researches/spanish/functionWordsSpec.js
+++ b/spec/researches/spanish/functionWordsSpec.js
@@ -1,0 +1,15 @@
+let functionWords = require( "../../../js/researches/spanish/functionWords.js" );
+
+describe('a test for the existence of the properties of functionWords', function() {
+	it('returns true for all of its properties', function() {
+		expect ( functionWords().hasOwnProperty('filteredAtBeginning') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAtBeginningAndEnding') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('filteredAnywhere') ).toBe( true );
+		expect ( functionWords().hasOwnProperty('all') ).toBe( true );
+	});
+
+	it('returns false for a non-existing property', function() {
+		expect ( functionWords().hasOwnProperty('fakeProperty') ).toBe( false );
+	});
+});


### PR DESCRIPTION
## Summary
Fixes the following eslint error:
`210:1  error    Function 'filterCombinations' has too many statements (31). Maximum allowed is 30  max-statements`.
