### PR TITLE
Add filter for exception words between auxiliary and passive participle

### DIFF
--- a/spec/researches/english/EnglishParticipleSpec.js
+++ b/spec/researches/english/EnglishParticipleSpec.js
@@ -7,15 +7,17 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
 	it( "checks the properties of the English participle object with a non-verb ending in -ed", function() {
-		let mockParticiple = new EnglishParticiple( "airbed", "It is wellbred", { auxiliaries: [ "is" ], type: "regular" } );
-		expect( mockParticiple.getParticiple() ).toBe( "airbed" );
+		let mockParticiple = new EnglishParticiple( "wellbred", "It is wellbred", { auxiliaries: [ "is" ], type: "regular" } );
+		expect( mockParticiple.getParticiple() ).toBe( "wellbred" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( true );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -25,6 +27,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( true );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -34,6 +37,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( true );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -43,6 +47,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( true );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -52,6 +57,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -61,6 +67,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( true );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -70,6 +77,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -79,6 +87,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -90,7 +99,7 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 		it( "checks the properties of the English participle object with a precedence exception when the word from the list doesn't directly precede the participle", function() {
-		let mockParticiple = new EnglishParticiple( "enjoyed", "It’s something I’ve always enjoyed doing", { auxiliaries: [ "it's" ], type: "regular" } );
+		let mockParticiple = new EnglishParticiple( "enjoyed", "It's something I've always enjoyed doing", { auxiliaries: [ "it's" ], type: "regular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "enjoyed" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -100,12 +109,22 @@ describe( "A test for checking the English Participle", function() {
 	});
 
 	it( "checks the properties of the English participle object with a precedence exception when the word from the list directly precedes the participle", function() {
-		let mockParticiple = new EnglishParticiple( "adopted", "Here is a list of ten beliefs I have adopted.", { auxiliaries: [ "is" ], type: "regular" } );
+		let mockParticiple = new EnglishParticiple( "adopted", "Here is a list of ten beliefs I have adopted", { auxiliaries: [ "is" ], type: "regular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "adopted" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException() ).toBe( false );
 		expect( mockParticiple.precedenceException() ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	});
+
+	it( "checks the properties of the English participle object with a precedence exception when the word from the list occurs after the participle", function() {
+		let mockParticiple = new EnglishParticiple( "stolen", "The money was stolen, but nobody has been able to prove it", { auxiliaries: [ "was" ], type: "irregular" } );
+		expect( mockParticiple.getParticiple() ).toBe( "stolen" );
+		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
+		expect( mockParticiple.hasRidException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 });

--- a/spec/researches/english/EnglishParticipleSpec.js
+++ b/spec/researches/english/EnglishParticipleSpec.js
@@ -88,4 +88,24 @@ describe( "A test for checking the English Participle", function() {
 		mockParticiple.checkException();
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
+
+		it( "checks the properties of the English participle object with a precedence exception when the word from the list doesn't directly precede the participle", function() {
+		let mockParticiple = new EnglishParticiple( "enjoyed", "It’s something I’ve always enjoyed doing", { auxiliaries: [ "it's" ], type: "regular" } );
+		expect( mockParticiple.getParticiple() ).toBe( "enjoyed" );
+		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
+		expect( mockParticiple.hasRidException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( true );
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	});
+
+	it( "checks the properties of the English participle object with a precedence exception when the word from the list directly precedes the participle", function() {
+		let mockParticiple = new EnglishParticiple( "adopted", "Here is a list of ten beliefs I have adopted.", { auxiliaries: [ "is" ], type: "regular" } );
+		expect( mockParticiple.getParticiple() ).toBe( "adopted" );
+		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
+		expect( mockParticiple.hasRidException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException() ).toBe( false );
+		expect( mockParticiple.precedenceException() ).toBe( true );
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	});
 });

--- a/spec/researches/english/EnglishParticipleSpec.js
+++ b/spec/researches/english/EnglishParticipleSpec.js
@@ -1,13 +1,14 @@
 let EnglishParticiple = require( "../../../js/researches/english/EnglishParticiple.js" );
 
 describe( "A test for checking the English Participle", function() {
+
 	it( "checks the properties of the English participle object with a passive", function() {
 		let mockParticiple = new EnglishParticiple( "fired", "He was fired", { auxiliaries: [ "was" ], type: "regular" } );
 		expect( mockParticiple.getParticiple() ).toBe( "fired" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 7 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 7 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -16,8 +17,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "wellbred" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( true );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 6 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 6 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -26,8 +27,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "rid" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( true );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 16 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 16 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -36,8 +37,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "read" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( true );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 22 ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 22 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -46,8 +47,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "left" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( true );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 14 ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 14 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -56,8 +57,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "left" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 7 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 7 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -66,8 +67,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( true );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 10 ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 10 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -76,8 +77,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "painted" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 24 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 24 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -86,8 +87,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 18 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 18 ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 
@@ -103,8 +104,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "enjoyed" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 27 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 27 ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -113,8 +114,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "adopted" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 37 ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 37 ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	});
 
@@ -123,8 +124,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "stolen" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException() ).toBe( false );
-		expect( mockParticiple.precedenceException() ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 14) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 14) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	});
 });

--- a/src/.baseDir.ts
+++ b/src/.baseDir.ts
@@ -1,0 +1,1 @@
+// Ignore this file. See https://github.com/grunt-ts/grunt-ts/issues/77

--- a/src/researches/english/EnglishParticiple.js
+++ b/src/researches/english/EnglishParticiple.js
@@ -156,8 +156,8 @@ EnglishParticiple.prototype.hasRidException = function() {
  * the participle, otherwise returns false.
  */
 EnglishParticiple.prototype.directPrecedenceException = function( sentencePart, participleIndex ) {
-	var exceptionMatch = getWordIndices( sentencePart, directPrecedenceExceptionRegex );
-	return includesIndex( exceptionMatch, participleIndex );
+	var directPrecedenceExceptionMatch = getWordIndices( sentencePart, directPrecedenceExceptionRegex );
+	return includesIndex( directPrecedenceExceptionMatch, participleIndex );
 };
 
 /**
@@ -171,8 +171,8 @@ EnglishParticiple.prototype.directPrecedenceException = function( sentencePart, 
  * sentence part before the participle, otherwise returns false.
  */
 EnglishParticiple.prototype.precedenceException = function( sentencePart, participleIndex ) {
-	var exceptionMatch = getWordIndices( sentencePart, precedenceExceptionRegex );
-	return precedesIndex( exceptionMatch, participleIndex );
+	var precedenceExceptionMatch = getWordIndices( sentencePart, precedenceExceptionRegex );
+	return precedesIndex( precedenceExceptionMatch, participleIndex );
 };
 
 

--- a/src/researches/english/EnglishParticiple.js
+++ b/src/researches/english/EnglishParticiple.js
@@ -149,6 +149,9 @@ EnglishParticiple.prototype.hasRidException = function() {
  * Checks whether the participle is directly preceded by a word from the direct precedence exception list.
  * If this is the case, the sentence part is not passive.
  *
+ * @param {string} sentencePart The sentence part that contains the participle.
+ * @param {number} participleIndex The index of the participle.
+ *
  * @returns {boolean} Returns true if a word from the direct precedence exception list is directly preceding
  * the participle, otherwise returns false.
  */
@@ -160,6 +163,9 @@ EnglishParticiple.prototype.directPrecedenceException = function( sentencePart, 
 /**
  * Checks whether a word from the precedence exception list occurs anywhere in the sentence part before the participle.
  * If this is the case, the sentence part is not passive.
+ *
+ * @param {string} sentencePart The sentence part that contains the participle.
+ * @param {number} participleIndex The index of the participle.
  *
  * @returns {boolean} Returns true if a word from the precedence exception list occurs anywhere in the
  * sentence part before the participle, otherwise returns false.

--- a/src/researches/english/EnglishParticiple.js
+++ b/src/researches/english/EnglishParticiple.js
@@ -56,15 +56,14 @@ var precedesIndex = function( precedingWords, participleIndex ) {
 		var precedingWordsIndex = precedingWord.index;
 		precedingWordsIndices.push( precedingWordsIndex );
 	} );
-	console.log( "precedingWordsIndices:", precedingWordsIndices );
 
 	var matches = [];
 	forEach( precedingWordsIndices, function( precedingWordsIndex ) {
+		// + 1 because the beginning word boundary is not included in the passive participle match
 		if ( precedingWordsIndex + 1 < participleIndex ) {
 			matches.push( precedingWordsIndex );
 		}
 	} );
-	console.log( "matches:", matches );
 
 	if ( matches.length ) {
 		return true;
@@ -167,11 +166,8 @@ EnglishParticiple.prototype.directPrecedenceException = function() {
  */
 EnglishParticiple.prototype.precedenceException = function() {
 	var sentencePart = this.getSentencePart();
-	console.log( "sentencePart:", sentencePart );
 	var participleIndex = sentencePart.indexOf( this.getParticiple() );
-	console.log( "participleIndex:", participleIndex );
 	var exceptionMatch = getWordIndices( sentencePart, precedenceExceptionRegex );
-	console.log(precedesIndex( exceptionMatch, participleIndex ));
 	return precedesIndex( exceptionMatch, participleIndex );
 };
 

--- a/src/researches/english/EnglishParticiple.js
+++ b/src/researches/english/EnglishParticiple.js
@@ -108,10 +108,12 @@ EnglishParticiple.prototype.checkException = function() {
  * @returns {boolean} Returns true if no exception is found.
  */
 EnglishParticiple.prototype.isPassive = function() {
+	let sentencePart = this.getSentencePart();
+	let participleIndex = sentencePart.indexOf( this.getParticiple() );
 	return 	! this.isNonVerbEndingEd() &&
 				! this.hasRidException() &&
-				! this.directPrecedenceException() &&
-				! this.precedenceException();
+				! this.directPrecedenceException( sentencePart, participleIndex ) &&
+				! this.precedenceException( sentencePart, participleIndex );
 };
 
 /**
@@ -150,9 +152,7 @@ EnglishParticiple.prototype.hasRidException = function() {
  * @returns {boolean} Returns true if a word from the direct precedence exception list is directly preceding
  * the participle, otherwise returns false.
  */
-EnglishParticiple.prototype.directPrecedenceException = function() {
-	var sentencePart = this.getSentencePart();
-	var participleIndex = sentencePart.indexOf( this.getParticiple() );
+EnglishParticiple.prototype.directPrecedenceException = function( sentencePart, participleIndex ) {
 	var exceptionMatch = getWordIndices( sentencePart, directPrecedenceExceptionRegex );
 	return includesIndex( exceptionMatch, participleIndex );
 };
@@ -164,9 +164,7 @@ EnglishParticiple.prototype.directPrecedenceException = function() {
  * @returns {boolean} Returns true if a word from the precedence exception list occurs anywhere in the
  * sentence part before the participle, otherwise returns false.
  */
-EnglishParticiple.prototype.precedenceException = function() {
-	var sentencePart = this.getSentencePart();
-	var participleIndex = sentencePart.indexOf( this.getParticiple() );
+EnglishParticiple.prototype.precedenceException = function( sentencePart, participleIndex ) {
 	var exceptionMatch = getWordIndices( sentencePart, precedenceExceptionRegex );
 	return precedesIndex( exceptionMatch, participleIndex );
 };

--- a/src/researches/english/getSentenceParts.js
+++ b/src/researches/english/getSentenceParts.js
@@ -1,5 +1,5 @@
 var verbEndingInIngRegex = /\w+ing($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
-var ingExclusionArray = [ "king", "cling", "ring", "being" ];
+var ingExclusionArray = [ "king", "cling", "ring", "being", "thing", "something", "anything" ];
 var indices = require( "../../stringProcessing/indices" );
 var getIndicesOfList = indices.getIndicesByWordList;
 var filterIndices = indices.filterIndices;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Adds a filter to avoid incorrectly marking participles as passive when the participle belongs to a non-passive auxiliary. E.g., 'enjoyed' in 'It's something I've always enjoyed doing' will now be correctly marked as non-passive because it belongs to 'I've' and not 'It's'.

## Test instructions

This PR can be tested by following these steps:
- Use the browserified example. Don't forget to run `grunt build:js`.
- Paste the sentence `It's something I've always enjoyed doing`.
- Make sure it is not marked as passive.

Fixes #920
