### PR TITLE
Change feedback for meta description length assessment

### DIFF
--- a/languages/yoast-seo.pot
+++ b/languages/yoast-seo.pot
@@ -303,7 +303,7 @@ msgid ""
 msgstr ""
 
 #: js/assessments/seo/metaDescriptionLengthAssessment.js:56
-msgid "The length of the meta description is sufficient."
+msgid "The meta description has a nice length."
 msgstr ""
 
 #: js/assessments/seo/outboundLinksAssessment.js:48

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -35,6 +35,6 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "The length of the meta description is sufficient." );
+		expect( assessment.getText() ).toEqual ( "The meta description has a nice length." );
 	} );
 } );

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -103,7 +103,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 		}
 
 		if ( descriptionLength >= this._config.recommendedMaximumLength && descriptionLength <= this._config.maximumLength ) {
-			return i18n.dgettext( "js-text-analysis", "The length of the meta description is sufficient." );
+			return i18n.dgettext( "js-text-analysis", "The meta description has a nice length." );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: The feedback string for a good meta description length has been changed from `The length of the meta description is sufficient.` to `The meta description has a nice length.`

## Test instructions

This PR can be tested by following these steps:

* Use the browserified example. Don't forget to run `grunt build:js`.
* Enter a meta description that's long enough to get a good score.
* Make sure the right feedback is displayed.


Fixes #1306
