### PR TITLE
Add sentences research

### DIFF
--- a/src/researcher.js
+++ b/src/researcher.js
@@ -1,3 +1,5 @@
+import sentences from "./researches/sentences";
+
 var merge = require( "lodash/merge" );
 var InvalidTypeError = require( "./errors/invalidType" );
 var MissingArgument = require( "./errors/missingArgument" );
@@ -72,6 +74,7 @@ var Researcher = function( paper ) {
 		passiveVoice: passiveVoice,
 		getSentenceBeginnings: getSentenceBeginnings,
 		relevantWords: relevantWords,
+		sentences,
 	};
 
 	this.customResearches = {};

--- a/src/researches/sentences.ts
+++ b/src/researches/sentences.ts
@@ -1,0 +1,8 @@
+const getSentences = require( "../stringProcessing/getSentences" );
+
+/**
+ * @param {Paper} paper The paper to analyze.
+ */
+export default function( paper: any ) {
+    return getSentences( paper.getText() );
+}

--- a/tslint.json
+++ b/tslint.json
@@ -2,5 +2,8 @@
     "defaultSeverity": "error",
     "extends": [
         "tslint:recommended"
-    ]
+    ],
+    "rules": {
+        "no-var-requires": false
+    }
 }


### PR DESCRIPTION
I have disabled `no-var-requires` because it is not possible to use `import` with a file that uses `module.exports = `. To use `import` that file needs to actually do an `export`. Because `getSentences` doesn't do an `export` we have to use `require`. So for now lets disable `no-var-requires`.