### PR TITLE
Add test to getSentencePartsSpec

### DIFF
--- a/spec/researches/german/getSentencePartsSpec.js
+++ b/spec/researches/german/getSentencePartsSpec.js
@@ -7,4 +7,8 @@ describe( "splits German sentences into parts", function() {
 		expect( getSentenceParts( sentence )[ 1 ].getSentencePartText() ).toBe( "und 1933 hatte sie intensiven Kontakt zur Erzabtei Beuron." );
 		expect( getSentenceParts( sentence ).length ).toBe( 2 );
 	} );
+	it ( "splits German sentences that begin with a stopword into sentence parts", function() {
+		var sentence =  "und 1933 hatte sie intensiven Kontakt zur Erzabtei Beuron.";
+		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "und 1933 hatte sie intensiven Kontakt zur Erzabtei Beuron." );
+	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Adds a checking whether German sentences that begin with a stopword are correctly split into sentence parts.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`.
* Check whether all tests pass.

Fixes #1233 
