### PR TITLE
Add Spanish stopwords

### DIFF
--- a/spec/assessments/urlStopWordsSpec.js
+++ b/spec/assessments/urlStopWordsSpec.js
@@ -40,6 +40,10 @@ describe( "Checks if the assessment is applicable", function() {
 		var paper = new Paper( "", {locale: "en_EN"} );
 		expect( stopWordsInUrlAssessment.isApplicable( paper )).toBe( true );
 	} );
+	it( "returns true for isApplicable for a Spanish paper", function() {
+		var paper = new Paper( "", {locale: "es_ES"} );
+		expect( stopWordsInUrlAssessment.isApplicable( paper )).toBe( true );
+	} );
 	it( "returns false for isApplicable for an Dutch paper", function() {
 		var paper = new Paper( "", {locale: "nl_NL"} );
 		expect( stopWordsInUrlAssessment.isApplicable( paper )).toBe( false );

--- a/spec/researches/stopWordsInTextSpecs.js
+++ b/spec/researches/stopWordsInTextSpecs.js
@@ -13,16 +13,16 @@ describe( "a test for finding stopwords from a string", function(){
 		expect( stopwordsFunction( "niets bijzonders", "en_US").length ).toBe( 0 );
 	});
 	it( "returns Spanish stopwords found in a string", function(){
-		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES" ) ).toContain( "este" );
-		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES" ) ).toContain( "un" );
-		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES" ) ).toContain( "sobre" );
-		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES").length ).toBe( 3 );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES", false ) ).toContain( "este" );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES", false ) ).toContain( "un" );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES", false ) ).toContain( "sobre" );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES", false ).length ).toBe( 3 );
 		expect( stopwordsFunction( "Nothing special", "es_ES").length ).toBe( 0 );
 	});
 	it( "returns Spanish stopwords with diacritics found in a string", function(){
-		expect( stopwordsFunction( "Aquí", "es_ES" ) ).toContain( "aquí" );
-		expect( stopwordsFunction( "Aquí", "es_ES" ) ).not.toContain( "aqui" );
-		expect( stopwordsFunction( "Aquí", "es_ES").length ).toBe( 1 );
+		expect( stopwordsFunction( "Aquí", "es_ES", false ) ).toContain( "aquí" );
+		expect( stopwordsFunction( "Aqui", "es_ES", false ) ).not.toContain( "aquí" );
+		expect( stopwordsFunction( "Aquí", "es_ES", false ).length ).toBe( 1 );
 	});
 	it( "returns English stopwords found in a string when no locale is specified", function(){
 		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "a" );

--- a/spec/researches/stopWordsInTextSpecs.js
+++ b/spec/researches/stopWordsInTextSpecs.js
@@ -2,11 +2,11 @@ var stopwordsFunction = require( "../../js/researches/stopWordsInText.js" );
 
 describe("a test for finding stopwords from a string", function(){
 	it("returns stopwords found in a string", function(){
-		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "a" );
-		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "about" );
-		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "this" );
-		expect( stopwordsFunction( "tell about yourself" ) ).toContain( "about" );
-		expect( stopwordsFunction( "tell about yourself" ) ).toContain( "yourself" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "a" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "about" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "this" );
+		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "about" );
+		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "yourself" );
 		expect( stopwordsFunction( "niets bijzonders").length ).toBe( 0 );
 	});
 });

--- a/spec/researches/stopWordsInTextSpecs.js
+++ b/spec/researches/stopWordsInTextSpecs.js
@@ -19,6 +19,11 @@ describe( "a test for finding stopwords from a string", function(){
 		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES").length ).toBe( 3 );
 		expect( stopwordsFunction( "Nothing special", "es_ES").length ).toBe( 0 );
 	});
+	it( "returns Spanish stopwords with diacritics found in a string", function(){
+		expect( stopwordsFunction( "Aquí", "es_ES" ) ).toContain( "aquí" );
+		expect( stopwordsFunction( "Aquí", "es_ES" ) ).not.toContain( "aqui" );
+		expect( stopwordsFunction( "Aquí", "es_ES").length ).toBe( 1 );
+	});
 	it( "returns English stopwords found in a string when no locale is specified", function(){
 		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "a" );
 		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "about" );

