### PR TITLE
Restore check-coverage in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ install:
 - yarn install
 script:
 - yarn lint
-- yarn test --coverage
+- yarn test
 - grunt check
+- yarn run check-coverage
 after_script:
 - grunt publish
 after_success:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "grunt build:js",
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "pretest": "grunt build:test",
-    "test": "jest"
+    "test": "jest",
+    "check-coverage": "istanbul check-coverage --statements 86 --branches 77 --functions 78 --lines 86"
   },
   "browser": "js/browser.js",
   "devDependencies": {


### PR DESCRIPTION
I accidentally removed `yarn run test-coverage` from `.travis.yml`, because it wasn't in `package.json` and that caused the build on Travis to fail. This PR fixes that.