### PR TITLE
Prevent redundant refreshing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -492,6 +492,11 @@ App.prototype.getData = function() {
  * @returns {void}
  */
 App.prototype.refresh = function() {
+	// Until all plugins are loaded, do not trigger a refresh.
+	if ( ! this.pluggable.loaded ) {
+		return;
+	}
+
 	this._pureRefresh();
 };
 

--- a/src/app.js
+++ b/src/app.js
@@ -713,7 +713,7 @@ App.prototype.modifyData = function( data ) {
 App.prototype.pluginsLoaded = function() {
 	this.getData();
 	this.removeLoadingDialog();
-	this.runAnalyzer();
+	this.refresh();
 };
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -714,7 +714,6 @@ App.prototype.modifyData = function( data ) {
  * @returns {void}
  */
 App.prototype.pluginsLoaded = function() {
-	this.getData();
 	this.removeLoadingDialog();
 	this.refresh();
 };

--- a/src/app.js
+++ b/src/app.js
@@ -281,8 +281,6 @@ var App = function( args ) {
 	}
 	this.initSnippetPreview();
 	this.initAssessorPresenters();
-
-	this.refresh();
 };
 
 /**


### PR DESCRIPTION
## Summary

Please note that this PR does not resolve any duplicate render calls on the `Results.render` method as should have been described in the original issue.

This PR can be summarized in the following changelog entry:

* Reduce the number of refreshing the analysis on page load. 

## Relevant technical choices:

* Only refresh the analysis when all YoastSEO.js plugins have been loaded.
* Always use the debounced version of the refresh function instead of using the runAnalyzer on plugins loaded.


## Test instructions

This PR can be tested by following these steps:

* Load a page or post and see that the analysis is being done as expected

Fixes https://github.com/Yoast/wordpress-seo/issues/8399
