### PR TITLE
Added analysis results callbacks

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -917,6 +917,4 @@ App.prototype.createSnippetPreview = function() {
 	this.initSnippetPreview();
 };
 
-
-
 module.exports = App;

--- a/js/app.js
+++ b/js/app.js
@@ -38,6 +38,8 @@ var defaults = {
 		updateSnippetValues: function() {},
 		saveScores: function() {},
 		saveContentScore: function() {},
+		updatedContentResults: function() {},
+		updatedKeywordsResults: function() {},
 	},
 	sampleText: {
 		baseUrl: "example.org/",
@@ -185,13 +187,21 @@ function verifyArguments( args ) {
 /**
  * @callback YoastSEO.App~updatedContentResults
  *
- * @param {object} results The updated page analysis results.
+ * @param {Object[]} result The updated content analysis results.
+ * @param {number} result[].score The SEO score.
+ * @param {string} result[].rating String representation of the SEO score.
+ * @param {string} result[].text Textual explanation of the score.
+ * @param {number} overallContentScore The overall content SEO score.
  */
 
 /**
  * @callback YoastSEO.App~updatedKeywordsResults
  *
- * @param {object} results The updated keyword analysis results.
+ * @param {Object[]} result The updated keywords analysis results.
+ * @param {number} result[].score The SEO score.
+ * @param {string} result[].rating String representation of the SEO score.
+ * @param {string} result[].text Textual explanation of the score.
+ * @param {number} overallContentScore The overall keywords SEO score.
  */
 
 /**
@@ -216,6 +226,10 @@ function verifyArguments( args ) {
  * @param {YoastSEO.App~saveScores} args.callbacks.saveScores Called when the score has been determined by the analyzer.
  * @param {YoastSEO.App~saveContentScore} args.callback.saveContentScore Called when the content score has been
  *                                                                       determined by the assessor.
+ * @param {YoastSEO.App~updatedContentResults} args.callbacks.updatedContentResults Called when the score has been determined
+ *                                                                                  by the analyzer.
+ * @param {YoastSEO.App~updatedKeywordsResults} args.callback.updatedKeywordsResults Called when the content score has been
+ *                                                                                   determined by the assessor.
  * @param {Function} args.callbacks.saveSnippetData Function called when the snippet data is changed.
  * @param {Function} args.marker The marker to use to apply the list of marks retrieved from an assessment.
  *
@@ -494,18 +508,6 @@ App.prototype._pureRefresh = function() {
 };
 
 /**
- * Creates the elements for the snippetPreview
- *
- * @deprecated Don't create a snippet preview using this method, create it directly using the prototype and pass it as
- * an argument instead.
- * @returns {void}
- */
-App.prototype.createSnippetPreview = function() {
-	this.snippetPreview = createDefaultSnippetPreview.call( this );
-	this.initSnippetPreview();
-};
-
-/**
  * Initializes the snippet preview for this App.
  *
  * @returns {void}
@@ -638,7 +640,7 @@ App.prototype.runAnalyzer = function() {
 
 	this.runContentAnalysis();
 
-	this.renderAnalysisResults();
+	this._renderAnalysisResults();
 
 	if ( this.config.dynamicDelay ) {
 		this.endTime();
@@ -656,11 +658,6 @@ App.prototype.runKeywordAnalysis = function() {
 	if ( this.config.keywordAnalysisActive ) {
 		this.seoAssessor.assess( this.paper );
 		const overallSeoScore = this.seoAssessor.calculateOverallScore();
-
-		if( ! isUndefined( this.seoAssessorPresenter ) ) {
-			this.seoAssessorPresenter.setKeyword( this.paper.getKeyword() );
-			this.seoAssessorPresenter.render();
-		}
 
 		if( ! isUndefined( this.callbacks.updatedKeywordsResults ) ) {
 			this.callbacks.updatedKeywordsResults( this.seoAssessor.results, overallSeoScore );
@@ -681,10 +678,6 @@ App.prototype.runContentAnalysis = function() {
 	if ( this.config.contentAnalysisActive ) {
 		this.contentAssessor.assess( this.paper );
 		const overallContentScore = this.contentAssessor.calculateOverallScore();
-
-		if( ! isUndefined( this.contentAssessorPresenter ) ) {
-			this.contentAssessorPresenter.renderIndividualRatings();
-		}
 
 		if( ! isUndefined( this.callbacks.updatedContentResults ) ) {
 			this.callbacks.updatedContentResults( this.contentAssessor.results, overallContentScore );
@@ -862,16 +855,12 @@ App.prototype.disableMarkers = function() {
 	}
 };
 
-// Deprecated functions
 /**
  * Renders the content and keyword analysis results.
  *
- * @deprecated: Rendering shouldn't be this library's responsibility, please use the updatedContentResults and
- * updatedKeywordResults callbacks to obtain the analysis data for rendering.
- *
  * @returns {void}
  */
-App.prototype.renderAnalysisResults = function() {
+App.prototype._renderAnalysisResults = function() {
 	if( this.config.contentAnalysisActive && ! isUndefined( this.contentAssessorPresenter ) ) {
 		this.contentAssessorPresenter.renderIndividualRatings();
 	}
@@ -881,6 +870,7 @@ App.prototype.renderAnalysisResults = function() {
 	}
 };
 
+// Deprecated functions
 /**
  * The analyzeTimer calls the checkInputs function with a delay, so the function won't be executed
  * at every keystroke checks the reference object, so this function can be called from anywhere,
@@ -913,6 +903,20 @@ App.prototype.analyzeTimer = function() {
 App.prototype.registerTest = function() {
 	console.error( "This function is deprecated, please use registerAssessment" );
 };
+
+/**
+ * Creates the elements for the snippetPreview
+ *
+ * @deprecated Don't create a snippet preview using this method, create it directly using the prototype and pass it as
+ * an argument instead.
+ *
+ * @returns {void}
+ */
+App.prototype.createSnippetPreview = function() {
+	this.snippetPreview = createDefaultSnippetPreview.call( this );
+	this.initSnippetPreview();
+};
+
 
 
 module.exports = App;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Added `updatedKeywordsResults` and `updatedContentResults` callbacks to `app.js`.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

1. In `examples/browserified/example.js` add the following callbacks to the `callbacks` section of the app definition:

```js
updatedKeywordsResults: function( results, overallScore ) {
	console.log( results, overallScore );
},
updatedContentResults: function( results, overallScore ) {
	console.log( results, overallScore );
},
```
2. Run `grunt build`.
3. Open `examples/browserified/index.html` in your browser
4. Open your developer tools, and see the updated analysis results as you edit the text in the input fields.

Fixes #1227
