### PR TITLE
Change feedback text for previously used keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwa
 
 ## 1.28.0 December 18th, 2017
 ### Changed
-* Include the link to the post about using your focus keyword multiple times also to the feedback text that is shown when using a focus keyword twice. 
-* Change the anchor text of the link to the post about using your focus keyword multiple times to a more accessible one.
+* Includes the link to the post about using your focus keyword multiple times also to the feedback text that is shown when using a focus keyword twice. 
+* Changes the anchor text of the link to the post about using your focus keyword multiple times to a more accessible one.
 
 ## 1.27.0 December 15th, 2017
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwards.
 
+## 1.28.0 December 18th, 2017
+### Changed
+* Include the link to the post about using your focus keyword multiple times also to the feedback text that is shown when using a focus keyword twice. 
+* Change the anchor text of the link to the post about using your focus keyword multiple times to a more accessible one.
+
 ## 1.27.0 December 15th, 2017
 ### Changed
 * The upper boundary of the meta description length has been changed from 156 to 320 characters.
 
 ## 1.26.0 December 13th, 2017
 ### Changed
-
 * Updates the copy for the `previouslyUsedKeywords` assessment by referring to a new blogpost on why it might be a bad idea to use the same keyword more than once.
 
 ## 1.25.0 December 11th, 2017

--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -24,11 +24,10 @@ describe( "checks for keyword doubles", function(){
 
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
 		expect( plugin.scoreAssessment( {id: 1, count: 1}, paper, i18n ).score ).toBe( 6 );
-		expect( plugin.scoreAssessment( {id: 1, count: 1}, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://post?1' target='_blank'>once before</a>, " +
-			"be sure to make very clear which URL on your site is the most important for this keyword." );
+		expect( plugin.scoreAssessment( {id: 1, count: 1}, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://post?1' target='_blank'>once before</a>. It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 
 		expect( plugin.scoreAssessment( {id: 1, count: 2}, paper, i18n ).score ).toBe( 1 );
-		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword' target='_blank'>2 times before</a>. It’s probably a good idea to read <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>this post</a> about why you should not use your focus keyword more than once." );
+		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword' target='_blank'>2 times before</a>. It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 
 		expect( plugin.scoreAssessment( {id: 0, count: 0}, paper, i18n ).score ).toBe( 9 );
 		expect( plugin.scoreAssessment( {id: 0, count: 0}, paper, i18n ).text ).toBe( "You've never used this focus keyword before, very good." );
@@ -37,7 +36,7 @@ describe( "checks for keyword doubles", function(){
 	it("escapes the keyword's special characters in the url", function(){
 		var paper = new Paper( "text", { keyword: "keyword/bla"} );
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
-		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. It’s probably a good idea to read <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>this post</a> about why you should not use your focus keyword more than once." );
+		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 	});
 });
 

--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -24,10 +24,12 @@ describe( "checks for keyword doubles", function(){
 
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
 		expect( plugin.scoreAssessment( {id: 1, count: 1}, paper, i18n ).score ).toBe( 6 );
-		expect( plugin.scoreAssessment( {id: 1, count: 1}, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://post?1' target='_blank'>once before</a>. It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
+		expect( plugin.scoreAssessment( {id: 1, count: 1}, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://post?1' target='_blank'>once before</a>. " +
+			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 
 		expect( plugin.scoreAssessment( {id: 1, count: 2}, paper, i18n ).score ).toBe( 1 );
-		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword' target='_blank'>2 times before</a>. It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
+		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword' target='_blank'>2 times before</a>. " +
+			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 
 		expect( plugin.scoreAssessment( {id: 0, count: 0}, paper, i18n ).score ).toBe( 9 );
 		expect( plugin.scoreAssessment( {id: 0, count: 0}, paper, i18n ).text ).toBe( "You've never used this focus keyword before, very good." );
@@ -36,7 +38,8 @@ describe( "checks for keyword doubles", function(){
 	it("escapes the keyword's special characters in the url", function(){
 		var paper = new Paper( "text", { keyword: "keyword/bla"} );
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
-		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
+		expect( plugin.scoreAssessment({id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. " +
+			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 	});
 });
 

--- a/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/src/bundledPlugins/previouslyUsedKeywords.js
@@ -73,9 +73,11 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 	if( count === 1 ) {
 		var url = "<a href='" + this.postUrl.replace( "{id}", id ) + "' target='_blank'>";
 		return {
-			/* Translators: %1$s and %2$s expand to an admin link where the focus keyword is already used */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "You've used this focus keyword %1$sonce before%2$s, " +
-				"be sure to make very clear which URL on your site is the most important for this keyword." ), url, "</a>" ),
+			/* Translators: %1$s and %2$s expand to an admin link where the focus keyword is already used. %3$s and %4$s
+			expand to a link to an article on yoast.com about why you should not use a keyword more than once. */
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "You've used this focus keyword %1$sonce before%2$s. " +
+				"It’s probably a good idea to read about %3$swhy you should not use your focus keyword more than once%4$s." ),
+				url, "</a>",  "<a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>", "</a>" ),
 			score: 6,
 		};
 	}
@@ -86,7 +88,7 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 			of times this focus keyword has been used before, %4$s and %5$s expand to a link to an article on yoast.com
 			about why you should not use a keyword more than once. */
 			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "You've used this focus keyword %1$s%2$d times before%3$s. " +
-				"It’s probably a good idea to read %4$sthis post%5$s about why you should not use your focus keyword more than once." ),
+				"It’s probably a good idea to read about %4$swhy you should not use your focus keyword more than once%5$s." ),
 				url, count, "</a>", "<a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>", "</a>" ),
 			score: 1,
 		};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: 
* Include the link to the post about using your focus keyword multiple times also to the feedback text that is shown when using a focus keyword twice. 
* Change the anchor text of the link to the post about using your focus keyword multiple times to a more accessible one.