### PR TITLE
added paper declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can also invoke internal components directly to be able to work with the raw
 
 ```js
 var Researcher = require( "yoastseo" ).Researcher;
+var Paper = require( "yoastseo" ).Paper;
 
 var researcher = new Researcher( new Paper( "Text that has been written" ) );
 


### PR DESCRIPTION
## Summary

When creating a new project using YoastSEO.js using the instructions from the readme, It didn't seem to understand `Paper`. After adding it, it seemed to work fine, so I figured I should update the instructions in the readme.

## Test instructions
This PR can be tested by following these steps:

- Create a js file in an empty folder for example:`filename.js`. 
- Paste the edited instructions into the file ( you can leave out the `var paper` line to test it didn't work without adding it ):
```
var Researcher = require( "yoastseo" ).Researcher;
var Paper = require( "yoastseo" ).Paper;

var researcher = new Researcher( new Paper( "Text that has been written" ) );
```
- run `npm install https://github.com/Yoast/YoastSEO.js#develop` in the folder. This should create a node-modules folder with all yoastseo.js and other projects it uses.
- run `yarn install` and `grunt build` in the yoastseo folder.
- run the js file. It should work now (`node filename.js`)