--- a/spec/researches/stopWordsInTextSpecs.js
+++ b/spec/researches/stopWordsInTextSpecs.js
@@ -1,26 +1,33 @@
 import stopwordsFunction from "../../js/researches/stopWordsInText.js";
 
-describe("a test for finding stopwords from a string", function(){
-	it("returns English stopwords found in a string", function(){
+describe( "a test for finding stopwords from a string", function(){
+	it( "returns English stopwords found in a string", function(){
 		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "a" );
 		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "about" );
 		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "this" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "is" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ).length ).toBe( 4 );
 		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "about" );
 		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "yourself" );
-		expect( stopwordsFunction( "niets bijzonders").length ).toBe( 0 );
+		expect( stopwordsFunction( "tell about yourself", "en_US").length ).toBe( 2 );
+		expect( stopwordsFunction( "niets bijzonders", "en_US").length ).toBe( 0 );
 	});
-	it("returns Spanish stopwords found in a string", function(){
+	it( "returns Spanish stopwords found in a string", function(){
 		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES" ) ).toContain( "este" );
 		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES" ) ).toContain( "un" );
 		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES" ) ).toContain( "sobre" );
-		expect( stopwordsFunction( "nada especial").length ).toBe( 0 );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES").length ).toBe( 3 );
+		expect( stopwordsFunction( "Nothing special", "es_ES").length ).toBe( 0 );
 	});
-	it("returns English stopwords found in a string when no locale is specified", function(){
+	it( "returns English stopwords found in a string when no locale is specified", function(){
 		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "a" );
-		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "about" );
-		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "this" );
-		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "about" );
-		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "yourself" );
-		expect( stopwordsFunction( "niets bijzonders").length ).toBe( 0 );
+		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "about" );
+		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "this" );
+		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "is" );
+		expect( stopwordsFunction( "this is a story about..." ).length ).toBe( 4 );
+		expect( stopwordsFunction( "tell about yourself" ) ).toContain( "about" );
+		expect( stopwordsFunction( "tell about yourself" ) ).toContain( "yourself" );
+		expect( stopwordsFunction( "tell about yourself" ).length ).toBe( 2 );
+		expect( stopwordsFunction( "niets bijzonders", ).length ).toBe( 0 );
 	});
 });

