### PR TITLE
Fixes a bug where words ending in ing plus parentheses break the passive analysis

### DIFF
--- a/spec/researches/english/getSentencePartsSpec.js
+++ b/spec/researches/english/getSentencePartsSpec.js
@@ -17,4 +17,9 @@ describe( "splits English sentences into parts", function() {
 		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "is praise due." );
 		expect( getSentenceParts( sentence ).length ).toBe( 1 );
 	} );
+	it ( "correctly splits when matching punctuation after words ending in ing", function() {
+		var sentence = "(is having)";
+		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "having)" );
+		expect( getSentenceParts( sentence ).length ).toBe( 1 );
+	} );
 } );

--- a/spec/researches/english/getSentencePartsSpec.js
+++ b/spec/researches/english/getSentencePartsSpec.js
@@ -17,7 +17,7 @@ describe( "splits English sentences into parts", function() {
 		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "is praise due." );
 		expect( getSentenceParts( sentence ).length ).toBe( 1 );
 	} );
-	it ( "correctly splits when matching punctuation after words ending in ing", function() {
+	it ( "correctly splits English sentences when matching punctuation after words ending in ing", function() {
 		var sentence = "(is having)";
 		expect( getSentenceParts( sentence )[ 0 ].getSentencePartText() ).toBe( "having)" );
 		expect( getSentenceParts( sentence ).length ).toBe( 1 );

--- a/src/researches/english/getSentenceParts.js
+++ b/src/researches/english/getSentenceParts.js
@@ -1,4 +1,4 @@
-var verbEndingInIngRegex = /\w+ing($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
+var verbEndingInIngRegex = /\w+ing(?=$|[ \n\r\t\.,'\(\)\"\+\-;?:\/»«‹›<>])/ig;
 var ingExclusionArray = [ "king", "cling", "ring", "being", "thing", "something", "anything" ];
 var indices = require( "../../stringProcessing/indices" );
 var getIndicesOfList = indices.getIndicesByWordList;
@@ -27,7 +27,6 @@ var map = require( "lodash/map" );
 var getVerbsEndingInIng = function( sentence ) {
 	// Matches the sentences with words ending in ing.
 	var matches = sentence.match( verbEndingInIngRegex ) || [];
-
 	// Filters out words ending in -ing that aren't verbs.
 	return filter( matches, function( match ) {
 		return ! includes( ingExclusionArray, stripSpaces( match ) );

--- a/src/researches/english/getSentenceParts.js
+++ b/src/researches/english/getSentenceParts.js
@@ -1,4 +1,4 @@
-var verbEndingInIngRegex = /\w+ing(?=$|[ \n\r\t\.,'\(\)\"\+\-;?:\/»«‹›<>])/ig;
+var verbEndingInIngRegex = /\w+ing(?=$|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
 var ingExclusionArray = [ "king", "cling", "ring", "being", "thing", "something", "anything" ];
 var indices = require( "../../stringProcessing/indices" );
 var getIndicesOfList = indices.getIndicesByWordList;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Fixes a bug that caused an error in the passive analysis when certain words ending in ing were followed by a parenthesis.

## Relevant technical choices:

- Added positive lookahead to `verbEndingInIngRegex` in `getSentenceParts.js`.

## Test instructions

This PR can be tested by following these steps:
- Use the browserified example. Don't forget to run a `grunt build:js`.
- Paste the string `being(`.
- Make sure the passive analysis is still working (showing that 0% of the sentences contain passive voice).


Fixes #1251 
