### PR TITLE
Add Portuguese transition word assessment

### DIFF
--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -1,291 +1,314 @@
 let transitionWordsResearch = require( "../../js/researches/findTransitionWords.js" );
 let Paper = require( "../../js/values/Paper.js" );
 
-describe("a test for finding transition words from a string", function() {
+describe( "a test for finding transition words from a string", function () {
 	let mockPaper, result;
 
-	it("returns 1 when a transition word is found in the middle of a sentence (English)", function () {
+	it( "returns 1 when a transition word is found in the middle of a sentence (English)", function () {
 		// Transition word: above all.
-		mockPaper = new Paper("this story is, above all, about a boy", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "this story is, above all, about a boy", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a transition word with capital is found at the beginning of a sentence (English)", function () {
+	it( "returns 1 when a transition word with capital is found at the beginning of a sentence (English)", function () {
 		// Transition word: firstly.
-		mockPaper = new Paper("Firstly, I'd like to say", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Firstly, I'd like to say", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a transition word combination is found in the middle of a sentence (English)", function () {
+	it( "returns 1 when a transition word combination is found in the middle of a sentence (English)", function () {
 		// Transition word: different from.
-		mockPaper = new Paper("that is different from something else", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "that is different from something else", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a transition word combination is found at the end of a sentence (English)", function () {
+	it( "returns 1 when a transition word combination is found at the end of a sentence (English)", function () {
 		// Transition word: for example.
-		mockPaper = new Paper("A story, for example", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "A story, for example", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word  is found in a sentence (English)", function () {
+	it( "returns 1 when a two-part transition word  is found in a sentence (English)", function () {
 		// Transition word: either...or.
-		mockPaper = new Paper("I will either tell you a story, or read you a novel.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "I will either tell you a story, or read you a novel.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word  is found in a sentence, and no transition word in another sentence. (English)", function () {
+	it( "returns 1 when a two-part transition word  is found in a sentence, and no transition word in another sentence. (English)", function () {
 		// Transition word: either...or.
-		mockPaper = new Paper("I will either tell you a story, or read you a novel. Okay?", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "I will either tell you a story, or read you a novel. Okay?", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 2 when a two-part transition word  is found in a sentence, and a transition word in another sentence. (English)", function () {
+	it( "returns 2 when a two-part transition word  is found in a sentence, and a transition word in another sentence. (English)", function () {
 		// Transition words: either...or, unless.
-		mockPaper = new Paper("I will either tell you a story, or read you a novel. Unless it is about a boy.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(2);
-	});
+		mockPaper = new Paper( "I will either tell you a story, or read you a novel. Unless it is about a boy.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 2 );
+	} );
 
-	it("returns 2 when a two-part transition word is found in two sentences. (English)", function () {
+	it( "returns 2 when a two-part transition word is found in two sentences. (English)", function () {
 		// Transition words: either...or, if...then.
-		mockPaper = new Paper("I will either tell you a story, or read you a novel. If you want, then I will.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(2);
-	});
+		mockPaper = new Paper( "I will either tell you a story, or read you a novel. If you want, then I will.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 2 );
+	} );
 
-	it("returns 2 when a two-part transition word is found in two sentences, and an additional transition word is found in one of them. (English)", function () {
+	it( "returns 2 when a two-part transition word is found in two sentences, and an additional transition word is found in one of them. (English)", function () {
 		// Transition words: either...or, if ...then, as soon as.
-		mockPaper = new Paper("I will either tell you a story about a boy, or read you a novel. If you want, then I will start as soon as you're ready.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(2);
-	});
+		mockPaper = new Paper( "I will either tell you a story about a boy, or read you a novel. If you want, then I will start as soon as you're ready.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 2 );
+	} );
 
-	it("returns 1 when a transition word abbreviation found in a sentence (English)", function () {
+	it( "returns 1 when a transition word abbreviation found in a sentence (English)", function () {
 		// Transition word: e.g..
-		mockPaper = new Paper("That is e.g. a story...", { locale: 'en_US'} );
-		 result = transitionWordsResearch(mockPaper);
-		 expect(result.totalSentences).toBe(1);
-		 expect(result.transitionWordSentences).toBe(1);
-	 });
+		mockPaper = new Paper( "That is e.g. a story...", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when 2 transition words are found in the same sentence (English)", function () {
+	it( "returns 1 when 2 transition words are found in the same sentence (English)", function () {
 		// Transition words: firstly, for example.
-		mockPaper = new Paper("Firstly, I'd like to tell a story, for example", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Firstly, I'd like to tell a story, for example", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 2 when 2 transition words are found in two sentences (1 transition word each) (English)", function () {
+	it( "returns 2 when 2 transition words are found in two sentences (1 transition word each) (English)", function () {
 		// Transition words: firstly, for example.
-		mockPaper = new Paper("Firstly, I'd like to tell a story. For example.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(2);
-	});
+		mockPaper = new Paper( "Firstly, I'd like to tell a story. For example.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 2 );
+	} );
 
-	it("returns 2 in the case of a sentence with 1 transition word and a sentence with 2 transition words) (English)", function () {
+	it( "returns 2 in the case of a sentence with 1 transition word and a sentence with 2 transition words) (English)", function () {
 		// Transition words: firstly, for example, as I have said.
-		mockPaper = new Paper("Firstly, I'd like to tell a story. For example, about you, as I have said.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(2);
-	});
+		mockPaper = new Paper( "Firstly, I'd like to tell a story. For example, about you, as I have said.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 2 );
+	} );
 
-	it("returns 1 in the case of a sentence with 1 transition word and a sentence without transition words) (English)", function () {
+	it( "returns 1 in the case of a sentence with 1 transition word and a sentence without transition words) (English)", function () {
 		// Transition word: firstly.
-		mockPaper = new Paper("Firstly, I'd like to tell a story. Haha.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(2);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Firstly, I'd like to tell a story. Haha.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 2 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word  is found in a sentence (English)", function () {
+	it( "returns 1 when a two-part transition word  is found in a sentence (English)", function () {
 		// Transition word: either...or.
-		mockPaper = new Paper("I will either tell you a story, or read you a novel.", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "I will either tell you a story, or read you a novel.", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 0 when no transition words are present in a sentence (English)", function () {
-		mockPaper = new Paper("nothing special", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in a sentence (English)", function () {
+		mockPaper = new Paper( "nothing special", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("returns 0 when no transition words are present in multiple sentences (English)", function () {
-		mockPaper = new Paper("nothing special. Nothing special Either. Boring!", { locale: 'en_US'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(3);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in multiple sentences (English)", function () {
+		mockPaper = new Paper( "nothing special. Nothing special Either. Boring!", { locale: 'en_US' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 3 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("returns 1 when a transition word is found in a sentence (German)", function () {
+	it( "returns 1 when a transition word is found in a sentence (German)", function () {
 		// Transition word: zuerst.
-		mockPaper = new Paper("Zuerst werde ich versuchen zu verstehen, warum er so denkt.", { locale: 'de_DE'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Zuerst werde ich versuchen zu verstehen, warum er so denkt.", { locale: 'de_DE' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a transition abbreviation is found in a sentence (German)", function () {
+	it( "returns 1 when a transition abbreviation is found in a sentence (German)", function () {
 		// Transition word: z.b.
-		mockPaper = new Paper("Ich werde z.b. versuchen zu verstehen, warum er so denkt.", { locale: 'de_DE'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Ich werde z.b. versuchen zu verstehen, warum er so denkt.", { locale: 'de_DE' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word is found in a sentence (German)", function () {
+	it( "returns 1 when a two-part transition word is found in a sentence (German)", function () {
 		// Transition word: nicht nur...sondern.
-		mockPaper = new Paper("Man soll nicht nur in seinen Liebesbeziehungen, sondern in sämtlichen Lebensbereichen um das Glück kämpfen.", { locale: 'de_DE'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Man soll nicht nur in seinen Liebesbeziehungen, sondern in sämtlichen Lebensbereichen um das Glück kämpfen.", { locale: 'de_DE' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 0 when no transition words are present in a sentence (German)", function () {
-		mockPaper = new Paper("Eins, zwei, drei.", { locale: 'de_DE'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in a sentence (German)", function () {
+		mockPaper = new Paper( "Eins, zwei, drei.", { locale: 'de_DE' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("returns 1 when a transition word is found in a sentence (French)", function () {
+	it( "returns 1 when a transition word is found in a sentence (French)", function () {
 		// Transition word: deuxièmement.
-		mockPaper = new Paper("Deuxièmement, il convient de reconnaître la complexité des tâches à entreprendre.", { locale: 'fr_FR'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Deuxièmement, il convient de reconnaître la complexité des tâches à entreprendre.", { locale: 'fr_FR' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word is found in a sentence (French)", function () {
+	it( "returns 1 when a two-part transition word is found in a sentence (French)", function () {
 		// Transition word: non seulement, mais encore.
-		mockPaper = new Paper("Non seulement on l’estime, mais encore on l’aime.", { locale: 'fr_FR'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Non seulement on l’estime, mais encore on l’aime.", { locale: 'fr_FR' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a transition word with an apostrophe is found in a sentence (French)", function () {
+	it( "returns 1 when a transition word with an apostrophe is found in a sentence (French)", function () {
 		// Transition word: quoi qu’il en soit.
-		mockPaper = new Paper("Quoi qu’il en soit, le gouvernement du Mali a perdu sa légitimité.", { locale: 'fr_FR'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Quoi qu’il en soit, le gouvernement du Mali a perdu sa légitimité.", { locale: 'fr_FR' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 0 when no transition words are present in a sentence (French)", function () {
-		mockPaper = new Paper("Une, deux, trois.", { locale: 'fr_FR'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in a sentence (French)", function () {
+		mockPaper = new Paper( "Une, deux, trois.", { locale: 'fr_FR' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("returns 1 when a transition word is found in a sentence (Dutch)", function () {
+	it( "returns 1 when a transition word is found in a sentence (Dutch)", function () {
 		// Transition word: want.
-		mockPaper = new Paper("Want daar brandt nog licht.", { locale: 'nl_NL'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Want daar brandt nog licht.", { locale: 'nl_NL' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word is found in a sentence (Dutch)", function () {
+	it( "returns 1 when a two-part transition word is found in a sentence (Dutch)", function () {
 		// Transition word: zowel, als.
-		mockPaper = new Paper("Zowel 'deze' als 'zin' staat in deze zin.", { locale: 'nl_NL'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Zowel 'deze' als 'zin' staat in deze zin.", { locale: 'nl_NL' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 0 when no transition words are present in a sentence (Dutch)", function () {
-		mockPaper = new Paper("Een, twee, drie.", { locale: 'nl_NL'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in a sentence (Dutch)", function () {
+		mockPaper = new Paper( "Een, twee, drie.", { locale: 'nl_NL' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("returns 1 when a transition word is found in a sentence (Spanish)", function () {
+	it( "returns 1 when a transition word is found in a sentence (Spanish)", function () {
 		// Transition word: por el contrario.
-		mockPaper = new Paper("Por el contrario, desea que se inicien cambios beneficiosos en Europa.", { locale: 'es_ES'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Por el contrario, desea que se inicien cambios beneficiosos en Europa.", { locale: 'es_ES' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word is found in a sentence (Spanish)", function () {
+	it( "returns 1 when a two-part transition word is found in a sentence (Spanish)", function () {
 		// Transition word: de un lado...de otra parte.
-		mockPaper = new Paper("Se trata además, de una restauración que ha pretendido de un lado ser reversible y que de otra parte ha intentado minimizar al máximo el impacto material.", { locale: 'es_ES'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Se trata además, de una restauración que ha pretendido de un lado ser reversible y que de otra parte ha intentado minimizar al máximo el impacto material.", { locale: 'es_ES' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 0 when no transition words are present in a sentence (Spanish)", function () {
-		mockPaper = new Paper("Uno, dos, tres.", { locale: 'es_ES'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in a sentence (Spanish)", function () {
+		mockPaper = new Paper( "Uno, dos, tres.", { locale: 'es_ES' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("returns 1 when a transition word is found in a sentence (Italian)", function () {
+	it( "returns 1 when a transition word is found in a sentence (Italian)", function () {
 		// Transition word: in conclusione.
-		mockPaper = new Paper("In conclusione, possiamo dire che il risultato è ottimo.", { locale: 'it_IT'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "In conclusione, possiamo dire che il risultato è ottimo.", { locale: 'it_IT' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 1 when a two-part transition word is found in a sentence (Italian)", function () {
+	it( "returns 1 when a two-part transition word is found in a sentence (Italian)", function () {
 		// Transition word: no ... ma.
-		mockPaper = new Paper("No, non credo che sia una buona idea ma possiamo sempre verificare caso per caso.", { locale: 'it_IT'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "No, non credo che sia una buona idea ma possiamo sempre verificare caso per caso.", { locale: 'it_IT' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("returns 0 when no transition words are present in a sentence (Italian)", function () {
-		mockPaper = new Paper("Uno, due, tre.", { locale: 'it_IT'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+	it( "returns 0 when no transition words are present in a sentence (Italian)", function () {
+		mockPaper = new Paper( "Uno, due, tre.", { locale: 'it_IT' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it("defaults to English in case of a bogus locale", function () {
+	it( "returns 1 when a transition word is found in a sentence (Portuguese)", function () {
+		// Transition word: por exemplo
+		mockPaper = new Paper( "Por exemplo, a maioria das lojas está fechada hoje.", { locale: 'pt_PT' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+
+	it( "returns 1 when a two-part transition word is found in a sentence (Portuguese)", function () {
+		// Transition word: ora...ora
+		mockPaper = new Paper("Ora a criança chora, ora a criança ri.", { locale: 'pt_PT'} );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+
+	it( "returns 0 when no transition words are present in a sentence (Portuguese)", function () {
+		mockPaper = new Paper( "A pintura é bonita.", { locale: 'pt_PT' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
+
+	it( "defaults to English in case of a bogus locale", function () {
 		// Transition word: because.
-		mockPaper = new Paper("Because of a bogus locale.", { locale: 'xx_YY'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(1);
-	});
+		mockPaper = new Paper( "Because of a bogus locale.", { locale: 'xx_YY' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 
-	it("defaults to English in case of a bogus locale", function () {
+	it( "defaults to English in case of a bogus locale", function () {
 		// Transition word: none in English (but zuerst is a German transition word).
-		mockPaper = new Paper("Zuerst eine bogus locale.", { locale: 'xx_YY'} );
-		result = transitionWordsResearch(mockPaper);
-		expect(result.totalSentences).toBe(1);
-		expect(result.transitionWordSentences).toBe(0);
-	});
+		mockPaper = new Paper( "Zuerst eine bogus locale.", { locale: 'xx_YY' } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
 
-	it( "works with normalizes quotes", function() {
+	it( "works with normalizes quotes", function () {
 		// Transition word: what’s more.
 		mockPaper = new Paper( "what’s more", {} );
 		result = transitionWordsResearch( mockPaper );
@@ -300,22 +323,22 @@ describe("a test for finding transition words from a string", function() {
 			],
 			transitionWordSentences: 1
 		} );
-	});
+	} );
 
-	it( "works with the no-break space character", function() {
+	it( "works with the no-break space character", function () {
 		// Transition word: then.
 		mockPaper = new Paper( "and\u00a0then" );
 		let expected = {
 			totalSentences: 1,
-			sentenceResults: [{
+			sentenceResults: [ {
 				sentence: "and\u00a0then",
 				transitionWords: [ "then" ]
-			}],
+			} ],
 			transitionWordSentences: 1
 		};
 
 		let result = transitionWordsResearch( mockPaper );
 
 		expect( result ).toEqual( expected );
-	});
+	} );
 } );

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ let Mark = require( "../../values/Mark.js" );
 let marker = require( "../../markers/addMark.js" );
 
 let getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
-let availableLanguages = [ "en", "de", "es", "fr", "nl", "it" ];
+let availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/src/helpers/getTransitionWords.js
+++ b/src/helpers/getTransitionWords.js
@@ -10,6 +10,8 @@ let transitionWordsDutch = require( "../researches/dutch/transitionWords.js" )()
 let twoPartTransitionWordsDutch = require( "../researches/dutch/twoPartTransitionWords.js" );
 let transitionWordsItalian = require( "../researches/italian/transitionWords.js" )().allWords;
 let twoPartTransitionWordsItalian = require( "../researches/italian/twoPartTransitionWords.js" );
+let transitionWordsPortuguese = require( "../researches/portuguese/transitionWords.js" )().allWords;
+let twoPartTransitionWordsPortuguese = require( "../researches/portuguese/twoPartTransitionWords.js" );
 
 let getLanguage = require( "./getLanguage.js" );
 
@@ -39,6 +41,11 @@ module.exports = function( locale ) {
 			return {
 				transitionWords: transitionWordsItalian,
 				twoPartTransitionWords: twoPartTransitionWordsItalian,
+			};
+		case "pt":
+			return {
+				transitionWords: transitionWordsPortuguese,
+				twoPartTransitionWords: twoPartTransitionWordsPortuguese,
 			};
 		default:
 		case "en":

--- a/src/researches/portuguese/transitionWords.js
+++ b/src/researches/portuguese/transitionWords.js
@@ -1,10 +1,10 @@
 let singleWords = [ "ademais", "afinal", "aliás", "analogamente", "anteriormente", "assim", "certamente", "conforme",
-	"conquanto", "contudo", "decerto", "demais", "embora", "enfim", "enquanto", "então", "entretanto", "eventualmente",
-	"igualmente", "inegavelmente", "inesperadamente", "mas", "menos", "outrossim", "pois", "porquanto", "porque", "portanto",
-	"posteriormente", "precipuamente", "primeiramente", "primordialmente", "principalmente", "quando", "salvo",
+	"conquanto", "contudo", "decerto", "embora", "enfim", "enquanto", "então", "entretanto", "eventualmente",
+	"igualmente", "inegavelmente", "inesperadamente", "mas", "outrossim", "pois", "porquanto", "porque", "portanto",
+	"posteriormente", "precipuamente", "primeiramente", "primordialmente", "principalmente", "salvo",
 	"semelhantemente", "similarmente", "sobretudo", "surpreendentemente", "todavia" ];
 
-let multipleWords = [ "a fim de", "a fim de que", "a menos que", "a princípio", "a saber", "acima de tudo", "ainda mais", "ainda que",
+let multipleWords = [ "a fim de", "a fim de que", "a menos que", "a princípio", "a saber", "acima de tudo", "ainda assim", "ainda mais", "ainda que",
 	"além disso", "antes de mais nada", "antes de tudo", "antes que", "ao mesmo tempo", "ao passo que", "ao propósito",
 	"apesar de", "às vezes", "assim como", "assim que", "assim sendo", "assim também", "bem como", "com a finalidade de",
 	"com efeito", "com o fim de", "com o intuito de", "com o propósito de", "com toda a certeza", "como resultado", "como se",

--- a/src/researches/portuguese/transitionWords.js
+++ b/src/researches/portuguese/transitionWords.js
@@ -1,0 +1,31 @@
+let singleWords = [ "ademais", "afinal", "aliás", "analogamente", "anteriormente", "assim", "certamente", "conforme",
+	"conquanto", "contudo", "decerto", "demais", "embora", "enfim", "enquanto", "então", "entretanto", "eventualmente",
+	"igualmente", "inegavelmente", "inesperadamente", "mas", "menos", "outrossim", "pois", "porquanto", "porque", "portanto",
+	"posteriormente", "precipuamente", "primeiramente", "primordialmente", "principalmente", "quando", "salvo",
+	"semelhantemente", "similarmente", "sobretudo", "surpreendentemente", "todavia" ];
+
+let multipleWords = [ "a fim de", "a fim de que", "a menos que", "a princípio", "a saber", "acima de tudo", "ainda mais", "ainda que",
+	"além disso", "antes de mais nada", "antes de tudo", "antes que", "ao mesmo tempo", "ao passo que", "ao propósito",
+	"apesar de", "às vezes", "assim como", "assim que", "assim sendo", "assim também", "bem como", "com a finalidade de",
+	"com efeito", "com o fim de", "com o intuito de", "com o propósito de", "com toda a certeza", "como resultado", "como se",
+	"da mesma forma", "de acordo com", "de conformidade com", "de fato", "de maneira idêntica", "de tal forma que", "de tal sorte que",
+	"depois que", "desde que", "dessa forma", "dessa maneira", "desse modo", "do mesmo modo", "é provável", "em conclusão",
+	"em contrapartida", "em contraste com", "em outras palavras", "em primeiro lugar", "em princípio", "em resumo", "em seguida",
+	"em segundo lugar", "em síntese", "em suma", "em terceiro lugar", "em virtude de", "finalmente agora atualmente", "isto é",
+	"já que", "logo após", "logo depois", "logo que", "mesmo que", "não apenas", "nesse hiato", "nesse ínterim", "nesse meio tempo",
+	"nesse sentido", "no entanto", "no momento em que", "ou por outra", "ou seja", "para que", "pelo contrário", "por analogia",
+	"por causa de", "por certo", "por conseguinte", "por conseqüência", "por exemplo", "por fim", "por isso", "por mais que",
+	"por menos que", "por outro lado", "posto que", "se acaso", "se bem que", "seja como for", "sem dúvida", "só para exemplificar",
+	"só para ilustrar", "só que", "sob o mesmo ponto de vista", "talvez provavelmente", "tanto quanto", "uma vez que", "visto que" ];
+
+/**
+ * Returns lists with transition words to be used by the assessments.
+ * @returns {Object} The object with transition word lists.
+ */
+module.exports = function() {
+	return {
+		singleWords: singleWords,
+		multipleWords: multipleWords,
+		allWords: singleWords.concat( multipleWords ),
+	};
+};

--- a/src/researches/portuguese/twoPartTransitionWords.js
+++ b/src/researches/portuguese/twoPartTransitionWords.js
@@ -1,0 +1,10 @@
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @returns {Array} The array filled with two-part transition words.
+ */
+module.exports = function() {
+	return [
+		[ "não apenas", "como também" ], [ "não só", "bem como" ], [ "não só", "como também" ],
+		[ "não só", "mas também" ], [ "ora", "ora" ], [ "ou", "ou" ], [ "quer", "quer" ],
+	];
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Introduce transition words assessment for Portuguese.

## Test instructions

This PR can be tested by following these steps:

* Check out the branch.
* Use the browserified example. Don't forget to run a `grunt build:js`.
* Set locale to pt_PT.
* Write a Portuguese sentence containing a one or two-part transition word (see list of transition words).
* Hit the mark transition word sentences button.

Fixes #1413