--- a/spec/researches/stopWordsInTextSpecs.js
+++ b/spec/researches/stopWordsInTextSpecs.js
@@ -1,8 +1,22 @@
-var stopwordsFunction = require( "../../js/researches/stopWordsInText.js" );
+import stopwordsFunction from "../../js/researches/stopWordsInText.js";
 
 describe("a test for finding stopwords from a string", function(){
-	it("returns stopwords found in a string", function(){
+	it("returns English stopwords found in a string", function(){
 		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "a" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "about" );
+		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "this" );
+		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "about" );
+		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "yourself" );
+		expect( stopwordsFunction( "niets bijzonders").length ).toBe( 0 );
+	});
+	it("returns Spanish stopwords found in a string", function(){
+		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES" ) ).toContain( "este" );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre...", "es_ES" ) ).toContain( "un" );
+		expect( stopwordsFunction( "Este paper es un esbozo sobre", "es_ES" ) ).toContain( "sobre" );
+		expect( stopwordsFunction( "nada especial").length ).toBe( 0 );
+	});
+	it("returns English stopwords found in a string when no locale is specified", function(){
+		expect( stopwordsFunction( "this is a story about..." ) ).toContain( "a" );
 		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "about" );
 		expect( stopwordsFunction( "this is a story about...", "en_US" ) ).toContain( "this" );
 		expect( stopwordsFunction( "tell about yourself", "en_US" ) ).toContain( "about" );

--- a/spec/researches/stopWordsInUrlSpec.js
+++ b/spec/researches/stopWordsInUrlSpec.js
@@ -2,11 +2,18 @@ var urlStopwords = require( "../../js/researches/stopWordsInUrl.js" );
 var Paper = require( "../../js/values/Paper.js" );
 
 describe( "Checks the URL for stopwords", function() {
-	it("returns any stopwords found", function() {
+	it("returns any English stopwords found", function() {
 		expect( urlStopwords( new Paper("Sample", { url: "before-and-after" }) ) ).toEqual( [ "after", "and", "before" ] );
 		expect( urlStopwords( new Paper("Sample", { url: "before-after" }) ) ).toEqual( [ "after", "before" ] );
 		expect( urlStopwords( new Paper("Sample", { url: "stopword-after" }) ) ).toEqual( [ "after" ] );
 		expect( urlStopwords( new Paper("Sample", { url: "stopword" }) ) ).toEqual( [  ] );
 		expect( urlStopwords( new Paper("Sample", { url: "" }) ) ).toEqual( [  ] );
+	});
+	it("returns any Spanish stopwords found", function() {
+		expect( urlStopwords( new Paper("Sample", { url: "una-nos-poco", locale: "es_ES" } ) ) ).toEqual( [ "una", "nos", "poco" ] );
+		expect( urlStopwords( new Paper("Sample", { url: "una-habra", locale: "es_ES" }) ) ).toEqual( [ "una", "habrá" ] );
+		expect( urlStopwords( new Paper("Sample", { url: "una", locale: "es_ES" }) ) ).toEqual( [ "una" ] );
+		expect( urlStopwords( new Paper("Sample", { url: "stopword", locale: "es_ES" }) ) ).toEqual( [  ] );
+		expect( urlStopwords( new Paper("Sample", { url: "", locale: "es_ES" }) ) ).toEqual( [  ] );
 	});
 });

--- a/src/assessments/seo/keywordStopWordsAssessment.js
+++ b/src/assessments/seo/keywordStopWordsAssessment.js
@@ -2,7 +2,7 @@ var AssessmentResult = require( "../../values/AssessmentResult.js" );
 
 var getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 
-var availableLanguages = [ "en" ];
+var availableLanguages = [ "en", "es" ];
 
 /**
  * Calculate the score based on the amount of stop words in the keyword.

--- a/src/assessments/seo/urlStopWordsAssessment.js
+++ b/src/assessments/seo/urlStopWordsAssessment.js
@@ -2,7 +2,7 @@ var AssessmentResult = require( "../../values/AssessmentResult.js" );
 
 var getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 
-var availableLanguages = [ "en" ];
+var availableLanguages = [ "en", "es" ];
 
 /**
  * Calculate the score based on the amount of stop words in the url.

--- a/src/config/stopwords.js
+++ b/src/config/stopwords.js
@@ -1,5 +1,4 @@
-let getLanguage = require( "../helpers/getLanguage.js" );
-let isUndefined = require( "lodash/isUndefined" );
+import getLanguage from "../helpers/getLanguage.js";
 
 let es = require( "./stopwords/es.json" ).stopwords;
 let en = require( './stopwords/en.json' ).stopwords;

--- a/src/config/stopwords.js
+++ b/src/config/stopwords.js
@@ -1,17 +1,3 @@
-/** @module config/stopwords */
-
-/**
- * Returns an array with stopwords to be used by the analyzer.
- *
- * @returns {Array} stopwords The array filled with stopwords.
- */
-/*module.exports = function() {
-	return [ "a", "about", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "could", "did", "do", "does", "doing", "down", "during", "each", "few", "for", "from", "further", "had", "has", "have", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "it", "it's", "its", "itself", "let's", "me", "more", "most", "my", "myself", "nor", "of", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "she", "she'd", "she'll", "she's", "should", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "we", "we'd", "we'll", "we're", "we've", "were", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "would", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves" ];
-};
-
-
-*/
-
 let getLanguage = require( "../helpers/getLanguage.js" );
 let isUndefined = require( "lodash/isUndefined" );
 

--- a/src/config/stopwords.js
+++ b/src/config/stopwords.js
@@ -5,6 +5,28 @@
  *
  * @returns {Array} stopwords The array filled with stopwords.
  */
-module.exports = function() {
+/*module.exports = function() {
 	return [ "a", "about", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "could", "did", "do", "does", "doing", "down", "during", "each", "few", "for", "from", "further", "had", "has", "have", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "it", "it's", "its", "itself", "let's", "me", "more", "most", "my", "myself", "nor", "of", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "she", "she'd", "she'll", "she's", "should", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "we", "we'd", "we'll", "we're", "we've", "were", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "would", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves" ];
+};
+
+
+*/
+
+let getLanguage = require( "../helpers/getLanguage.js" );
+let isUndefined = require( "lodash/isUndefined" );
+
+let es = require( "./stopwords/es.json" ).stopwords;
+let en = require( './stopwords/en.json' ).stopwords;
+
+let languages = { es, en };
+
+module.exports = function( locale = "en_US" ) {
+	let language = getLanguage( locale );
+
+	if( languages.hasOwnProperty( language ) ) {
+		return languages[ language ];
+	}
+
+	// If an unknown locale is used, default to English.
+	return languages[ "en" ];
 };

--- a/src/config/stopwords/en.json
+++ b/src/config/stopwords/en.json
@@ -1,0 +1,12 @@
+{
+	"stopwords": [ "a", "about", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "as", "at", "be", "because", "been",
+		"before", "being", "below", "between", "both", "but", "by", "could", "did", "do", "does", "doing", "down", "during", "each", "few", "for",
+		"from", "further", "had", "has", "have", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself",
+		"his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "it", "it's", "its", "itself", "let's", "me", "more",
+		"most", "my", "myself", "nor", "of", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own",
+		"same", "she", "she'd", "she'll", "she's", "should", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them",
+		"themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to",
+		"too", "under", "until", "up", "very", "was", "we", "we'd", "we'll", "we're", "we've", "were", "what", "what's", "when", "when's",
+		"where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "would", "you", "you'd", "you'll", "you're",
+		"you've", "your", "yours", "yourself", "yourselves" ]
+}

--- a/src/config/stopwords/es.json
+++ b/src/config/stopwords/es.json
@@ -18,5 +18,5 @@
 		"hubimos", "hubisteis", "hubieron", "había", "habías", "habíamos", "habíais", "habían", "habría", "habrías", "habría",
 		"habríamos", "habríais", "habrían", "habré", "habrás", "habrá", "habremos", "habréis", "habrán", "haya", "hayas", "hayamos",
 		"hayáis", "hayan", "hubiera", "hubieras", "hubiéramos", "hubierais", "hubieran", "hubiere", "hubieres", "hubiéremos",
-		"hubiereis", "hubieren", "al", "del" ]
+		"hubiereis", "hubieren", "al", "del", "sobre" ]
 }

--- a/src/config/stopwords/es.json
+++ b/src/config/stopwords/es.json
@@ -1,0 +1,22 @@
+{
+	"stopwords": [ "un", "una", "unas", "unos", "el", "la", "los", "las", "yo", "tú", "usted", "ella", "él", "ello", "nosotros", "nosotras",
+		"vosotros", "vosotras", "vos", "ustedes", "ellos", "ellas", "ud", "uds", "uno", "me", "te", "lo", "se", "nos", "os", "los",
+		"mí", "ti", "sí", "conmigo", "contigo", "consigo", "mismo", "misma", "mismos", "mismas", "mío", "mía", "míos", "mías",
+		"tuyo", "tuyos", "tuya", "tuyas", "suyo", "suya", "suyos", "suyas", "su", "sus", "mi", "mis", "tu", "tus", "nuestro",
+		"nuestra", "nuestros", "nuestras", "vuestro", "vuestros", "vuestra", "vuestras", "le", "les", "éste", "ésta", "esto",
+		"éstos", "éstas", "ése", "ésa", "eso", "ésos", "ésas", "aquél", "aquélla", "aquello", "aquéllos", "aquéllas", "este", "esta",
+		"estos", "estas", "ese", "esos", "esas", "aquel", "aquella", "aquellos", "aquellas", "que", "cual", "cuales", "quien", "quién",
+		"donde", "adonde", "como", "cuando", "cuyo", "cuyos", "cuya", "cuyas", "quienes", "alguien", "algo", "alguno", "alguna",
+		"algunos", "algunas", "nadie", "nada", "cualquiera", "cualesquiera", "cualquier", "ninguno", "ninguna", "muchos", "muchas",
+		"todos", "todas", "todo", "otro", "otra", "otros", "otras", "poco", "poca", "pocos", "pocas", "ambos", "mucho", "más",
+		"mas", "menos", "mayoría", "toda", "ningún", "ningunas", "ningunos", "cierto", "cierta", "ciertos", "ciertas", "cada",
+		"cades", "diferentes", "varios", "cuándo", "adónde", "dónde", "cuántos", "cuántas", "qué", "cómo", "cuál", "cuáles",
+		"si", "cuánto", "cuánta", "dondequiera", "aquí", "acá", "ahí", "allí", "allá", "estoy", "estás", "está", "estamos",
+		"estáis", "están", "estuve", "estuviste", "estuvo", "estuvimos", "estuvisteis", "estuvieron", "estaba", "estabas",
+		"estábamos", "estabais", "estaban", "estaría", "estarías", "estaríamos", "estaríais", "estarían", "estaré", "estarás",
+		"estará", "estaremos", "estaréis", "estarán", "he", "has", "ha", "hemos", "habéis", "han", "hube", "hubiste", "hubo",
+		"hubimos", "hubisteis", "hubieron", "había", "habías", "habíamos", "habíais", "habían", "habría", "habrías", "habría",
+		"habríamos", "habríais", "habrían", "habré", "habrás", "habrá", "habremos", "habréis", "habrán", "haya", "hayas", "hayamos",
+		"hayáis", "hayan", "hubiera", "hubieras", "hubiéramos", "hubierais", "hubieran", "hubiere", "hubieres", "hubiéremos",
+		"hubiereis", "hubieren", "al", "del" ]
+}

--- a/src/researches/stopWordsInKeyword.js
+++ b/src/researches/stopWordsInKeyword.js
@@ -1,8 +1,7 @@
 /** @module researches/stopWordsInKeyword */
 
-var stopWordsInText = require( "./stopWordsInText.js" );
-
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import stopWordsInText from  "./stopWordsInText.js";
+import escapeRegExp from "lodash/escapeRegExp";
 
 /**
  * Checks for the amount of stop words in the keyword.

--- a/src/researches/stopWordsInKeyword.js
+++ b/src/researches/stopWordsInKeyword.js
@@ -10,6 +10,7 @@ var escapeRegExp = require( "lodash/escapeRegExp" );
  * @returns {Array} All the stopwords that were found in the keyword.
  */
 module.exports = function( paper ) {
-	var keyword = escapeRegExp( paper.getKeyword() );
-	return stopWordsInText( keyword );
+	let locale = paper.getLocale();
+	let keyword = escapeRegExp( paper.getKeyword() );
+	return stopWordsInText( keyword, locale );
 };

--- a/src/researches/stopWordsInKeyword.js
+++ b/src/researches/stopWordsInKeyword.js
@@ -11,5 +11,5 @@ import escapeRegExp from "lodash/escapeRegExp";
 module.exports = function( paper ) {
 	let locale = paper.getLocale();
 	let keyword = escapeRegExp( paper.getKeyword() );
-	return stopWordsInText( keyword, locale );
+	return stopWordsInText( keyword, locale, false );
 };

--- a/src/researches/stopWordsInText.js
+++ b/src/researches/stopWordsInText.js
@@ -6,14 +6,15 @@ import toRegex from "../stringProcessing/createWordRegex.js";
  *
  * @param {string} text The input text to match stopwords.
  * @param {string} locale The text's locale.
+ * @param {boolean} replaceDiacritics True if diacritics should be replaced.
  * @returns {Array} An array with all stopwords found in the text.
  */
-module.exports = function( text, locale ) {
+module.exports = function( text, locale, replaceDiacritics ) {
 	let stopwordList = stopwords( locale );
 	let i, matches = [];
 
 	for ( i = 0; i < stopwordList.length; i++ ) {
-		if ( text.match( toRegex( stopwordList[ i ], "", false ) ) !== null ) {
+		if ( text.match( toRegex( stopwordList[ i ], "", replaceDiacritics ) ) !== null ) {
 			matches.push( stopwordList[ i ] );
 		}
 	}

--- a/src/researches/stopWordsInText.js
+++ b/src/researches/stopWordsInText.js
@@ -1,5 +1,5 @@
-let stopwords = require( "../config/stopwords.js" );
-let toRegex = require( "../stringProcessing/createWordRegex.js" );
+import stopwords from "../config/stopwords.js";
+import toRegex from "../stringProcessing/createWordRegex.js";
 
 /**
  * Checks a text to see if there are any stopwords, that are defined in the stopwords config.

--- a/src/researches/stopWordsInText.js
+++ b/src/researches/stopWordsInText.js
@@ -1,18 +1,20 @@
-var stopwords = require( "../config/stopwords.js" )();
-var toRegex = require( "../stringProcessing/createWordRegex.js" );
+let stopwords = require( "../config/stopwords.js" );
+let toRegex = require( "../stringProcessing/createWordRegex.js" );
 
 /**
  * Checks a text to see if there are any stopwords, that are defined in the stopwords config.
  *
  * @param {string} text The input text to match stopwords.
+ * @param {string} locale The text's locale.
  * @returns {Array} An array with all stopwords found in the text.
  */
-module.exports = function( text ) {
-	var i, matches = [];
+module.exports = function( text, locale ) {
+	let stopwordList = stopwords( locale );
+	let i, matches = [];
 
-	for ( i = 0; i < stopwords.length; i++ ) {
-		if ( text.match( toRegex( stopwords[ i ] ) ) !== null ) {
-			matches.push( stopwords[ i ] );
+	for ( i = 0; i < stopwordList.length; i++ ) {
+		if ( text.match( toRegex( stopwordList[ i ] ) ) !== null ) {
+			matches.push( stopwordList[ i ] );
 		}
 	}
 

--- a/src/researches/stopWordsInText.js
+++ b/src/researches/stopWordsInText.js
@@ -13,10 +13,9 @@ module.exports = function( text, locale ) {
 	let i, matches = [];
 
 	for ( i = 0; i < stopwordList.length; i++ ) {
-		if ( text.match( toRegex( stopwordList[ i ] ) ) !== null ) {
+		if ( text.match( toRegex( stopwordList[ i ], "", false ) ) !== null ) {
 			matches.push( stopwordList[ i ] );
 		}
 	}
-
 	return matches;
 };

--- a/src/researches/stopWordsInUrl.js
+++ b/src/researches/stopWordsInUrl.js
@@ -8,5 +8,6 @@ var stopWordsInText = require( "./stopWordsInText.js" );
  * @returns {Array} stopwords found in URL
  */
 module.exports = function( paper ) {
-	return stopWordsInText( paper.getUrl().replace( /[-_]/g, " " ) );
+	let locale = paper.getLocale();
+	return stopWordsInText( paper.getUrl().replace( /[-_]/g, " " ), locale );
 };

--- a/src/researches/stopWordsInUrl.js
+++ b/src/researches/stopWordsInUrl.js
@@ -9,5 +9,5 @@ var stopWordsInText = require( "./stopWordsInText.js" );
  */
 module.exports = function( paper ) {
 	let locale = paper.getLocale();
-	return stopWordsInText( paper.getUrl().replace( /[-_]/g, " " ), locale );
+	return stopWordsInText( paper.getUrl().replace( /[-_]/g, " " ), locale, true );
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Add Spanish support for the stopWordsInUrl and stopWordsInKeyword assessment. Props Luis Benítez.

## Relevant technical choices: Adds support for the urlStopWordsAssessment and keywordStopWordsAssessment for Spanish.

* Add Spanish stopwords list
* I've used the same structure as is used for the syllable count/Flesch Reading: a helper function that provides the research with the correct stopwords list (`src/config/stopwords.js`) and json files with word list in config folder (`src/config/stopwords/en.json` and `es.json`)
* Add Spanish support for the keywordStopWordsAssessment and urlStopWordsAssessment


## Test instructions

This PR can be tested by following these steps:

* Link this branch to your local WordPress install. Don't forget to run a `grunt build:js`.
* Set the site language to Spanish. 
* Create a post with a focus keyword containing one or more of the words from `es.json`.
* Put also one of the stopwords in the slug of the post.
* Check whether the following two bullets are shown:
<img width="606" alt="schermafbeelding_2017-11-10_om_14_58_11" src="https://user-images.githubusercontent.com/17744553/32662499-13b8cbba-c62b-11e7-92b2-ad04b6511d53.png">

* Repeat the above steps for English to check I didn't break anything for English.
* Repeat the above steps for another locale. The above bullet should not show up, even when you are using English/Spanish stop words.

Fixes #1280
