### PR TITLE
Copies json files when grunt publish is ran

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -44,6 +44,9 @@ module.exports = {
 		}, {
 			src: "LICENSE",
 			dest: "dist/",
+		}, {
+			src: "js/config/syllables/**/*.json",
+			dest: "dist/",
 		} ],
 	},
 };


### PR DESCRIPTION
Copy json files from the js folder to the dist folder when `grunt build` is ran.

## Test instructions
* Run `grunt publish`
* Inspect `dist` folder and see if the language files are there  (de.json, it.json, en.json and nl.json).