### PR TITLE
Add excited to exception -ed verbs

### DIFF
--- a/src/researches/english/passivevoice/non-verb-ending-ed.js
+++ b/src/researches/english/passivevoice/non-verb-ending-ed.js
@@ -411,6 +411,7 @@ module.exports = function() {
 		"evilhearted",
 		"evilminded",
 		"exceed",
+		"excited",
 		"exemplified",
 		"exponentiated",
 		"expurgated",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Add 'excited' to the list of non-verbs ending in -ed. To be + excited is usually not passive.
