### PR TITLE
Add language support table to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 |                     | English | German | Dutch | French | Spanish | Italian | Japanese |
 |---------------------|---------|--------|-------|--------|---------|---------|----------|
 | Transition words    | ✅      | ✅     | ✅    | ✅      | ✅       | ✅       |          |
-| Flesh reading ease  | ✅      | ✅     | ✅    |        |         |         | ❌        |
-| Passive voice       | ✅      | ✅     |       |       |         |         | ❌        |
-| Sentence beginnings<sup>1</sup> | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       | ❌        |
+| Flesh reading ease  | ✅      | ✅     | ✅    |        |         |         | ❌<sup>2</sup>        |
+| Passive voice       | ✅      | ✅     |       |       |         |         | ❌<sup>2</sup>        |
+| Sentence beginnings<sup>1</sup> | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       | ❌<sup>2</sup>        |
 | Sentence length     | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
 | Function words (for Internal linking and insights)      | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
+<sup>2</sup> This means that this feature doesn't make sense for the specific language.
 
 The following readability assessments are available for all languages: 
 - sentence length (with a default upper limit of 20 words, see<sup>1</sup> above )

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 | Transition words    | ✅      | ✅     | ✅    | ✅      | ✅       | ✅       |          |
 | Flesh reading ease  | ✅      | ✅     | ✅    |        |         |         | ❌<sup>2</sup>        |
 | Passive voice       | ✅      | ✅     |       |       |         |         | ❌<sup>2</sup>        |
-| Sentence beginnings<sup>1</sup> | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       | ❌<sup>2</sup>        |
-| Sentence length     | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
+| Sentence beginnings | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       | ❌<sup>2</sup>        |
+| Sentence length<sup>1</sup>     | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
 | Function words (for Internal linking and insights)      | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ var researcher = new Researcher( new Paper( "Text that has been written" ) );
 console.log( researcher.getResearch( "wordCountInText" ) );
 ```
 
+## Supported languages
+|                     | English | German | Dutch | French | Spanish | Italian | Japanese |
+|---------------------|---------|--------|-------|--------|---------|---------|----------|
+| Transition words    | ✅      | ✅     | ✅    | ✅      | ✅       | ✅       |          |
+| Flesh reading ease  | ✅      | ✅     | ✅    |        |         |         | ❌        |
+| Passive voice       | ✅      | ✅     |       |       |         |         | ❌        |
+| Sentence beginnings<sup>1</sup> | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       | ❌        |
+| Sentence length     | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
+| Function words (for Internal linking and insights)      | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |
+
+<sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
+
+The following readability assessments are available for all languages: 
+- sentence length (with a default upper limit of 20 words, see<sup>1</sup> above )
+- too long paragraphs
+- subheading distribution
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry: Add language support table to the readme.

## Testing instructions
Please use the preview feature on GitHub, because PHPStorm doesn't understand MD tables.
<img width="913" alt="schermafbeelding 2018-01-03 om 15 22 56" src="https://user-images.githubusercontent.com/17744553/34523963-0098ced8-f09a-11e7-83bb-d438d5948e94.png">
