### PR TITLE
Bumped max warnings due to an upcoming package version bump

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	target: {
 		src: [ "<%= files.js %>", "!src/templates.js" ],
 		options: {
-			maxWarnings: 22,
+			maxWarnings: 140,
 		},
 	},
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Bumps the maximum allowed warnings to 140 to ensure we can safely upgrade to ESLint 4.0.

## Test instructions

This PR can be tested by following these steps:

* Check that the build succeeds.
