### PR TITLE
Added protocol check to determine whether link is relative

### DIFF
--- a/spec/stringProcessing/linkTypeSpec.js
+++ b/spec/stringProcessing/linkTypeSpec.js
@@ -1,14 +1,52 @@
 var linkTypeFunction = require( "../../js/stringProcessing/getLinkType.js" );
 
-describe( "checks type of link", function(){
+describe( "getLinkType", function(){
+
 	it( "should classify relative links as internal", function() {
-		expect( linkTypeFunction( "<a href='http://example.org/'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
-		expect( linkTypeFunction( "<a href='http://example.org/some-path?query_args#hash'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+		expect( linkTypeFunction( "<a href='another-path'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify relative links with query params as internal", function() {
+		expect( linkTypeFunction( "<a href='another-path?test=123&another=abc'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify relative links with empty query params as internal", function() {
+		expect( linkTypeFunction( "<a href='another-path?test=&another='>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify relative links with fragments as internal", function() {
+		expect( linkTypeFunction( "<a href='another-path#subheader'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify absolute links without host as internal", function() {
+		expect( linkTypeFunction( "<a href='/some-path'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
 	});
 
-	it( "returns linktype", function(){
-		expect( linkTypeFunction( "<a href='http://yoast.com'>A link</a>", "http://yoast.com" ) ).toBe( "internal" );
-		expect( linkTypeFunction( "<a href='http://yoast.com'>A link</a>", "http://example.com" ) ).toBe( "external" );
-		expect( linkTypeFunction( "<a href='ftp://yoast.com'>A link</a>", "http://yoast.com" ) ).toBe( "other" );
+	it( "should classify absolute links without host with query params as internal", function() {
+		expect( linkTypeFunction( "<a href='/some-path?test=123'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	});
+
+	it( "should classify absolute links without host with a fragment as internal", function() {
+		expect( linkTypeFunction( "<a href='/some-path#subheader'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	});
+
+	it( "should classify absolute links without host with query params and fragment as internal", function() {
+		expect( linkTypeFunction( "<a href='/some-path?test=123#subheader'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	});
+
+	it( "should classify absolute links as internal", function() {
+		expect( linkTypeFunction( "<a href='http://yoast.com'>Internal</a>", "http://yoast.com" ) ).toBe( "internal" );
+	});
+
+	it( "should classify absolute links with a different host as external", function() {
+		expect( linkTypeFunction( "<a href='http://yoast.com'>Internal</a>", "http://example.com" ) ).toBe( "external" );
+	});
+
+	it( "should classify absolute links with ftp protocol as other", function() {
+		expect( linkTypeFunction( "<a href='ftp://yoast.com'>Internal</a>", "http://yoast.com" ) ).toBe( "other" );
+	});
+
+	it( "should classify absolute relative fragment URLs as other", function() {
+		expect( linkTypeFunction( "<a href='#subheader'>Internal</a>", "http://yoast.com" ) ).toBe( "other" );
 	});
 });

--- a/spec/stringProcessing/linkTypeSpec.js
+++ b/spec/stringProcessing/linkTypeSpec.js
@@ -6,6 +6,22 @@ describe( "getLinkType", function(){
 		expect( linkTypeFunction( "<a href='another-path'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
 	} );
 
+	it( "should classify relative links with double-dot notation as internal", function () {
+		expect( linkTypeFunction( "<a href='../another-path'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify relative links with single-dot notation as internal", function () {
+		expect( linkTypeFunction( "<a href='./another-path'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify relative links with multiple directories as internal", function() {
+		expect( linkTypeFunction( "<a href='another-path/directory'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
+	it( "should classify relative links with double-dot notation and multiple directories as internal", function() {
+		expect( linkTypeFunction( "<a href='../another-path/directory'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
+	} );
+
 	it( "should classify relative links with query params as internal", function() {
 		expect( linkTypeFunction( "<a href='another-path?test=123&another=abc'>Internal</a>", "http://example.org" ) ).toBe( "internal" );
 	} );
@@ -46,7 +62,7 @@ describe( "getLinkType", function(){
 		expect( linkTypeFunction( "<a href='ftp://yoast.com'>Internal</a>", "http://yoast.com" ) ).toBe( "other" );
 	});
 
-	it( "should classify absolute relative fragment URLs as other", function() {
+	it( "should classify relative fragment URLs as other", function() {
 		expect( linkTypeFunction( "<a href='#subheader'>Internal</a>", "http://yoast.com" ) ).toBe( "other" );
 	});
 });

--- a/spec/stringProcessing/urlSpec.js
+++ b/spec/stringProcessing/urlSpec.js
@@ -202,4 +202,33 @@ describe( "A URL helper", function() {
 			expect( actual ).toBe( expected );
 		} );
 	} );
+
+	describe( "isRelativeFragmentURL", function() {
+		it( "recognizes a relative fragment URL", function() {
+			const urlA = "#relative-fragment-url";
+			const expected = true;
+
+			const actual = url.isRelativeFragmentURL( urlA );
+
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "returns false on a non-relative fragment url", function() {
+			const urlA = "http://www.google.nl/#relative-fragment-url";
+			const expected = false;
+
+			const actual = url.isRelativeFragmentURL( urlA );
+
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "returns false on a regular url", function() {
+			const urlA = "http://www.google.nl/";
+			const expected = false;
+
+			const actual = url.isRelativeFragmentURL( urlA );
+
+			expect( actual ).toBe( expected );
+		} );
+	} );
 });

--- a/spec/stringProcessing/urlSpec.js
+++ b/spec/stringProcessing/urlSpec.js
@@ -163,7 +163,7 @@ describe( "A URL helper", function() {
 			expect( actual ).toBe( expected );
 		} );
 
-		it( "should identify a relative url", function() {
+		it( "should identify a relative url as an internal link", function() {
 			const urlA = "test/abc";
 			const host = "www.google.nl";
 			const expected = true;
@@ -173,7 +173,7 @@ describe( "A URL helper", function() {
 			expect( actual ).toBe( expected );
 		} );
 
-		it( "should identify a link as external with host", function() {
+		it( "should identify a link as external when it contains a different origin", function() {
 			const urlA = "http://www.google.nl";
 			const host = "www.abc.nl";
 			const expected = false;

--- a/spec/stringProcessing/urlSpec.js
+++ b/spec/stringProcessing/urlSpec.js
@@ -173,6 +173,16 @@ describe( "A URL helper", function() {
 			expect( actual ).toBe( expected );
 		} );
 
+		it( "should identify a relative url with double-dot notation as an internal link", function() {
+			const urlA = "../test/abc";
+			const host = "www.google.nl";
+			const expected = true;
+
+			const actual = url.isInternalLink( urlA, host );
+
+			expect( actual ).toBe( expected );
+		} );
+
 		it( "should identify a link as external when it contains a different origin", function() {
 			const urlA = "http://www.google.nl";
 			const host = "www.abc.nl";

--- a/spec/stringProcessing/urlSpec.js
+++ b/spec/stringProcessing/urlSpec.js
@@ -1,4 +1,4 @@
-var url = require( "../../js/stringProcessing/url" );
+var url = require( "../../src/stringProcessing/url" );
 
 describe( "A URL helper", function() {
 	describe( "removeHash", function() {
@@ -142,22 +142,64 @@ describe( "A URL helper", function() {
 		});
 	});
 
-	describe( "getProtocol", function() {
-		it( "should return the protocol of the URL", function() {
-			const urlA = "http://ww.google.nl";
-			const expected = "http://";
+	describe( "isInternalLink", function() {
+		it( "should identify an absolute internal link with host", function() {
+			const urlA = "http://www.google.nl";
+			const host = "www.google.nl";
+			const expected = true;
 
-			const actual = url.getProtocol( urlA );
+			const actual = url.isInternalLink( urlA, host );
 
 			expect( actual ).toBe( expected );
 		} );
 
+		it( "should identify an absolute internal link without host", function() {
+			const urlA = "/test/abc";
+			const host = "www.google.nl";
+			const expected = true;
+
+			const actual = url.isInternalLink( urlA, host );
+
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "should identify a relative url", function() {
+			const urlA = "test/abc";
+			const host = "www.google.nl";
+			const expected = true;
+
+			const actual = url.isInternalLink( urlA, host );
+
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "should identify a link as external with host", function() {
+			const urlA = "http://www.google.nl";
+			const host = "www.abc.nl";
+			const expected = false;
+
+			const actual = url.isInternalLink( urlA, host );
+
+			expect( actual ).toBe( expected );
+		} );
+	} );
+
+	describe( "getProtocol", function() {
 		it( "should return null when passing a relative URL", function() {
-			const urlA = "/relative/url";
+			const urlA = "relative/url";
 
 			const actual = url.getProtocol( urlA );
 
 			expect( actual ).toBeNull();
+		} );
+
+		it( "should return the correct protocol", function() {
+			const urlA = "http://www.google.nl";
+			const expected = "http:";
+
+			const actual = url.getProtocol( urlA );
+
+			expect( actual ).toBe( expected );
 		} );
 	} );
 });

--- a/spec/stringProcessing/urlSpec.js
+++ b/spec/stringProcessing/urlSpec.js
@@ -231,4 +231,23 @@ describe( "A URL helper", function() {
 			expect( actual ).toBe( expected );
 		} );
 	} );
+
+	describe( "protocolIsHttpScheme", function() {
+		it( "recognizes http as a http scheme protocol", function() {
+			const protocol = "http:";
+			const expected = true;
+
+			const actual = url.protocolIsHttpScheme( protocol );
+
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "returns false when no protocol is passed", function() {
+			const expected = false;
+
+			const actual = url.protocolIsHttpScheme( null );
+
+			expect( actual ).toBe( expected );
+		} );
+	} );
 });

--- a/spec/stringProcessing/urlSpec.js
+++ b/spec/stringProcessing/urlSpec.js
@@ -141,4 +141,23 @@ describe( "A URL helper", function() {
 			expect( actual ).toBe( expected );
 		});
 	});
+
+	describe( "getProtocol", function() {
+		it( "should return the protocol of the URL", function() {
+			const urlA = "http://ww.google.nl";
+			const expected = "http://";
+
+			const actual = url.getProtocol( urlA );
+
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "should return null when passing a relative URL", function() {
+			const urlA = "/relative/url";
+
+			const actual = url.getProtocol( urlA );
+
+			expect( actual ).toBeNull();
+		} );
+	} );
 });

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -18,7 +18,8 @@ module.exports = function( text, url ) {
 	 * - The protocol is neither null, nor http, nor https.
 	 * - The link is a relative fragment URL (starts with #), because it won't navigate to another page.
 	 */
-	if ( ! urlHelper.protocolIsHttpScheme( urlHelper.getProtocol( anchorUrl ) ) ||
+	const protocol = urlHelper.getProtocol( anchorUrl );
+	if ( protocol && ! urlHelper.protocolIsHttpScheme( protocol ) ||
 		urlHelper.isRelativeFragmentURL( anchorUrl ) ) {
 		return "other";
 	}

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -23,7 +23,7 @@ module.exports = function( text, url ) {
 		if ( urlHelper.getHostname( anchorUrl ) === urlHelper.getHostname( url ) ) {
 			linkType = "internal";
 		}
-	} else if ( protocol === null ) {
+	} else if ( protocol === null && anchorUrl.charAt( 0 ) !== "#" ) {
 		linkType = "internal";
 	}
 

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -1,6 +1,6 @@
 /** @module stringProcess/getLinkType */
 
-var urlHelper = require( "./url" );
+const urlHelper = require( "./url" );
 
 /**
  * Determines the type of link.
@@ -11,17 +11,20 @@ var urlHelper = require( "./url" );
  */
 
 module.exports = function( text, url ) {
-	var linkType = "other";
+	let linkType = "other";
 
-	var anchorUrl = urlHelper.getFromAnchorTag( text );
+	const anchorUrl = urlHelper.getFromAnchorTag( text );
+	const protocol = urlHelper.getProtocol( anchorUrl );
 
 	// Matches all links that start with http:// and https://, case insensitive and global
-	if ( anchorUrl.match( /https?:\/\//ig ) !== null ) {
+	if ( protocol === "http://" || protocol === "https://" ) {
 		linkType = "external";
 
 		if ( urlHelper.getHostname( anchorUrl ) === urlHelper.getHostname( url ) ) {
 			linkType = "internal";
 		}
+	} else if ( protocol === null ) {
+		linkType = "internal";
 	}
 
 	return linkType;

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -12,17 +12,17 @@ const urlHelper = require( "./url" );
 
 module.exports = function( text, url ) {
 	const anchorUrl = urlHelper.getFromAnchorTag( text );
-	const protocol = urlHelper.getProtocol( anchorUrl );
 
 	/**
 	 * A link is "Other" if:
 	 * - The protocol is not null, not http or https.
 	 * - The link is a relative fragment URL (starts with #).
 	 */
-	if( ( protocol !== null && protocol !== "http:" && protocol !== "https:" ) ||
-		anchorUrl.indexOf( "#" ) === 0 ) {
+	if ( ! urlHelper.protocolIsHttpScheme( urlHelper.getProtocol( anchorUrl ) ) ||
+		urlHelper.isRelativeFragmentURL( anchorUrl ) ) {
 		return "other";
 	}
+
 	if ( urlHelper.isInternalLink( anchorUrl, urlHelper.getHostname( url ) ) ) {
 		return "internal";
 	}

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -6,7 +6,7 @@ const urlHelper = require( "./url" );
  * Determines the type of link.
  *
  * @param {string} text String with anchor tag.
- * @param {string} url Url to match against.
+ * @param {string} url URL to match against.
  * @returns {string} The link type (other, external or internal).
  */
 

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -16,7 +16,7 @@ module.exports = function( text, url ) {
 	/**
 	 * A link is "Other" if:
 	 * - The protocol is neither null, nor http, nor https.
-	 * - The link is a relative fragment URL (starts with #).
+	 * - The link is a relative fragment URL (starts with #), because it won't navigate to another page.
 	 */
 	if ( ! urlHelper.protocolIsHttpScheme( urlHelper.getProtocol( anchorUrl ) ) ||
 		urlHelper.isRelativeFragmentURL( anchorUrl ) ) {

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -15,7 +15,7 @@ module.exports = function( text, url ) {
 
 	/**
 	 * A link is "Other" if:
-	 * - The protocol is not null, not http or https.
+	 * - The protocol is neither null, nor http, nor https.
 	 * - The link is a relative fragment URL (starts with #).
 	 */
 	if ( ! urlHelper.protocolIsHttpScheme( urlHelper.getProtocol( anchorUrl ) ) ||

--- a/src/stringProcessing/getLinkType.js
+++ b/src/stringProcessing/getLinkType.js
@@ -11,21 +11,21 @@ const urlHelper = require( "./url" );
  */
 
 module.exports = function( text, url ) {
-	let linkType = "other";
-
 	const anchorUrl = urlHelper.getFromAnchorTag( text );
 	const protocol = urlHelper.getProtocol( anchorUrl );
 
-	// Matches all links that start with http:// and https://, case insensitive and global
-	if ( protocol === "http://" || protocol === "https://" ) {
-		linkType = "external";
-
-		if ( urlHelper.getHostname( anchorUrl ) === urlHelper.getHostname( url ) ) {
-			linkType = "internal";
-		}
-	} else if ( protocol === null && anchorUrl.charAt( 0 ) !== "#" ) {
-		linkType = "internal";
+	/**
+	 * A link is "Other" if:
+	 * - The protocol is not null, not http or https.
+	 * - The link is a relative fragment URL (starts with #).
+	 */
+	if( ( protocol !== null && protocol !== "http:" && protocol !== "https:" ) ||
+		anchorUrl.indexOf( "#" ) === 0 ) {
+		return "other";
+	}
+	if ( urlHelper.isInternalLink( anchorUrl, urlHelper.getHostname( url ) ) ) {
+		return "internal";
 	}
 
-	return linkType;
+	return "external";
 };

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -81,6 +81,21 @@ function getHostname( url ) {
 	return url.hostname;
 }
 
+/**
+ * Returns the protocol of a URL.
+ *
+ * @param {string} url The URL to retrieve the protocol of.
+ * @returns {string|null} The protocol of the URL.
+ */
+function getProtocol( url ) {
+	const protocolMatcher = /^(?:[a-z]+:)?\/\//i;
+	const protocolMatch = protocolMatcher.exec( url );
+	if ( ! protocolMatch ) {
+		return null;
+	}
+	return protocolMatch[ 0 ];
+}
+
 module.exports = {
 	removeHash: removeHash,
 	removeQueryArgs: removeQueryArgs,
@@ -89,4 +104,5 @@ module.exports = {
 	getFromAnchorTag: getFromAnchorTag,
 	areEqual: areEqual,
 	getHostname: getHostname,
+	getProtocol: getProtocol,
 };

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -84,7 +84,7 @@ function getHostname( url ) {
 /**
  * Returns the protocol of a URL.
  *
- * Note that the colon (http:) is also part of the protocol.
+ * Note that the colon (http:) is also part of the protocol, conform to node's url.parse api.
  *
  * @param {string} url The URL to retrieve the protocol of.
  * @returns {string|null} The protocol of the URL.
@@ -137,7 +137,7 @@ function protocolIsHttpScheme( protocol ) {
 }
 
 /**
- * Determines whther the link is a relative fragment URL.
+ * Determines whether the link is a relative fragment URL.
  *
  * @param {string} url The protocol to test.
  *

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -90,7 +90,7 @@ function getHostname( url ) {
  * @returns {string|null} The protocol of the URL.
  */
 function getProtocol( url ) {
-	return urlMethods.parse( url ).protocol;
+	return urlMethods.parse(url).protocol;
 }
 
 /**

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -84,16 +84,37 @@ function getHostname( url ) {
 /**
  * Returns the protocol of a URL.
  *
+ * Note that the colon (http:) is also part of the protocol.
+ *
  * @param {string} url The URL to retrieve the protocol of.
  * @returns {string|null} The protocol of the URL.
  */
 function getProtocol( url ) {
-	const protocolMatcher = /^(?:[a-z]+:)?\/\//i;
-	const protocolMatch = protocolMatcher.exec( url );
-	if ( ! protocolMatch ) {
-		return null;
+	return urlMethods.parse( url ).protocol;
+}
+
+/**
+ * Determine whether a URL is internal.
+ *
+ * @param {string} url The URL to test.
+ * @param {string} host The current host.
+ * @returns {boolean} Whether or not the URL is internal.
+ */
+function isInternalLink( url, host ) {
+	const parsedUrl = urlMethods.parse( url, false, true );
+	// Check if the URL starts with a singe slash
+	if( url.indexOf( "//" ) === -1 && url.indexOf( "/" ) === 0 ) {
+		return true;
 	}
-	return protocolMatch[ 0 ];
+	// Check if the URL starts with a # indicating a fragment
+	if( url.indexOf( "#" ) === 0 ) {
+		return false;
+	}
+	// No host indicates a internal link
+	if( ! parsedUrl.host ) {
+		return true;
+	}
+	return parsedUrl.host === host;
 }
 
 module.exports = {
@@ -105,4 +126,5 @@ module.exports = {
 	areEqual: areEqual,
 	getHostname: getHostname,
 	getProtocol: getProtocol,
+	isInternalLink: isInternalLink,
 };

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -98,23 +98,53 @@ function getProtocol( url ) {
  *
  * @param {string} url The URL to test.
  * @param {string} host The current host.
+ *
  * @returns {boolean} Whether or not the URL is internal.
  */
 function isInternalLink( url, host ) {
 	const parsedUrl = urlMethods.parse( url, false, true );
-	// Check if the URL starts with a singe slash
-	if( url.indexOf( "//" ) === -1 && url.indexOf( "/" ) === 0 ) {
+	// Check if the URL starts with a singe slash.
+	if ( url.indexOf( "//" ) === -1 && url.indexOf( "/" ) === 0 ) {
 		return true;
 	}
-	// Check if the URL starts with a # indicating a fragment
-	if( url.indexOf( "#" ) === 0 ) {
+
+	// Check if the URL starts with a # indicating a fragment.
+	if ( url.indexOf( "#" ) === 0 ) {
 		return false;
 	}
-	// No host indicates a internal link
-	if( ! parsedUrl.host ) {
+
+	// No host indicates a internal link.
+	if ( ! parsedUrl.host ) {
 		return true;
 	}
+
 	return parsedUrl.host === host;
+}
+
+/**
+ * Checks whether the protocol is either HTTP: or HTTPS:
+ *
+ * @param {string} protocol The protocol to test.
+ *
+ * @returns {boolean} Whether the protocol is http(s):.
+ */
+function protocolIsHttpScheme( protocol ) {
+	if ( ! protocol ) {
+		return false;
+	}
+
+	return ( protocol === "http:" || protocol === "https:" );
+}
+
+/**
+ * Determines whther the link is a relative fragment URL.
+ *
+ * @param {string} url The protocol to test.
+ *
+ * @returns {boolean} Whether the link is a relative fragment URL.
+ */
+function isRelativeFragmentURL( url ) {
+	return url.indexOf( "#" ) === 0;
 }
 
 module.exports = {
@@ -127,4 +157,6 @@ module.exports = {
 	getHostname: getHostname,
 	getProtocol: getProtocol,
 	isInternalLink: isInternalLink,
+	protocolIsHttpScheme: protocolIsHttpScheme,
+	isRelativeFragmentURL: isRelativeFragmentURL,
 };

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -90,7 +90,7 @@ function getHostname( url ) {
  * @returns {string|null} The protocol of the URL.
  */
 function getProtocol( url ) {
-	return urlMethods.parse(url).protocol;
+	return urlMethods.parse( url ).protocol;
 }
 
 /**

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -87,7 +87,7 @@ function getHostname( url ) {
  * Note that the colon (http:) is also part of the protocol, conform to node's url.parse api.
  *
  * @param {string} url The URL to retrieve the protocol of.
- * @returns {string|null} The protocol of the URL.
+ * @returns {string|null} The protocol of the URL or null if no protocol is present.
  */
 function getProtocol( url ) {
 	return urlMethods.parse( url ).protocol;

--- a/src/stringProcessing/url.js
+++ b/src/stringProcessing/url.js
@@ -42,7 +42,7 @@ function addTrailingSlash( url ) {
 }
 
 /**
- * Retrieves the URL from an anchor tag
+ * Retrieves the URL from an anchor tag.
  *
  * @param {string} anchorTag An anchor tag.
  * @returns {string} The URL in the anchor tag.
@@ -54,7 +54,7 @@ function getFromAnchorTag( anchorTag ) {
 }
 
 /**
- * Returns whether or not the given URLs are equal
+ * Returns whether or not the given URLs are equal.
  *
  * @param {string} urlA The first URL to compare.
  * @param {string} urlB The second URL to compare.
@@ -70,7 +70,7 @@ function areEqual( urlA, urlB ) {
 }
 
 /**
- * Returns the domain name of a URL
+ * Returns the domain name of a URL.
  *
  * @param {string} url The URL to retrieve the domain name of.
  * @returns {string} The domain name of the URL.
@@ -103,7 +103,7 @@ function getProtocol( url ) {
  */
 function isInternalLink( url, host ) {
 	const parsedUrl = urlMethods.parse( url, false, true );
-	// Check if the URL starts with a singe slash.
+	// Check if the URL starts with a single slash.
 	if ( url.indexOf( "//" ) === -1 && url.indexOf( "/" ) === 0 ) {
 		return true;
 	}
@@ -113,7 +113,7 @@ function isInternalLink( url, host ) {
 		return false;
 	}
 
-	// No host indicates a internal link.
+	// No host indicates an internal link.
 	if ( ! parsedUrl.host ) {
 		return true;
 	}
@@ -122,7 +122,7 @@ function isInternalLink( url, host ) {
 }
 
 /**
- * Checks whether the protocol is either HTTP: or HTTPS:
+ * Checks whether the protocol is either HTTP: or HTTPS:.
  *
  * @param {string} protocol The protocol to test.
  *
@@ -139,7 +139,7 @@ function protocolIsHttpScheme( protocol ) {
 /**
  * Determines whether the link is a relative fragment URL.
  *
- * @param {string} url The protocol to test.
+ * @param {string} url The URL to test.
  *
  * @returns {boolean} Whether the link is a relative fragment URL.
  */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Relative URL's now count as internal links in the link assessment.

## Relevant technical choices:

* Whether a link is relative is determined by extracting the protocol from the URL with a new helper-function in `stringProcessing/url.js` called `getProtocol`.
* Relative fragment URLs (`#header`) are not considered internal links because they don't navigate to another page.
* The `getProtocol` returns the protocol including the colon (`http:`). This is because Node's `url.parse` method returns the protocol like that.

## Test instructions

This PR can be tested by following these steps:

* Add a relative URL to a new post.
* The assessment that says you should use internal links no longer is present. 

Fixes Yoast/wordpress-seo#7083

  