### PR TITLE
Set a score of -1 and 'error' rating for errors

### DIFF
--- a/src/assessor.js
+++ b/src/assessor.js
@@ -185,7 +185,7 @@ Assessor.prototype.executeAssessment = function( paper, researcher, assessment )
 
 		result = new AssessmentResult();
 
-		result.setScore( 0 );
+		result.setScore( -1 );
 		result.setText( this.i18n.sprintf(
 			/* Translators: %1$s expands to the name of the assessment. */
 			this.i18n.dgettext( "js-text-analysis", "An error occurred in the '%1$s' assessment" ),

--- a/src/interpreters/scoreToRating.js
+++ b/src/interpreters/scoreToRating.js
@@ -4,7 +4,11 @@
  * @param {Number} score The score to interpreter.
  * @returns {string} The rating, given based on the score.
  */
-var ScoreToRating = function( score ) {
+let ScoreToRating = function( score ) {
+	if ( score === -1 ) {
+		return "error";
+	}
+
 	if ( score === 0 ) {
 		return "feedback";
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Introduces a separation in scores and ratings between errors and other grey bullets in the content analysis.

## Relevant technical choices:

* In the assessor, a score of -1 is set for errors (instead of 0)
* in scoreToRating, 'error' instead of 'feedback' is set as rating text for errors 

