### PR TITLE
Adds a link to yoa.st/headings in the readability analysis

### DIFF
--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -23,7 +23,7 @@ describe( "An assessment for scoring too long text fragments following a subhead
 	it ( "returns score 2 for no subheadings", function() {
 		let assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [] ), i18n );
 		expect( assessment.getScore() ).toBe( 2 );
-		expect( assessment.getText() ).toBe( "The text does not contain any subheadings. Add at least one subheading." );
+		expect( assessment.getText() ).toBe( "The text does not contain any <a href='https://yoa.st/headings' target='_blank'>subheadings</a>. Add at least one subheading." );
 	} );
 	it ( "returns score 3 for a text fragment over 350 words", function() {
 		let assessment = subheadingDistributionTooLong.getResult( paper, Factory.buildMockResearcher( [ {text: "", wordCount: 60},  {text: "", wordCount: 400}, {text: "", wordCount: 300} ] ), i18n );

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -150,10 +150,14 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 */
 	translateScore( score, tooLongTexts, i18n ) {
 		if ( score === 2 ) {
-			return i18n.dgettext(
-				"js-text-analysis",
-				"The text does not contain any subheadings. Add at least one subheading."
-			);
+            return i18n.sprintf(
+                i18n.dgettext(
+                	"js-text-analysis",
+					"The text does not contain any %1$ssubheadings%2$s. Add at least one subheading."
+				),
+				"<a href='https://yoa.st/headings' target='_blank'>",
+				"</a>"
+            );
 		}
 
 		if ( score >= 7 ) {

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -150,6 +150,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 */
 	translateScore( score, tooLongTexts, i18n ) {
 		if ( score === 2 ) {
+			// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
 			return i18n.sprintf(
 				i18n.dgettext(
 					"js-text-analysis",

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -150,14 +150,14 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 */
 	translateScore( score, tooLongTexts, i18n ) {
 		if ( score === 2 ) {
-            return i18n.sprintf(
-                i18n.dgettext(
-                	"js-text-analysis",
+			return i18n.sprintf(
+				i18n.dgettext(
+					"js-text-analysis",
 					"The text does not contain any %1$ssubheadings%2$s. Add at least one subheading."
 				),
 				"<a href='https://yoa.st/headings' target='_blank'>",
 				"</a>"
-            );
+			);
 		}
 
 		if ( score >= 7 ) {


### PR DESCRIPTION
For the readability check 'The text does not contain any subheadings.' the following link: https://yoa.st/headings has been added.

Fixes https://github.com/Yoast/wordpress-seo/issues/7247
