### PR TITLE
Escape keyword in url and add spec

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
   "presets": [ "es2015" ],
-  "ignore": [
-    "js/templates.js",
-    "src/templates.js"
-  ]
+  "plugins": [ "transform-object-rest-spread" ],
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ script:
 - yarn lint
 - yarn test --coverage
 - grunt check
-after_script:
-- grunt publish
 after_success:
 - yarn global add codeclimate-test-reporter
 - codeclimate-test-reporter < coverage/lcov.info
+- grunt publish # Builds in dist folder
 # Deploy from dist folder, because this has the built version of YoastSEO.js
 before_deploy:
 - cd dist
@@ -28,6 +27,7 @@ notifications:
   slack:
     secure: W3StABr+AdcdQawTObK4nbsnn5nLrTTtZfVpD/GEN6gvSOQcykbGEC5+ceYg0jn5b4StDyCiTo5blEsrpVICFpYKc44+ogah+qaGRUfVRS/rpOvn4AueXTWn4JxhZzuxqKMiTmyW+MQG0uYM7sk7Q5S+15jj6ilkj4QATaBVNbY=
 deploy:
+  skip_cleanup: true
   provider: npm
   email: webmaster@yoast.com
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwards.
 
+## 1.23.0 October 31st, 2017
+* Errors now give a score of -1. `ScoreToRating` interpreter will convert `-1` to `error`. #1272
+* Adds `Excited` to exception -ed verbs for passive voice assessment. #1269
+* Adds `release` script to `.travis.yml` for publishing to npm. #1265
+* Adds a filter to exclude `code` tags and their enclosed content from the content analysis assessments. #1250
+* Adds a filter to exclude `pre` tags and their enclosed content from the content analysis assessments, props [chrisboo](https://github.com/chrisboo). #1258
+* Switches testing framework to `jest`. #1266
+
 ## 1.22.0 October 3rd, 2017
 * Added typescript support.
 * Add filter for exception words between auxiliary and passive participle.

--- a/grunt/config/babel.js
+++ b/grunt/config/babel.js
@@ -7,6 +7,7 @@ module.exports = {
 		} ],
 		options: {
 			sourceMap: true,
+			comments: true,
 		},
 	},
 };

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -44,6 +44,9 @@ module.exports = {
 		}, {
 			src: "LICENSE",
 			dest: "dist/",
+		}, {
+			src: "js/config/syllables/**/*.json",
+			dest: "dist/",
 		} ],
 	},
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "index.js",
   "license": "GPL-3.0",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Yoast/YoastSEO.js"
@@ -29,6 +29,9 @@
     "babel-jest": "^21.2.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "grunt-babel": "^7.0.0",
     "babelify": "^7.3.0",
     "eslint-config-yoast": "^2.0.2",
     "eslint-plugin-react": "^6.0.0",
@@ -59,8 +62,6 @@
     "url": "https://github.com/Yoast/js-text-analysis/issues"
   },
   "dependencies": {
-    "babel-core": "^6.26.0",
-    "grunt-babel": "^7.0.0",
     "htmlparser2": "^3.9.2",
     "jed": "^1.1.0",
     "jest": "^21.2.1",
@@ -92,6 +93,9 @@
     ],
     "testPathIgnorePatterns": [
       "/spec/helpers/factory.js"
+    ],
+    "coveragePathIgnorePatterns": [
+      "js/templates.js"
     ],
     "coverageThreshold": {
       "global": {

--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -33,6 +33,12 @@ describe( "checks for keyword doubles", function(){
 		expect( plugin.scoreAssessment( {id: 0, count: 0}, paper, i18n ).score ).toBe( 9 );
 		expect( plugin.scoreAssessment( {id: 0, count: 0}, paper, i18n ).text ).toBe( "You've never used this focus keyword before, very good." );
 	});
+
+	it("escapes the keyword's special characters in the url", function(){
+		var paper = new Paper( "text", { keyword: "keyword/bla"} );
+		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
+		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>, it's probably a good idea to read <a href='https://yoast.com/cornerstone-content-rank/' target='_blank'>this post on cornerstone content</a> and improve your keyword strategy." );
+	});
 });
 
 describe( "checks for keyword doubles", function(){

--- a/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/src/bundledPlugins/previouslyUsedKeywords.js
@@ -80,7 +80,7 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 		};
 	}
 	if ( count > 1 ) {
-		url = "<a href='" + this.searchUrl.replace( "{keyword}", paper.getKeyword() ) + "' target='_blank'>";
+		url = "<a href='" + this.searchUrl.replace( "{keyword}", encodeURIComponent( paper.getKeyword() ) ) + "' target='_blank'>";
 		return {
 			/* Translators: %1$s and $3$s expand to the admin search page for the focus keyword, %2$d expands to the number of times this focus
 			 keyword has been used before, %4$s and %5$s expand to a link to an article on yoast.com about cornerstone content */

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,7 +484,7 @@ babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -665,6 +665,13 @@ babel-plugin-transform-es2015-unicode-regex@^6.3.13:
     babel-helper-regex "^6.8.0"
     babel-runtime "^6.0.0"
     regexpu-core "^2.0.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.16.0:
   version "6.21.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Escapes the keyword in the url generated in the PreviouslyUsedKeywords assessment.

## Relevant technical choices:

* I used `encodeURIComponent` rather than `encodeURI` to make sure that forward slashes and other characters that can break an URL are escaped.

## Test instructions

This PR can be tested by following these steps:

* On line 84 of previouslyUsedKeywords.js, add `console.log(url);`
* Link yoastSEO.js to wordpress SEO. Don't forget to run grunt build.
* Create two posts with the same focus keyword. Make sure the focus keyword contains a special character, like a forward slash.
* Check whether the special character is escaped in the url in the console.
