### PR TITLE
Better "nofollow" detection

### DIFF
--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -40,6 +40,102 @@ describe("Tests a string for anchors and analyzes these", function() {
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 	} );
 
+	it("should detect nofollow suffixed with some other argument in the rel tag", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow noreferrer'>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(1);
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow noreferrer noopener'>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(1);
+	});
+
+	it("should detect nofollow prefixed with some other argument in the rel tag", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"noreferrer nofollow\">link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(1);
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"noopener noreferrer nofollow\">link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(1);
+	});
+
+	it("should detect nofollow prefixed and suffixed with some other argument in the rel tag", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='external nofollow noreferrer'>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(1);
+	});
+
+	it("should allow nofollow as single argument without quotes", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=nofollow>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(1);
+	});
+
+	it("should ignore nofollow outside of rel tag", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"\" nofollow>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(0);
+	});
+
+	it("should ignore malformed rel tag", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"nofollow'>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(0);
+	});
+
 	it( "should return all special types", function () {
 		var attributes = {
 			keyword: "keyword",

--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -108,6 +108,34 @@ describe("Tests a string for anchors and analyzes these", function() {
 		expect(foundLinks.externalNofollow).toBe(1);
 	});
 
+	it("should ignore single argument without quotes when starting with nofollow", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=nofollowmoretext>link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(0);
+	});
+
+	it("should ignore tags ending in rel", function () {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' horel=\"nofollow\">link</a>", attributes);
+		foundLinks = linkCount(mockPaper);
+		expect(foundLinks.total).toBe(2);
+		expect(foundLinks.otherTotal).toBe(1);
+		expect(foundLinks.externalNofollow).toBe(0);
+	});
+
 	it("should ignore nofollow outside of rel tag", function () {
 		var attributes = {
 			keyword: "link",

--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -2,30 +2,24 @@ var linkCount = require( "../../js/researches/getLinkStatistics.js" );
 var Paper = require( "../../js/values/Paper.js" );
 var foundLinks;
 
+describe( "Tests a string for anchors and its attributes", function() {
 
-describe("Tests a string for anchors and analyzes these", function() {
+	const paperAttributes = {
+		keyword: "link",
+		url: "http://yoast.com",
+		permalink: "http://yoast.com"
+	};
 
-	it( "returns an object with all linktypes found", function () {
-		var attributes = {
-			keyword: "test",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
-		var mockPaper = new Paper( "string <a href='http://yoast.com'>link</a>", attributes );
-
+	it( "should detect internal links", function() {
+		var mockPaper = new Paper( "string <a href='http://yoast.com'>link</a>", paperAttributes );
 		foundLinks = linkCount( mockPaper );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.internalTotal ).toBe( 1 );
 		expect( foundLinks.externalTotal ).toBe( 0 );
-		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
+	} );
 
-		attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
-
-		mockPaper = new Paper( "string <a href='http://yoast.com'>link</a>, <a href='http://example.com'>link</a>", attributes );
+	it( "should detect external links", function() {
+		var mockPaper = new Paper( "string <a href='http://yoast.com'>link</a>, <a href='http://example.com'>link</a>", paperAttributes );
 		foundLinks = linkCount( mockPaper );
 		expect( foundLinks.total ).toBe( 2 );
 		expect( foundLinks.internalTotal ).toBe( 1 );
@@ -33,151 +27,169 @@ describe("Tests a string for anchors and analyzes these", function() {
 		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
 	} );
 
+	it( "should detect no keyword in link text", function() {
+		var attributes = {
+			keyword: "test",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>link</a>", attributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
+	} );
+
+	it( "should detect the keyword in internal link text", function() {
+		var attributes = {
+			keyword: "focuskeyword",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>focuskeyword</a>", attributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.internalTotal ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
+	} );
+
+	it( "should detect the keyword in external link text", function() {
+		var attributes = {
+			keyword: "focuskeyword",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
+
+		var mockPaper = new Paper( "string <a href='http://example.com/some-page/'>focuskeyword</a>", attributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalTotal ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
+	} );
+
+	it( "should not detect the keyword in link text which links to itself", function() {
+		var attributes = {
+			keyword: "focuskeyword",
+			url: "http://yoast.com/this-page/",
+			permalink: "http://yoast.com/this-page/"
+		};
+
+		var mockPaper = new Paper( "string <a href='http://yoast.com/this-page/'>focuskeyword</a>", attributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.internalTotal ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
+	} );
+
 	it( "should detect nofollow as rel attribute", function() {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
-
-		var mockPaper = new Paper( "string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow'>link</a>", attributes );
+		var mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow'>link</a>", paperAttributes );
 		foundLinks = linkCount( mockPaper );
-		expect( foundLinks.total ).toBe( 2 );
-		expect( foundLinks.otherTotal ).toBe( 1 );
+		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
 
-		var mockPaper = new Paper( "string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=' nofollow '>link</a>", attributes );
+		mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow '>link</a>", paperAttributes );
 		foundLinks = linkCount( mockPaper );
-		expect( foundLinks.total ).toBe( 2 );
-		expect( foundLinks.otherTotal ).toBe( 1 );
+		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
-	});
+		expect( foundLinks.externalDofollow ).toBe( 0 );
 
-	it("should detect nofollow suffixed with some other argument in the rel tag", function () {
+		mockPaper = new Paper( "string <a href='http://example.com' rel=' nofollow'>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+
+		mockPaper = new Paper( "string <a href='http://example.com' rel=' nofollow '>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+	} );
+
+	it( "should detect nofollow suffixed with some other argument in the rel tag", function() {
 		var attributes = {
 			keyword: "link",
 			url: "http://yoast.com",
 			permalink: "http://yoast.com"
 		};
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow noreferrer'>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(1);
+		var mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow noreferrer'>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow noreferrer noopener'>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(1);
-	});
+		mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow noreferrer noopener'>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+	} );
 
-	it("should detect nofollow prefixed with some other argument in the rel tag", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
+	it( "should detect nofollow prefixed with some other argument in the rel tag", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' rel=\"noreferrer nofollow\">link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"noreferrer nofollow\">link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(1);
+		mockPaper = new Paper( "string <a href='http://example.com' rel=\"noopener noreferrer nofollow\">link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+	} );
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"noopener noreferrer nofollow\">link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(1);
-	});
+	it( "should detect nofollow prefixed and suffixed with some other argument in the rel tag", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' rel='external nofollow noreferrer'>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+	} );
 
-	it("should detect nofollow prefixed and suffixed with some other argument in the rel tag", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
+	it( "should allow nofollow as single argument without quotes", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' rel=nofollow>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+	} );
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='external nofollow noreferrer'>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(1);
-	});
+	it( "should ignore single argument without quotes when starting with nofollow", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' rel=nofollowmoretext>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 0 );
+		expect( foundLinks.externalDofollow ).toBe( 1 );
+	} );
 
-	it("should allow nofollow as single argument without quotes", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
+	it( "should ignore tags ending in rel", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' horel=\"nofollow\">link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 0 );
+		expect( foundLinks.externalDofollow ).toBe( 1 );
+	} );
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=nofollow>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(1);
-	});
+	it( "should ignore nofollow outside of rel tag", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' rel=\"\" nofollow>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 0 );
+		expect( foundLinks.externalDofollow ).toBe( 1 );
+	} );
 
-	it("should ignore single argument without quotes when starting with nofollow", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
+	it( "should ignore malformed rel tag", function() {
+		var mockPaper = new Paper( "string <a href='http://example.com' rel=\"nofollow'>link</a>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 0 );
+	} );
 
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=nofollowmoretext>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(0);
-	});
-
-	it("should ignore tags ending in rel", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
-
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' horel=\"nofollow\">link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(0);
-	});
-
-	it("should ignore nofollow outside of rel tag", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
-
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"\" nofollow>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(0);
-	});
-
-	it("should ignore malformed rel tag", function () {
-		var attributes = {
-			keyword: "link",
-			url: "http://yoast.com",
-			permalink: "http://yoast.com"
-		};
-
-		var mockPaper = new Paper("string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=\"nofollow'>link</a>", attributes);
-		foundLinks = linkCount(mockPaper);
-		expect(foundLinks.total).toBe(2);
-		expect(foundLinks.otherTotal).toBe(1);
-		expect(foundLinks.externalNofollow).toBe(0);
-	});
-
-	it( "should return all special types", function () {
+	it( "should return all special types", function() {
 		var attributes = {
 			keyword: "keyword",
 			url: "http://example.org",
@@ -206,23 +218,26 @@ describe("Tests a string for anchors and analyzes these", function() {
 		} );
 
 		mockPaper = new Paper( "<a href='http://example.org/test123'>test123</a>" +
-		                       "<a href='http://example.org/test123' rel='nofollow'>test123</a>" +
-		                       "<a href='http://example.org/test123'>keyword</a>" +
-		                       "<a href='http://yoast.com' rel='nofollow'>test123</a>" +
-		                       "<a href='http://yoast.com'>test123</a>" +
-		                       "<a href='http://yoast.com'>keyword</a>" +
-		                       "<a href='#foo'>foo</a>" +
-		                       "<a href='#bar' rel='nofollow'>bar</a>'" +
-		                       "" +
-		                       "" +
-		                       "", attributes );
+							   "<a href='http://example.org/test123' rel='nofollow'>test123</a>" +
+							   "<a href='http://example.org/test123'>keyword</a>" +
+							   "<a href='http://yoast.com' rel='nofollow'>test123</a>" +
+							   "<a href='http://yoast.com'>test123</a>" +
+							   "<a href='http://yoast.com'>keyword</a>" +
+							   "<a href='#foo'>foo</a>" +
+							   "<a href='#bar' rel='nofollow'>bar</a>'" +
+							   "" +
+							   "" +
+							   "", attributes );
 		foundLinks = linkCount( mockPaper );
 		expect( foundLinks ).toEqual( {
 			total: 8,
 			totalNaKeyword: 0,
 			keyword: {
 				totalKeyword: 2,
-				matchedAnchors: ["<a href='http://example.org/test123'>keyword</a>", "<a href='http://yoast.com'>keyword</a>"]
+				matchedAnchors: [
+					"<a href='http://example.org/test123'>keyword</a>",
+					"<a href='http://yoast.com'>keyword</a>"
+				]
 			},
 			internalTotal: 3,
 			internalDofollow: 2,
@@ -325,7 +340,7 @@ describe("Tests a string for anchors and analyzes these", function() {
 			otherNofollow: 0
 		} );
 
-	});
+	} );
 
 	it( "should match the keyword in an url with a hash", function() {
 		var attributes = {
@@ -356,7 +371,7 @@ describe("Tests a string for anchors and analyzes these", function() {
 			otherNofollow: 0
 		} );
 
-	});
+	} );
 
 	it( "should match the keyword in an url with a hash in the current url", function() {
 		var attributes = {
@@ -387,7 +402,7 @@ describe("Tests a string for anchors and analyzes these", function() {
 			otherNofollow: 0
 		} );
 
-	});
+	} );
 
 	it( "should match without a keyword", function() {
 		var attributes = {
@@ -417,6 +432,6 @@ describe("Tests a string for anchors and analyzes these", function() {
 			otherDofollow: 0,
 			otherNofollow: 0
 		} );
-	});
+	} );
 
-});
+} );

--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -31,14 +31,27 @@ describe("Tests a string for anchors and analyzes these", function() {
 		expect( foundLinks.internalTotal ).toBe( 1 );
 		expect( foundLinks.externalTotal ).toBe( 1 );
 		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
+	} );
 
+	it( "should detect nofollow as rel attribute", function() {
+		var attributes = {
+			keyword: "link",
+			url: "http://yoast.com",
+			permalink: "http://yoast.com"
+		};
 
-		mockPaper = new Paper( "string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow'>link</a>", attributes );
+		var mockPaper = new Paper( "string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel='nofollow'>link</a>", attributes );
 		foundLinks = linkCount( mockPaper );
 		expect( foundLinks.total ).toBe( 2 );
 		expect( foundLinks.otherTotal ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
-	} );
+
+		var mockPaper = new Paper( "string <a href='ftp://yoast.com'>link</a>, <a href='http://example.com' rel=' nofollow '>link</a>", attributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 2 );
+		expect( foundLinks.otherTotal ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+	});
 
 	it("should detect nofollow suffixed with some other argument in the rel tag", function () {
 		var attributes = {

--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -108,6 +108,14 @@ describe( "Tests a string for anchors and its attributes", function() {
 		expect( foundLinks.externalDofollow ).toBe( 0 );
 	} );
 
+	it( "should detect nofollow with capitals", function() {
+		var mockPaper = new Paper( "string <A HREF='http://example.com' REL='NOFOLLOW'>link</A>", paperAttributes );
+		foundLinks = linkCount( mockPaper );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.externalNofollow ).toBe( 1 );
+		expect( foundLinks.externalDofollow ).toBe( 0 );
+	});
+
 	it( "should detect nofollow suffixed with some other argument in the rel tag", function() {
 		var attributes = {
 			keyword: "link",

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -29,7 +29,7 @@ module.exports = function( text ) {
 			if ( nodeValue.rel.toLowerCase().split( /\s/ ).includes( "nofollow" ) ) {
 				linkFollow = "Nofollow";
 			}
-		}
+		},
 	} );
 
 	parser.write( text );

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -2,7 +2,6 @@
 
 // We use an external library, which can be found here: https://github.com/fb55/htmlparser2.
 let htmlparser = require( "htmlparser2" );
-let isString = require( "lodash/isString" );
 
 /**
  * Checks if a links has a nofollow attribute value. If it has, returns Nofollow, otherwise Dofollow.
@@ -18,15 +17,15 @@ module.exports = function( anchorHTML ) {
 		 * Detects if there is a `nofollow` argument value in the `rel` argument of a link.
 		 *
 		 * @param {string} tagName The tag name.
-		 * @param {object} nodeValue The attribute with the keys and values of the tag.
+		 * @param {object} attributes  The attribute with the keys and values of the tag.
 		 * @returns {void}
 		 */
-		onopentag: function( tagName, nodeValue ) {
-			if ( tagName !== "a" || ! isString( nodeValue.rel ) ) {
+		onopentag: function( tagName, attributes ) {
+			if ( tagName !== "a" || ! attributes.rel ) {
 				return;
 			}
 
-			if ( nodeValue.rel.toLowerCase().split( /\s/ ).includes( "nofollow" ) ) {
+			if ( attributes.rel.toLowerCase().split( /\s/ ).includes( "nofollow" ) ) {
 				linkFollow = "Nofollow";
 			}
 		},

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -5,24 +5,24 @@ let htmlparser = require( "htmlparser2" );
 let isString = require( "lodash/isString" );
 
 /**
- * Checks if a links has a nofollow attribute. If it has, returns Nofollow, otherwise Dofollow.
+ * Checks if a links has a nofollow attribute value. If it has, returns Nofollow, otherwise Dofollow.
  *
- * @param {string} text The text to check against.
+ * @param {string} anchorHTML The anchor HTML to check against.
  * @returns {string} Returns Dofollow or Nofollow.
  */
-module.exports = function( text ) {
+module.exports = function( anchorHTML ) {
 	let linkFollow = "Dofollow";
 
 	let parser = new htmlparser.Parser( {
 		/**
-		 * Detects if there is a `nofollow` argument in the `rel` attribute of a link.
+		 * Detects if there is a `nofollow` argument value in the `rel` argument of a link.
 		 *
 		 * @param {string} tagName The tag name.
-		 * @param {object} nodeValue The attribute with the keys and values of the tag.
+		 * @param {object} node The attribute with the keys and values of the tag.
 		 * @returns {void}
 		 */
 		onopentag: function( tagName, nodeValue ) {
-			if ( tagName.toLowerCase() !== "a" || ! isString( nodeValue.rel ) ) {
+			if ( tagName !== "a" || ! isString( nodeValue.rel ) ) {
 				return;
 			}
 
@@ -32,7 +32,8 @@ module.exports = function( text ) {
 		},
 	} );
 
-	parser.write( text );
+	parser.write( anchorHTML );
+	parser.end();
 
 	return linkFollow;
 };

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -10,7 +10,7 @@ module.exports = function( text ) {
 	var linkFollow = "Dofollow";
 
 	// Matches all nofollow links, case insensitive and global
-	if ( text.match( /rel=([\'\"])nofollow\1/ig ) !== null ) {
+	if ( text.match( /rel=(\'|\")([^\1]+\s)?nofollow(\s[^\1]+)?\1|rel=nofollow/ig ) !== null ) {
 		linkFollow = "Nofollow";
 	}
 	return linkFollow;

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -10,8 +10,9 @@ module.exports = function( text ) {
 	var linkFollow = "Dofollow";
 
 	// Matches all nofollow links, case insensitive and global
-	if ( text.match( /rel=(\'|\")([^\1]+\s)?nofollow(\s[^\1]+)?\1|rel=nofollow/ig ) !== null ) {
+	if ( text.match( /\srel=(nofollow(\s|\/>|>)|(\'|\")([^\3]+\s)?nofollow(\s[^\3]+)?\3)/ig ) !== null ) {
 		linkFollow = "Nofollow";
 	}
+
 	return linkFollow;
 };

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -22,11 +22,7 @@ module.exports = function( text ) {
 		 * @returns {void}
 		 */
 		onopentag: function( tagName, nodeValue ) {
-			if ( tagName.toLowerCase() !== "a" ) {
-				return;
-			}
-
-			if ( ! isString( nodeValue.rel ) ) {
+			if ( tagName.toLowerCase() !== "a" || ! isString( nodeValue.rel ) ) {
 				return;
 			}
 

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -10,7 +10,7 @@ module.exports = function( text ) {
 	var linkFollow = "Dofollow";
 
 	// Matches all nofollow links, case insensitive and global
-	if ( text.match( /\srel=(nofollow(\s|\/>|>)|(\'|\")([^\3]+\s)?nofollow(\s[^\3]+)?\3)/ig ) !== null ) {
+	if ( text.match( /\srel=(nofollow(\s|\/>|>)|(\'|\")([^\3]*\s)?nofollow(\s[^\3]*)?\3)/ig ) !== null ) {
 		linkFollow = "Nofollow";
 	}
 

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -17,7 +17,7 @@ module.exports = function( anchorHTML ) {
 		 * Detects if there is a `nofollow` argument value in the `rel` argument of a link.
 		 *
 		 * @param {string} tagName The tag name.
-		 * @param {object} attributes  The attribute with the keys and values of the tag.
+		 * @param {object} attributes The attribute with the keys and values of the tag.
 		 * @returns {void}
 		 */
 		onopentag: function( tagName, attributes ) {

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -11,7 +11,7 @@ let isString = require( "lodash/isString" );
  * @returns {string} Returns Dofollow or Nofollow.
  */
 module.exports = function( text ) {
-	let linkFollow = 'Dofollow';
+	let linkFollow = "Dofollow";
 
 	let parser = new htmlparser.Parser( {
 		/**
@@ -22,7 +22,7 @@ module.exports = function( text ) {
 		 * @returns {void}
 		 */
 		onopentag: function( tagName, nodeValue ) {
-			if ( tagName.toLowerCase() !== 'a' ) {
+			if ( tagName.toLowerCase() !== "a" ) {
 				return;
 			}
 
@@ -30,13 +30,13 @@ module.exports = function( text ) {
 				return;
 			}
 
-			if ( nodeValue.rel.toLowerCase().split(/\s/).includes('nofollow') ) {
-				linkFollow = 'Nofollow';
+			if ( nodeValue.rel.toLowerCase().split( /\s/ ).includes( "nofollow" ) ) {
+				linkFollow = "Nofollow";
 			}
 		}
-	});
+	} );
 
-	parser.write(text);
+	parser.write( text );
 
 	return linkFollow;
 };

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -15,8 +15,7 @@ module.exports = function( text ) {
 
 	let parser = new htmlparser.Parser( {
 		/**
-		 * Handles the opening tag. If the opening tag is included in the inlineTags array, set inScriptBlock to true.
-		 * If the opening tag is not included in the inlineTags array, push the tag to the textArray.
+		 * Detects if there is a `nofollow` argument in the `rel` attribute of a link.
 		 *
 		 * @param {string} tagName The tag name.
 		 * @param {object} nodeValue The attribute with the keys and values of the tag.

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -18,7 +18,7 @@ module.exports = function( anchorHTML ) {
 		 * Detects if there is a `nofollow` argument value in the `rel` argument of a link.
 		 *
 		 * @param {string} tagName The tag name.
-		 * @param {object} node The attribute with the keys and values of the tag.
+		 * @param {object} nodeValue The attribute with the keys and values of the tag.
 		 * @returns {void}
 		 */
 		onopentag: function( tagName, nodeValue ) {

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -1,5 +1,8 @@
 /** @module stringProcessing/checkNofollow */
 
+// Regular Expression to detect "nofollow" in the rel attribute.
+const noFollowExpression = /\srel=(nofollow(\s|\/>|>)|(\'|\")([^\3]*\s)?nofollow(\s[^\3]*)?\3)/ig;
+
 /**
  * Checks if a links has a nofollow attribute. If it has, returns Nofollow, otherwise Dofollow.
  *
@@ -10,7 +13,7 @@ module.exports = function( text ) {
 	var linkFollow = "Dofollow";
 
 	// Matches all nofollow links, case insensitive and global
-	if ( text.match( /\srel=(nofollow(\s|\/>|>)|(\'|\")([^\3]*\s)?nofollow(\s[^\3]*)?\3)/ig ) !== null ) {
+	if ( text.match( noFollowExpression ) !== null ) {
 		linkFollow = "Nofollow";
 	}
 

--- a/src/stringProcessing/checkNofollow.js
+++ b/src/stringProcessing/checkNofollow.js
@@ -4,7 +4,7 @@
 let htmlparser = require( "htmlparser2" );
 
 /**
- * Checks if a links has a nofollow attribute value. If it has, returns Nofollow, otherwise Dofollow.
+ * Checks if a link has a `rel` attribute with a `nofollow` value. If it has, returns Nofollow, otherwise Dofollow.
  *
  * @param {string} anchorHTML The anchor HTML to check against.
  * @returns {string} Returns Dofollow or Nofollow.
@@ -14,10 +14,10 @@ module.exports = function( anchorHTML ) {
 
 	let parser = new htmlparser.Parser( {
 		/**
-		 * Detects if there is a `nofollow` argument value in the `rel` argument of a link.
+		 * Detects if there is a `nofollow` value in the `rel` attribute of a link.
 		 *
 		 * @param {string} tagName The tag name.
-		 * @param {object} attributes The attribute with the keys and values of the tag.
+		 * @param {object} attributes The tag attributes with the names and values of each attribute found.
 		 * @returns {void}
 		 */
 		onopentag: function( tagName, attributes ) {


### PR DESCRIPTION
Even when other arguments are present in the `rel` tag

## Summary

This PR can be summarized in the following changelog entry:
* Fixes a bug where multiple `rel` arguments prevented correct `nofollow` detection.

## Relevant technical choices:
* Extended the regex to have a more accepting test.
* As the HTML spec also allows for `rel=nofollow`, this is added as separate check.

## Test instructions

This PR can be tested by following these steps:

* See issue.

Fixes https://github.com/Yoast/wordpress-seo/issues/7035
