### PR TITLE
Fix transition words marking by adding marks into the sentence

### DIFF
--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -120,10 +120,10 @@ describe( "An assessment for transition word percentage", function(){
 
 describe( "A test for marking sentences containing a transition word", function() {
 	it ("returns markers for too long sentences", function() {
-		let paper = new Paper( "This sentence is marked, because it contains a transition word." );
-		let transitionWords = Factory.buildMockResearcher( { sentenceResults: [ { sentence: "This sentence is marked, because it contains a transition word.", transitionWords: [ 'because' ] } ] } );
+		let paper = new Paper( "This sentence includes a mark, because it contains a transition word." );
+		let transitionWords = Factory.buildMockResearcher( { sentenceResults: [ { sentence: "This sentence includes a mark, because it contains a transition word.", transitionWords: [ 'because' ] } ] } );
 		let expected = [
-			new Mark( { original: "This sentence is marked, because it contains a transition word.", marked: "<yoastmark class='yoast-text-mark'>This sentence is marked, because it contains a transition word.</yoastmark>" } )
+			new Mark( { original: "This sentence includes a mark, because it contains a transition word.", marked: "This sentence includes a mark, <yoastmark class='yoast-text-mark'>because</yoastmark> it contains a transition word." } )
 		];
 		expect( transitionWordsAssessment.getMarks( paper, transitionWords ) ).toEqual( expected );
 	} );

--- a/spec/markers/addMarksInSentenceSpec.js
+++ b/spec/markers/addMarksInSentenceSpec.js
@@ -1,0 +1,36 @@
+const addMarksInSentence = require( "../../js/markers/addMarksInSentence" );
+const Mark = require( "../../js/values/Mark" );
+
+describe( 'addMarksInSentence', function() {
+	it( "should have the same marked sentence as the original", function() {
+		let expected = new Mark( {
+			original: "A piece of text.",
+			marked: "A piece of text.",
+		} );
+		expect( addMarksInSentence( "A piece of text.", [] ) ).toEqual( expected );
+	});
+
+	it( "should mark a part of the text", function() {
+		let expected = new Mark( {
+			original: "A piece of text.",
+			marked: "A piece <yoastmark class='yoast-text-mark'>of</yoastmark> text.",
+		} );
+		expect( addMarksInSentence( "A piece of text.", ["of"] ) ).toEqual( expected );
+	});
+
+	it( "should mark multiple parts of the text", function() {
+		let expected = new Mark( {
+			original: "A piece of text, with some more added.",
+			marked: "A piece <yoastmark class='yoast-text-mark'>of</yoastmark> text, <yoastmark class='yoast-text-mark'>with</yoastmark> some more added.",
+		} );
+		expect( addMarksInSentence( "A piece of text, with some more added.", ["with", "of"] ) ).toEqual( expected );
+	});
+
+	it( "should mark multiple parts of the text, ignoring case for searching but using the original case in the result", function() {
+		let expected = new Mark( {
+			original: "Of course this is still a piece of text, with some more added.",
+			marked: "<yoastmark class='yoast-text-mark'>Of</yoastmark> course this is still a piece <yoastmark class='yoast-text-mark'>of</yoastmark> text, <yoastmark class='yoast-text-mark'>with</yoastmark> some more added.",
+		} );
+		expect( addMarksInSentence( "Of course this is still a piece of text, with some more added.", ["with", "of"] ) ).toEqual( expected );
+	});
+});

--- a/spec/stringProcessing/wrapStringWithRegexSpec.js
+++ b/spec/stringProcessing/wrapStringWithRegexSpec.js
@@ -1,0 +1,18 @@
+const wrapStringWithRegex = require( "../../js/stringProcessing/wrapStringWithRegex" );
+
+describe( 'wrapStringWithRegex', function() {
+	it( "should wrap nothing", function() {
+		expect( wrapStringWithRegex( "Nothing will be wrapped.", "non-existing", "<span>", "</span>" ) )
+			.toEqual( "Nothing will be wrapped." );
+	});
+
+	it( "should wrap a single occurence", function() {
+		expect( wrapStringWithRegex( "Something will be wrapped.", "something", "<span>", "</span>" ) )
+			.toEqual( "<span>Something</span> will be wrapped." );
+	});
+
+	it( "should wrap multiple occurences", function() {
+		expect( wrapStringWithRegex( "Something will be wrapped, something again.", "something", "<span>", "</span>" ) )
+			.toEqual( "<span>Something</span> will be wrapped, <span>something</span> again." );
+	});
+});

--- a/spec/stringProcessing/wrapStringWithRegexSpec.js
+++ b/spec/stringProcessing/wrapStringWithRegexSpec.js
@@ -1,8 +1,13 @@
 const wrapStringWithRegex = require( "../../js/stringProcessing/wrapStringWithRegex" );
 
 describe( 'wrapStringWithRegex', function() {
-	it( "should wrap nothing", function() {
+	it( "should not find anything to wrap", function() {
 		expect( wrapStringWithRegex( "Nothing will be wrapped.", "non-existing", "<span>", "</span>" ) )
+			.toEqual( "Nothing will be wrapped." );
+	});
+
+	it( "should wrap with nothing", function() {
+		expect( wrapStringWithRegex( "Nothing will be wrapped.", "will" ) )
 			.toEqual( "Nothing will be wrapped." );
 	});
 
@@ -14,5 +19,15 @@ describe( 'wrapStringWithRegex', function() {
 	it( "should wrap multiple occurences", function() {
 		expect( wrapStringWithRegex( "Something will be wrapped, something again.", "something", "<span>", "</span>" ) )
 			.toEqual( "<span>Something</span> will be wrapped, <span>something</span> again." );
+	});
+
+	it( "should only prefix the occurences", function() {
+		expect( wrapStringWithRegex( "This will be prefixed, and this again.", "this", "prefix-", "" ) )
+			.toEqual( "prefix-This will be prefixed, and prefix-this again." );
+	});
+
+	it( "should only suffix the occurences", function() {
+		expect( wrapStringWithRegex( "This will be prefixed, and this again.", "this", "", "-suffix" ) )
+			.toEqual( "This-suffix will be prefixed, and this-suffix again." );
 	});
 });

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -1,11 +1,10 @@
 let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let formatNumber = require( "../../helpers/formatNumber.js" );
-let map = require( "lodash/map" );
+let forEach = require( "lodash/forEach" );
 let inRange = require( "../../helpers/inRange.js" ).inRangeStartInclusive;
 let stripTags = require( "../../stringProcessing/stripHTMLTags" ).stripIncompleteTags;
 
-let Mark = require( "../../values/Mark.js" );
-let marker = require( "../../markers/addMark.js" );
+let addMarksInSentence = require( "../../markers/addMarksInSentence" );
 
 let getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 let availableLanguages = [ "en", "de", "es", "fr", "nl", "it" ];
@@ -110,14 +109,14 @@ let transitionWordsAssessment = function( paper, researcher, i18n ) {
 let transitionWordsMarker = function( paper, researcher ) {
 	let transitionWordSentences = researcher.getResearch( "findTransitionWords" );
 
-	return map( transitionWordSentences.sentenceResults, function( sentenceResult ) {
+	let marks = [];
+	forEach( transitionWordSentences.sentenceResults, function( sentenceResult ) {
 		let sentence = sentenceResult.sentence;
+		let transitionWords = sentenceResult.transitionWords;
 		sentence = stripTags( sentence );
-		return new Mark( {
-			original: sentence,
-			marked: marker( sentence ),
-		} );
+		marks.push( addMarksInSentence( sentence, transitionWords ) );
 	} );
+	return marks;
 };
 
 module.exports = {

--- a/src/markers/addMarksInSentence.js
+++ b/src/markers/addMarksInSentence.js
@@ -1,0 +1,25 @@
+const forEach = require( "lodash/forEach" );
+
+const wrapStringWithRegex = require( "../stringProcessing/wrapStringWithRegex" );
+const Mark = require( "../values/Mark" );
+
+/**
+ * Marks multiple texts within a sentence with HTML tags
+ *
+ * @param {string}        sentence The unmarked text.
+ * @param {Array<string>} marks    Text to search for and mark.
+ *
+ * @returns {Mark} A new mark containing the original sentence and one marked with HTML tags.
+ */
+module.exports = function( sentence, marks ) {
+	let markedSentence = sentence;
+
+	forEach( marks, function( mark ) {
+		markedSentence = wrapStringWithRegex( markedSentence, mark, "<yoastmark class='yoast-text-mark'>", "</yoastmark>" );
+	} );
+
+	return new Mark( {
+		original: sentence,
+		marked: markedSentence,
+	} );
+};

--- a/src/markers/addMarksInSentence.js
+++ b/src/markers/addMarksInSentence.js
@@ -4,7 +4,7 @@ const wrapStringWithRegex = require( "../stringProcessing/wrapStringWithRegex" )
 const Mark = require( "../values/Mark" );
 
 /**
- * Marks multiple texts within a sentence with HTML tags
+ * Marks multiple strings within a sentence with HTML tags
  *
  * @param {string}        sentence The unmarked text.
  * @param {Array<string>} marks    Text to search for and mark.

--- a/src/stringProcessing/wrapStringWithRegex.js
+++ b/src/stringProcessing/wrapStringWithRegex.js
@@ -1,0 +1,26 @@
+/** @module stringProcessing/wrapStringWithRegex */
+
+/**
+ * Replaces all occurrences in a string and wrap them.
+ *
+ * @param {string} text        The text to look through.
+ * @param {string} search      A string to use as regex.
+ * @param {string} wrapPrefix  Insert this before the found text.
+ * @param {string} wrapSuffix  Insert this after the found text.
+ *
+ * @returns {string} The text with all the found string wrapped.
+ */
+module.exports = function( text, search, wrapPrefix = "", wrapSuffix = "" ) {
+	let leftover = text;
+	let regex = new RegExp( search, "ig" );
+	let result = "";
+	let index;
+
+	while ( ( index = leftover.search( regex ) ) !== -1 ) {
+		let original = leftover.substr( index, search.length );
+		result += leftover.substr( 0, index ) + wrapPrefix + original + wrapSuffix;
+		leftover = leftover.substr( index + search.length );
+	}
+
+	return result + leftover;
+};

--- a/src/stringProcessing/wrapStringWithRegex.js
+++ b/src/stringProcessing/wrapStringWithRegex.js
@@ -1,14 +1,14 @@
 /** @module stringProcessing/wrapStringWithRegex */
 
 /**
- * Replaces all occurrences in a string and wrap them.
+ * Replaces all occurrences in a string and wraps them.
  *
  * @param {string} text        The text to look through.
  * @param {string} search      A string to use as regex.
  * @param {string} wrapPrefix  Insert this before the found text.
  * @param {string} wrapSuffix  Insert this after the found text.
  *
- * @returns {string} The text with all the found string wrapped.
+ * @returns {string} The text with all the found strings wrapped.
  */
 module.exports = function( text, search, wrapPrefix = "", wrapSuffix = "" ) {
 	let leftover = text;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
A highlighted transition word sentence is no longer highlighted completely, but only the transition words themselves in that sentence; As received by the researcher.

### Notable

The researcher also checks for certain two part transition words. If those are found it returns the transition words with the words in between those two parts included.

Example sentence: "The best result does not only mean the best answer, but it also means the best experience.".
The new returned highlight is: " not only mean the best answer, but ". Where before the whole sentence was highlighted.

## Relevant technical choices:

* The mark in the current state does not keep track of where it is found in the text. This is why the whole sentence is used in a mark. And there can be multiple marks in that sentence.
* The original casing needs to be preserved, this is the reason for the search with leftover in the wrapStringWithRegex file.

## Test instructions

This PR can be tested by following these steps:

* Link YoastSEO.js to wordpress-seo using yarn link and build the project.
* Edit a few posts and in the Yoast SEO readability checks, highlight the transition words. Check if the transition words are correctly highlighted, preserving the case.

Fixes Yoast/wordpress-seo#6525
