### PR TITLE
Add babel plugin transform object rest spread

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
   "presets": [ "es2015" ],
-  "ignore": [
-    "js/templates.js",
-    "src/templates.js"
-  ]
+  "plugins": [ "transform-object-rest-spread" ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwa
 
 ## 1.23.0 October 31st, 2017
 * Errors now give a score of -1. `ScoreToRating` interpreter will convert `-1` to `error`. #1272
-* Adds `Excited` to exception -ed verbs. #1269
-* Adds `release` script in `.travis.yml` for publishing to npm. #1265
-* Adds `code` tags to filter. #1250
-* Adds `pre` tags to filter, props [chrisboo](https://github.com/chrisboo). #1258
-* Switched testing framework to `jest`. #1266
+* Adds `Excited` to exception -ed verbs for passive voice assessment. #1269
+* Adds `release` script to `.travis.yml` for publishing to npm. #1265
+* Adds a filter to exclude `code` tags and their enclosed content from the content analysis assessments. #1250
+* Adds a filter to exclude `pre` tags and their enclosed content from the content analysis assessments, props [chrisboo](https://github.com/chrisboo). #1258
+* Switches testing framework to `jest`. #1266
 
 ## 1.22.0 October 3rd, 2017
 * Added typescript support.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "babel-jest": "^21.2.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "grunt-babel": "^7.0.0",
     "babelify": "^7.3.0",
     "eslint-config-yoast": "^2.0.2",
     "eslint-plugin-react": "^6.0.0",
@@ -59,8 +62,6 @@
     "url": "https://github.com/Yoast/js-text-analysis/issues"
   },
   "dependencies": {
-    "babel-core": "^6.26.0",
-    "grunt-babel": "^7.0.0",
     "htmlparser2": "^3.9.2",
     "jed": "^1.1.0",
     "jest": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
     "testPathIgnorePatterns": [
       "/spec/helpers/factory.js"
     ],
+    "coveragePathIgnorePatterns": [
+      "js/templates.js"
+    ],
     "coverageThreshold": {
       "global": {
         "branches": 76,

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,7 +484,7 @@ babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -665,6 +665,13 @@ babel-plugin-transform-es2015-unicode-regex@^6.3.13:
     babel-helper-regex "^6.8.0"
     babel-runtime "^6.0.0"
     regexpu-core "^2.0.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.16.0:
   version "6.21.0"


### PR DESCRIPTION
Adds `babel-plugin-transform-object-rest-spread` to transpile the object rest spread syntax that looks like this:

`const { a, b, c } = obj`.

## Test instructions
* Run `grunt publish`.
* Inspect `templates.js` in `dist/js` and make sure no object rest spread syntax is found.
* Also test in `wordpress-seo` by using yarn link on the `dist` folder and building wordpress-seo.