### PR TITLE
Add babel plugin transform rest object spread

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
   "presets": [ "es2015" ],
-  "ignore": [
-    "js/templates.js",
-    "src/templates.js"
-  ]
+  "plugins": [ "transform-object-rest-spread" ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwa
 
 ## 1.23.0 October 31st, 2017
 * Errors now give a score of -1. `ScoreToRating` interpreter will convert `-1` to `error`. #1272
-* Added `Excited` to exception -ed verbs. #1269
-* Changed testing framework to `jest`. #1266
-* Added `release` script in `.travis.yml` for publishing to npm. #1265
-* Added `code` tags to filter. #1250
-* Added `pre` tags to filter, props [chrisboo](https://github.com/chrisboo). #1258
+* Adds `Excited` to exception -ed verbs. #1269
+* Adds `release` script in `.travis.yml` for publishing to npm. #1265
+* Adds `code` tags to filter. #1250
+* Adds `pre` tags to filter, props [chrisboo](https://github.com/chrisboo). #1258
+* Switched testing framework to `jest`. #1266
 
 ## 1.22.0 October 3rd, 2017
 * Added typescript support.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "autoprefixer": "^6.4.0",
     "babel-cli": "^6.16.0",
     "babel-jest": "^21.2.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
     "babelify": "^7.3.0",

--- a/src/config/syllables.js
+++ b/src/config/syllables.js
@@ -3,10 +3,10 @@
 let getLanguage = require( "../helpers/getLanguage.js" );
 let isUndefined = require( "lodash/isUndefined" );
 
-let de = require( "./syllables/de.json" );
-let en = require( './syllables/en.json' );
-let nl = require( './syllables/nl.json' );
-let it = require( './syllables/it.json' );
+let de = require( "./syllables/de.js" );
+let en = require( "./syllables/en.js" );
+let nl = require( "./syllables/nl.js" );
+let it = require( "./syllables/it.js" );
 
 let languages = { de, nl, en, it };
 
@@ -18,5 +18,5 @@ module.exports = function( locale = "en_US" ) {
 	}
 
 	// If an unknown locale is used, default to English.
-	return languages[ "en" ];
+	return languages.en;
 };

--- a/src/config/syllables/de.js
+++ b/src/config/syllables/de.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"vowels": "aeiouyäöüáéâàèîêâûôœ",
 	"deviations": {
 		"vowels": [

--- a/src/config/syllables/en.js
+++ b/src/config/syllables/en.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"vowels": "aeiouy",
 	"deviations": {
 		"vowels": [

--- a/src/config/syllables/it.js
+++ b/src/config/syllables/it.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"vowels": "aeiouyàèéìîïòù",
 	"deviations": {
 		"vowels": [

--- a/src/config/syllables/nl.js
+++ b/src/config/syllables/nl.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"vowels": "aáäâeéëêiíïîoóöôuúüûy",
 	"deviations": {
 		"vowels": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,7 +484,7 @@ babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -665,6 +665,13 @@ babel-plugin-transform-es2015-unicode-regex@^6.3.13:
     babel-helper-regex "^6.8.0"
     babel-runtime "^6.0.0"
     regexpu-core "^2.0.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.16.0:
   version "6.21.0"


### PR DESCRIPTION
Adds a babel plugin to tranform the object rest and spread syntax, to avoid build errors.

## Test instructions
* Run `grunt publish`.
* Inspect `templates.js` in `dist/js` and make sure no object rest spread syntax is found.

Example: `const { a, b, c } = obj;`