### PR TITLE
Change upper boundary of meta description length to 320

### DIFF
--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -19,7 +19,7 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters long. However, up to 330 characters are available." );
+		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters long. However, up to 320 characters are available." );
 	} );
 
 	it( "assesses a too long description", function(){
@@ -27,7 +27,7 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The meta description is over 330 characters. Reducing the length will ensure the entire description will be visible." );
+		expect( assessment.getText() ).toEqual ( "The meta description is over 320 characters. Reducing the length will ensure the entire description will be visible." );
 	} );
 
 	it( "assesses a good description", function(){

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -19,15 +19,15 @@ describe( "An descriptionLength assessment", function(){
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters long. However, up to 156 characters are available." );
+		expect( assessment.getText() ).toEqual ( "The meta description is under 120 characters long. However, up to 330 characters are available." );
 	} );
 
 	it( "assesses a too long description", function(){
 		var mockPaper = new Paper();
-		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 200 ), i18n );
+		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "The meta description is over 156 characters. Reducing the length will ensure the entire description will be visible." );
+		expect( assessment.getText() ).toEqual ( "The meta description is over 330 characters. Reducing the length will ensure the entire description will be visible." );
 	} );
 
 	it( "assesses a good description", function(){

--- a/spec/snippetPreviewSpec.js
+++ b/spec/snippetPreviewSpec.js
@@ -35,7 +35,7 @@ describe( "The SnippetPreview format functions", function(){
 			rawData: {
 				snippetTitle: "<span>snippetTitle keyword</span>",
 				snippetCite: "homeurl",
-				snippetMeta: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ultricies placerat nisl, in tempor ligula. Pellentesque in risus non quam maximus maximus sed a dui. In sed.",
+				snippetMeta: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et dapibus dictum. Duis imperdiet nisl id orci hendrerit imperdiet. Praesent commodo ornare ante vitae placerat. Aliquam leo justo, imperdiet ut purus at, pharetra semper eros. In cursus faucibus efficitur.",
 				keyword: "keyword"
 			},
 			pluggable: {
@@ -50,7 +50,7 @@ describe( "The SnippetPreview format functions", function(){
 		});
 
 		expect( snippetPreview.formatTitle() ).toBe( "snippetTitle keyword" );
-		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ultricies placerat nisl, in tempor ligula. Pellentesque in risus non quam maximus maximus sed " );
+		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et dapibus dictum. Duis imperdiet nisl id orci hendrerit imperdiet. Praesent commodo ornare ante vitae placerat. Aliquam leo justo, imperdiet ut purus at, pharetra semper eros. In" );
 		expect( snippetPreview.formatCite() ).toBe( "homeurl/" );
 		expect( snippetPreview.formatKeyword( "a string with keyword" ) ).toBe( "a string with<strong> keyword</strong>" );
 

--- a/spec/snippetPreviewSpec.js
+++ b/spec/snippetPreviewSpec.js
@@ -50,7 +50,7 @@ describe( "The SnippetPreview format functions", function(){
 		});
 
 		expect( snippetPreview.formatTitle() ).toBe( "snippetTitle keyword" );
-		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et dapibus dictum. Duis imperdiet nisl id orci hendrerit imperdiet. Praesent commodo ornare ante vitae placerat. Aliquam leo justo, imperdiet ut purus at, pharetra semper eros. In" );
+		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et dapibus dictum. Duis imperdiet nisl id orci hendrerit imperdiet. Praesent commodo ornare ante vitae placerat. Aliquam leo justo, imperdiet ut purus at, pharetra sempe" );
 		expect( snippetPreview.formatCite() ).toBe( "homeurl/" );
 		expect( snippetPreview.formatKeyword( "a string with keyword" ) ).toBe( "a string with<strong> keyword</strong>" );
 

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -19,7 +19,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 
 		let defaultConfig = {
 			recommendedMaximumLength: 120,
-			maximumLength: 156,
+			maximumLength: 330,
 			scores: {
 				noMetaDescription: 1,
 				tooLong: 6,

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -19,7 +19,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 
 		let defaultConfig = {
 			recommendedMaximumLength: 120,
-			maximumLength: 330,
+			maximumLength: 320,
 			scores: {
 				noMetaDescription: 1,
 				tooLong: 6,

--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -48,7 +48,7 @@ var defaults = {
 };
 
 var titleMaxLength = 600;
-var metadescriptionMaxLength = 156;
+var metadescriptionMaxLength = 330;
 
 var inputPreviewBindings = [
 	{
@@ -177,12 +177,12 @@ function rateMetaDescLength( metaDescLength ) {
 	var rating;
 
 	switch ( true ) {
-		case metaDescLength > 0 && metaDescLength <= 120:
-		case metaDescLength >= 157:
+		case metaDescLength > 0 && metaDescLength < 120:
+		case metaDescLength >= 330:
 			rating = "ok";
 			break;
 
-		case metaDescLength >= 120 && metaDescLength <= 157:
+		case metaDescLength >= 120 && metaDescLength < 330:
 			rating = "good";
 			break;
 
@@ -679,7 +679,7 @@ SnippetPreview.prototype.formatMeta = function() {
 
 /**
  * Generates a meta description with an educated guess based on the passed text and excerpt. It uses the keyword to
- * select an appropriate part of the text. If the keyword isn't present it takes the first 156 characters of the text.
+ * select an appropriate part of the text. If the keyword isn't present it takes the first 330 characters of the text.
  * If both the keyword, text and excerpt are empty this function returns the sample text.
  *
  * @returns {string} A generated meta description.

--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -48,7 +48,7 @@ var defaults = {
 };
 
 var titleMaxLength = 600;
-var metadescriptionMaxLength = 330;
+var metadescriptionMaxLength = 320;
 
 var inputPreviewBindings = [
 	{
@@ -178,11 +178,11 @@ function rateMetaDescLength( metaDescLength ) {
 
 	switch ( true ) {
 		case metaDescLength > 0 && metaDescLength < 120:
-		case metaDescLength >= 330:
+		case metaDescLength > 320:
 			rating = "ok";
 			break;
 
-		case metaDescLength >= 120 && metaDescLength < 330:
+		case metaDescLength >= 120 && metaDescLength <= 320:
 			rating = "good";
 			break;
 
@@ -679,7 +679,7 @@ SnippetPreview.prototype.formatMeta = function() {
 
 /**
  * Generates a meta description with an educated guess based on the passed text and excerpt. It uses the keyword to
- * select an appropriate part of the text. If the keyword isn't present it takes the first 330 characters of the text.
+ * select an appropriate part of the text. If the keyword isn't present it takes the first 320 characters of the text.
  * If both the keyword, text and excerpt are empty this function returns the sample text.
  *
  * @returns {string} A generated meta description.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: The upper boundary of the meta description length has been changed to 320 characters.

## Test instructions

This PR can be tested by following these steps:

* Link this PR to your local Yoast SEO install by running `yarn link`.
* Make sure to build the JS files by running grunt `build:js`.
* Create a post with a meta description with a length of 120 - 320 characters. Make sure you get `good` as feedback.
* Create a post with a meta description with more than 320 characters. Make sure you get `improvement` as feedback.

Fixes #1337 
