### PR TITLE
Fixes passive sentence breakers matching

### DIFF
--- a/js/researches/english/getSentenceParts.js
+++ b/js/researches/english/getSentenceParts.js
@@ -45,7 +45,6 @@ var getVerbsEndingInIng = function( sentence ) {
 var getSentenceBreakers = function( sentence ) {
 	sentence = sentence.toLocaleLowerCase();
 	var auxiliaryIndices = getIndicesOfList( auxiliaries, sentence );
-
 	var stopwordIndices = getIndicesOfList( stopwords, sentence );
 
 	var ingVerbs = getVerbsEndingInIng( sentence );
@@ -87,7 +86,6 @@ var getSentenceParts = function( sentence ) {
 	}
 
 	var indices = getSentenceBreakers( sentence );
-
 	// Get the words after the found auxiliary.
 	for ( var i = 0; i < indices.length; i++ ) {
 		var endIndex = sentence.length;
@@ -99,7 +97,6 @@ var getSentenceParts = function( sentence ) {
 		var sentencePart = stripSpaces( sentence.substr( indices[ i ].index, endIndex - indices[ i ].index ) );
 
 		var auxiliaryMatches = getAuxiliaryMatches(  sentencePart );
-
 		// If a sentence part doesn't have an auxiliary, we don't need it, so it can be filtered out.
 		if ( auxiliaryMatches.length !== 0 ) {
 			sentenceParts.push( new SentencePart( sentencePart, auxiliaryMatches ) );

--- a/js/stringProcessing/addWordboundary.js
+++ b/js/stringProcessing/addWordboundary.js
@@ -11,7 +11,7 @@ module.exports = function( matchString, extraWordBoundary ) {
 	var wordBoundary, wordBoundaryStart, wordBoundaryEnd;
 	var _extraWordBoundary = extraWordBoundary || "";
 
-	wordBoundary = "[ \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›" + _extraWordBoundary + "<>]";
+	wordBoundary = "[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›" + _extraWordBoundary + "<>]";
 	wordBoundaryStart = "(^|" + wordBoundary + ")";
 	wordBoundaryEnd = "($|" + wordBoundary + ")";
 

--- a/js/stringProcessing/indices.js
+++ b/js/stringProcessing/indices.js
@@ -52,7 +52,6 @@ var getIndicesByWordList = function( words, text ) {
 		}
 		matchedWords = matchedWords.concat( getIndicesByWord( word, text ) );
 	} );
-
 	return matchedWords;
 };
 

--- a/js/stringProcessing/matchWordInSentence.js
+++ b/js/stringProcessing/matchWordInSentence.js
@@ -24,13 +24,22 @@ var isWordInSentence = function( word, sentence ) {
 	word = word.toLocaleLowerCase();
 	sentence = sentence.toLocaleLowerCase();
 
-	word = addWordBoundary( word );
-	var occurrenceStart = sentence.search( new RegExp ( word, "ig" ) );
-	var occurrenceEnd = occurrenceStart + word.length;
+	var wordWithBoundaries = addWordBoundary( word );
+	var occurrenceStart = sentence.search( new RegExp ( wordWithBoundaries, "ig" ) );
 	// Return false if no match has been found.
 	if ( occurrenceStart === -1 ) {
 		return false;
 	}
+	/*
+	If there is a word boundary before the matched word, the regex includes this word boundary in the match.
+	This means that occurrenceStart is the index of the word boundary before the match. Therefore 1 has to
+	be added to occurrenceStart, except when there is no word boundary before the match (i.e. at the start
+	of a sentence).
+	 */
+	if ( occurrenceStart > 0 ) {
+		occurrenceStart += 1;
+	}
+	var occurrenceEnd = occurrenceStart + word.length;
 
 	// Check if the previous and next character are word boundaries to determine if a complete word was detected
 	var previousCharacter = characterInBoundary( sentence[ occurrenceStart - 1 ] ) || occurrenceStart === 0;

--- a/js/stringProcessing/matchWordInSentence.js
+++ b/js/stringProcessing/matchWordInSentence.js
@@ -1,5 +1,6 @@
 var wordBoundaries = require( "../config/wordBoundaries.js" )();
 var includes = require( "lodash/includes" );
+var addWordBoundary = require( "./addWordboundary.js" );
 
 /**
  * Checks whether a character is present in the list of word boundaries.
@@ -23,9 +24,9 @@ var isWordInSentence = function( word, sentence ) {
 	word = word.toLocaleLowerCase();
 	sentence = sentence.toLocaleLowerCase();
 
-	var occurrenceStart = sentence.indexOf( word );
+	word = addWordBoundary( word );
+	var occurrenceStart = sentence.search( new RegExp ( word, "ig" ) );
 	var occurrenceEnd = occurrenceStart + word.length;
-
 	// Return false if no match has been found.
 	if ( occurrenceStart === -1 ) {
 		return false;

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -3,7 +3,7 @@ let Paper = require( "../../js/values/Paper.js" );
 
 describe("a test for finding transition words from a string", function() {
 	let mockPaper, result;
-/*
+
 	it("returns 1 when a transition word is found in the middle of a sentence (English)", function () {
 		// Transition word: above all.
 		mockPaper = new Paper("this story is, above all, about a boy", { locale: 'en_US'} );
@@ -301,7 +301,7 @@ describe("a test for finding transition words from a string", function() {
 			transitionWordSentences: 1
 		} );
 	});
-*/
+
 	it( "works with the no-break space character", function() {
 		// Transition word: then.
 		mockPaper = new Paper( "and\u00a0then" );

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -3,7 +3,7 @@ let Paper = require( "../../js/values/Paper.js" );
 
 describe("a test for finding transition words from a string", function() {
 	let mockPaper, result;
-
+/*
 	it("returns 1 when a transition word is found in the middle of a sentence (English)", function () {
 		// Transition word: above all.
 		mockPaper = new Paper("this story is, above all, about a boy", { locale: 'en_US'} );
@@ -301,7 +301,7 @@ describe("a test for finding transition words from a string", function() {
 			transitionWordSentences: 1
 		} );
 	});
-
+*/
 	it( "works with the no-break space character", function() {
 		// Transition word: then.
 		mockPaper = new Paper( "and\u00a0then" );

--- a/spec/stringProcessing/addWordBoundarySpec.js
+++ b/spec/stringProcessing/addWordBoundarySpec.js
@@ -4,7 +4,7 @@ import addWordBoundary from "../../js/stringProcessing/addWordboundary";
 
 describe("a test adding wordboundaries to a string", function(){
 	it("adds start and end boundaries", function(){
-		expect( addWordBoundary( "keyword" ) ).toBe( "(^|[ \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])keyword($|[ \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])" );
-		expect( addWordBoundary( "keyword", "extra" ) ).toBe( "(^|[ \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])keyword($|[ \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])" );
+		expect( addWordBoundary( "keyword" ) ).toBe( "(^|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])keyword($|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])" );
+		expect( addWordBoundary( "keyword", "extra" ) ).toBe( "(^|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])keyword($|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])" );
 	});
 });

--- a/spec/stringProcessing/createWordRegexSpec.js
+++ b/spec/stringProcessing/createWordRegexSpec.js
@@ -2,13 +2,13 @@ var createWordRegex = require( "../../js/stringProcessing/createWordRegex.js" );
 
 describe( "creates regex from keyword", function(){
 	it("returns a regex", function(){
-		expect( createWordRegex( "keyword" ) ).toEqual( /(^|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])keyword($|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "keyword" ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])keyword($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
 	});
 	it("returns a regex - words with diacritics", function(){
-		expect( createWordRegex( "maïs", "", false ) ).toEqual( /(^|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])maïs($|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
-		expect( createWordRegex( "Slovníček pojmû", "", false ) ).toEqual( /(^|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])Slovníček pojmû($|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "maïs", "", false ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])maïs($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "Slovníček pojmû", "", false ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])Slovníček pojmû($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
 	});
 	it("returns a regex - words with characters that break regexes", function(){
-		expect( createWordRegex( "keyword*" ) ).toEqual( /(^|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])keyword\*($|[ \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "keyword*" ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])keyword\*($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
 	});
 });

--- a/spec/stringProcessing/matchWordInSentenceSpec.js
+++ b/spec/stringProcessing/matchWordInSentenceSpec.js
@@ -1,0 +1,3 @@
+/**
+ * Created by manuelaugustin on 02/08/2017.
+ */

--- a/spec/stringProcessing/matchWordInSentenceSpec.js
+++ b/spec/stringProcessing/matchWordInSentenceSpec.js
@@ -1,3 +1,44 @@
-/**
- * Created by manuelaugustin on 02/08/2017.
- */
+let matchWordInSentence = require( "../../js/stringProcessing/matchWordInSentence" );
+let wordBoundaries = require( "../../js/config/wordBoundaries.js" )();
+let characterInBoundary = matchWordInSentence.characterInBoundary;
+let isWordInSentence = matchWordInSentence.isWordInSentence;
+
+describe( "returns whether the character is in the word boundary list", function() {
+	it( "returns true if the character is in the word boundary list", function() {
+		let input = ".";
+		let expected = true;
+		expect( characterInBoundary( input ) ).toEqual( expected );
+	});
+	it( "returns false if the character is not in the word boundary list", function() {
+		let input = "a";
+		let expected = false;
+		expect( characterInBoundary( input ) ).toEqual( expected );
+	})
+});
+
+describe ( "returns whether a word is in the sentence", function () {
+	it( "returns true if the word is in the middle of the sentence", function() {
+		let word = "is";
+		let sentence = "this is a sentence with a word";
+		let expected = true;
+		expect( isWordInSentence( word, sentence ) ).toEqual( expected );
+	});
+	it( "returns true if the word is at the beginning of the sentence", function() {
+		let word = "this";
+		let sentence = "this is a sentence with a word";
+		let expected = true;
+		expect( isWordInSentence( word, sentence ) ).toEqual( expected );
+	});
+	it( "returns true if the word is at the end of the sentence", function() {
+		let word = "word";
+		let sentence = "this is a sentence with a word";
+		let expected = true;
+		expect( isWordInSentence( word, sentence ) ).toEqual( expected );
+	});
+	it( "returns false if the word not the sentence", function() {
+		let word = "not";
+		let sentence = "this is a sentence with a word";
+		let expected = false;
+		expect( isWordInSentence( word, sentence ) ).toEqual( expected );
+	});
+});


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Fixes the bug where the passive voice and transition word assessments were broken when the passive voice sentence breaker or the transition word was preceded by a word containing the same string of letters. For example, 'is' was not recognized after 'praise'.

## Relevant technical choices:

* Replaced `sentence.indexOf( word );` by `sentence.search( new RegExp ( wordWithBoundaries, "ig" ) );`
* Added non-break spaces (`\u00a0` and ` `) to wordBoundary list.

## Test instructions

This PR can be tested by following these steps:

- Checkout release/1.20
- Use the browserified example. Don't forget to run a `grunt build:js`.
- Write `Who commented praise is due`.
- The sentence is incorrectly recognized as passive.

- Check out this branch.
- Don't forget to run a `grunt build:js`.
- Write `Who commented praise is due`.
- The sentence is not recognized as passive anymore.

Fixes #1214
