### PR TITLE
Set up the typescript compiler

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [ "es2015" ],
   "ignore": [
-    "js/templates.js"
+    "js/templates.js",
+    "src/templates.js"
   ]
 }

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -11,6 +11,7 @@ build:
   - 'build-templates'
 # Build JavaScript from assets to production
 'build:js':
+  - 'ts'
   - 'browserify'
   - 'exorcise'
 # Build CSS

--- a/grunt/config/ts.js
+++ b/grunt/config/ts.js
@@ -1,0 +1,5 @@
+module.exports = {
+	"default": {
+		tsconfig: true,
+	},
+};

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "url": "https://github.com/Yoast/YoastSEO.js"
   },
   "scripts": {
+    "build": "grunt build:js",
     "test": "babel-node ./node_modules/istanbul/lib/cli.js cover jasmine",
     "check-coverage": "istanbul check-coverage --statements 86 --branches 77 --functions 78 --lines 86"
   },
   "browser": "js/browser.js",
   "devDependencies": {
+    "@types/node": "^8.0.20",
     "autoprefixer": "^6.4.0",
     "babel-cli": "^6.16.0",
     "babel-preset-es2015": "^6.16.0",
@@ -43,7 +45,10 @@
     "istanbul": "^0.4.0",
     "jasmine": "~2.5.1",
     "load-grunt-config": "^0.19.1",
-    "lodash-cli": "^4.14.1"
+    "lodash-cli": "^4.14.1",
+    "grunt-ts": "^5.5.1",
+    "lodash-cli": "^4.14.1",
+    "typescript": "^2.4.2"
   },
   "bugs": {
     "url": "https://github.com/Yoast/js-text-analysis/issues"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "load-grunt-config": "^0.19.1",
     "lodash-cli": "^4.14.1",
     "grunt-ts": "^5.5.1",
-    "lodash-cli": "^4.14.1",
     "typescript": "^2.4.2"
   },
   "bugs": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "typeRoots": [
+            "node_modules/@types"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "target": "es6",
+        "sourceMap": true,
+        "outDir": "js/",
+        "allowJs": true,
+        "rootDir": "src",
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "filesGlob": [
+        "src/**/*.ts",
+        "src/**/*.js"
+    ],
+    "files": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
         "noUnusedParameters": true,
         "strictNullChecks": true,
         "noImplicitThis": true,
-        "noFallthroughCasesInSwitch": true
+        "noFallthroughCasesInSwitch": true,
+        "alwaysStrict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmitOnError": true,
+        "noImplicitAny": true,
+        "pretty": true
     },
     "filesGlob": [
         "src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "typeRoots": [
             "node_modules/@types"
         ],
-        "module": "commonjs",
+        "module": "es6",
         "moduleResolution": "node",
         "target": "es6",
         "sourceMap": true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Added TypeScript compiler to YoastSEO.js

## Relevant technical choices:

* "src" is the root directory for TypeScript files

## Test instructions

This PR can be tested by following these steps:

*Add a TypeScript file to the src folder and build the project. There should be a new JavaScript file with the same name as the TypeScript file in the "JS" folder.

Fixes #1231
