### PR TITLE
Add prominent words for Portuguese

### DIFF
--- a/spec/helpers/getTransitionWordsSpec.js
+++ b/spec/helpers/getTransitionWordsSpec.js
@@ -23,6 +23,16 @@ describe( "gets transition words, based on language", function() {
 		expect (Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
+	it( "checks if all properties are set for Italian", function() {
+		var transitionWords = getTransitionWords( "it_IT" );
+		expect (Object.keys( transitionWords ) ).toEqual( properties );
+	} );
+
+	it( "checks if all properties are set for Portuguese", function() {
+		var transitionWords = getTransitionWords( "pt_PT" );
+		expect (Object.keys( transitionWords ) ).toEqual( properties );
+	} );
+
 	it( "checks if all properties are set if no locale is given", function() {
 		var transitionWords = getTransitionWords( "" );
 		expect (Object.keys( transitionWords ) ).toEqual( properties );

--- a/spec/stringProcessing/relevantWordsPortugueseSpec.js
+++ b/spec/stringProcessing/relevantWordsPortugueseSpec.js
@@ -1,0 +1,57 @@
+let WordCombination = require( "../../js/values/WordCombination" );
+let relevantWords = require( "../../js/stringProcessing/relevantWords" );
+let getRelevantWords = relevantWords.getRelevantWords;
+let portugueseFunctionWords = require( "../../js/researches/portuguese/functionWords.js" )().all;
+
+describe( "gets Portuguese word combinations", function() {
+	it( "returns word combinations", function() {
+		let input = "Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. " +
+			"Os números oficiais sugerem que o crime está em baixa, mas as autoridades " +
+			"dizem que muitas vítimas pararam de denunciar incidentes. ";
+		let expected = [
+			new WordCombination( [ "vítimas", "pararam", "de", "denunciar", "incidentes" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "pararam", "de", "denunciar", "incidentes" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "vítimas", "pararam", "de", "denunciar" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "números", "oficiais", "sugerem" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "pararam", "de", "denunciar" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "números", "oficiais" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "denunciar", "incidentes" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "vítimas", "pararam" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "oficiais", "sugerem" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "oficiais" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "incidentes" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "denunciar" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "pararam" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "vítimas" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "autoridades" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "crime" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "sugerem" ], 8, portugueseFunctionWords ),
+			new WordCombination( [ "números" ], 8, portugueseFunctionWords ),
+		];
+
+		// Make sure our words aren't filtered by density.
+		spyOn( WordCombination.prototype, "getDensity" ).and.returnValue( 0.01 );
+
+		let words = getRelevantWords( input, "pt_PT" );
+
+		words.forEach( function( word ) {
+			delete( word._relevantWords );
+		});
+
+		expect( words ).toEqual( expected );
+	} ) ;
+});
+

--- a/src/researches/portuguese/functionWords.js
+++ b/src/researches/portuguese/functionWords.js
@@ -115,7 +115,6 @@ let delexicalizedVerbs = [ "dou", "dás", "dá", "damos", "dais", "dão", "dei",
 
 let delexicalizedVerbsInfinitive = [ "dar", "fazer" ];
 
-
 /*
  * These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
  * Keyword combinations containing these adjectives/adverbs are fine.
@@ -152,7 +151,6 @@ let titles = [ "sr", "sra", "sras", "dr", "dra", "prof" ];
 
 module.exports = function() {
 	return {
-
 		// These word categories are filtered at the beginning of word combinations.
 		filteredAtBeginning: generalAdjectivesAdverbs,
 

--- a/src/researches/portuguese/functionWords.js
+++ b/src/researches/portuguese/functionWords.js
@@ -35,8 +35,8 @@ let demonstrativePronouns = [ "aquilo", "àquele", "àquela", "àqueles", "àque
 let possessivePronouns = [ "minhas", "tuas", "suas", "minha", "tua", "sua", "minhas", "tuas", "suas", "vossa", "vossas", "meu",
 	"meus", "teu", "teus", "seu", "seus", "nosso", "nossos", "nossa", "nossas" ];
 
-let quantifiers = [ "vário", "vários", "vária", "várias", "muito", "muitos", "muita", "muitas", "puoco", "puocos", "puoca",
-	"puocas", "bastante" ];
+let quantifiers = [ "apenas", "vário", "vários", "vária", "várias", "mais", "muito", "muitos", "muita", "muitas", "puoco", "puocos", "puoca",
+	"puocas", "bastante", "todo", "todos", "toda", "todas" ];
 
 let indefinitePronouns = [ "alguma", "algumas", "nenhuns", "nenhumas", "todo", "toda", "todas", "outro", "outra", "outros", "outras",
 	"qualquer", "quaisquer", "outrem", "tudo", "nada", "algo", "tanto", "tanta", "tantos", "tantas", "quanto", "quanta", "quantos",
@@ -56,7 +56,11 @@ let otherAuxiliaries = [ "tenho", "tens", "tem", "temos", "tendes", "têm", "tiv
 	"houveram", "havia", "havias", "havíamos", "havíeis", "haviam", "houvera", "houveras", "houvéramos", "houvéreis", "houveram", "haverei",
 	"haverás", "haverá", "haveremos", "havereis", "haverão", "haveria", "haverias", "haveríamos", "haveríeis", "haveriam", "haja", "hajas",
 	"hajamos", "hajais", "hajam", "houvesse", "houvesses", "houvéssemos", "houvésseis", "houvessem", "houver", "houveres", "houvermos",
-	"houverdes", "houverem", "havei", "hajais", "haveres", "havermos", "haverdes", "haverem", "havido" ];
+	"houverdes", "houverem", "havei", "hajais", "haveres", "havermos", "haverdes", "haverem", "havido", "poder", "posso", "podes", "pode",
+	"podemos", "podeis", "podem", "pude", "pudeste", "pôde", "pudemos", "pudestes", "puderam", "podia", "podias", "podia", "podíamos", "podíeis",
+	"podiam", "pudera", "puderas", "pudéramos", "pudéreis", "puderam", "poderei", "poderás", "poderá", "poderemos", "podereis", "poderão",
+	"poderia", "poderias", "poderíamos", "poderíeis", "poderiam", "possa", "possas", "possamos", "possais", "possam", "pudesse", "pudesses",
+	"pudéssemos", "pudésseis", "pudessem", "puder", "puderes", "pudermos", "puderdes", "puderem" ];
 
 let otherAuxiliariesInfinitive = [ "ter", "haver" ];
 
@@ -73,11 +77,12 @@ let copula = [ "sou", "és", "é", "somos", "sois", "fui", "foste", "foi", "fomo
 
 let copulaInfinitive = [ "estar", "ser" ];
 
-let prepositions = [ "a", "ante", "após", "até", "com", "contra", "desde", "sem", "entre", "para", "perante", "sob", "sobre", "trás", "de",
+let prepositions = [ "a", "ante", "antes", "após", "até", "através", "com", "contra", "depois", "desde", "sem", "entre", "para", "pra",
+	"perante", "sob", "sobre", "trás", "de",
 	"por", "em", "ao", "à", "aos", "às", "do", "da", "dos", "das", "dum", "duma", "duns", "dumas", "no", "na", "nos", "nas", "num", "numa",
 	"nuns", "numas", "pelo", "pela", "pelos", "pelas", "deste", "desse", "daquele", "desta", "dessa", "daquela", "destes", "desses",
 	"daqueles", "destas", "dessas", "daquelas", "neste", "nesse", "naquele", "nesta", "nessa", "naquela", "nestes", "nesses", "naqueles",
-	"nestas", "nessas", "naquelas", "disto", "disso", "daquilo", "nisto", "nisso", "naquilo" ];
+	"nestas", "nessas", "naquelas", "disto", "disso", "daquilo", "nisto", "nisso", "naquilo", "durante" ];
 
 let coordinatingConjunctions = [ "também", "e", "ou", "nem" ];
 
@@ -89,14 +94,14 @@ let interviewVerbs = [ "diz", "dizem", "disse", "disseram", "dizia", "diziam", "
 	"reivindicava", "reivindicavam", "requer", "requerem", "requereu", "requereram", "requeria", "requeriam", "afirma", "afirmam",
 	"afirmou", "afirmaram", "afirmava", "afirmavam", "reivindica", "reivindicam", "reivindicou", "reivindicaram", "reivindicava",
 	"reivindicavam", "perguntam", "perguntou", "perguntaram", "perguntava", "perguntavam", "explica", "explicam", "explicou", "explicaram",
-	"explicava", "explicavam" ];
+	"explicava", "explicavam", "relata", "relatam", "relatou", "relataram" ];
 
 // These transition words were not included in the list for the transition word assessment for various reasons.
 let additionalTransitionWords = [ "provavelmente", "imediatamente", "ocasionalmente", "indubitavelmente", "para", "possivelmente",
 	"logo", "simultaneamente", "exceto", "inquestionavelmente" ];
 
 let intensifiers = [ "extremamente", "bem", "completamente", "totalmente", "grandemente", "seriamente", "absolutamente", "bastante",
-	"sobremodo", "sobremaneira" ];
+	"sobremodo", "sobremaneira", "tão" ];
 
 // These verbs convey little meaning.
 let delexicalizedVerbs = [ "dou", "dás", "dá", "damos", "dais", "dão", "dei", "deu", "demos", "deram", "dava", "davas", "dávamos", "dáveis",
@@ -122,7 +127,8 @@ let generalAdjectivesAdverbs = [ "devagar", "rapidamente", "grande", "grandes", 
 	"baixos", "baixas", "longo", "longa", "longos", "longas", "curto", "curta", "curtos", "curtas", "fácil", "fáceis", "difícil", "difíceis",
 	"simples", "mesmo", "mesma", "mesmos", "mesmas", "mêsmo", "mêsmos", "mêsma", "mêsmas", "cedo", "tarde", "importante", "importantes", "capaz",
 	"capazes", "certo", "certa", "certos", "certas", "usual", "usuals", "ultimamente", "possível", "possíveis", "comum", "comuns", "freqüentemente",
-	"constantemente", "continuamente", "diretamente", "levemente", "algures", "semelhante", "semelhantes", "similar", "similares" ];
+	"constantemente", "continuamente", "diretamente", "levemente", "algures", "semelhante", "semelhantes", "similar", "similares", "sempre", "ainda",
+	"já", "atrás", "depois" ];
 
 // "grande", "velho" and "pequeno" can appear both before and after nouns and are therefore on both lists.
 let generalAdjectivesPreceding = [ "pior", "melhor", "melhores", "bom", "boa", "bons", "boas", "bonito", "bonita", "bonitos", "bonitas", "grande",
@@ -137,8 +143,8 @@ let recipeWords = [ "kg", "mg", "gr", "g", "km", "m", "l", "ml", "cl" ];
 let timeWords = [ "segundos", "minuto", "minutos", "hora", "horas", "dia", "dias", "semana", "semanas", "mes", "meses", "ano", "anos", "hoje",
 	"amanhã", "ontem" ];
 
-let vagueNouns = [ "caso", "casos", "coisa", "coisas", "detalhe", "detalhes", "forma", "formas", "jeito", "jeitos", "maneira", "maneiras", "suijeto",
-	"sujeitos", "tópico", "tópicos" ];
+let vagueNouns = [ "caso", "casos", "coisa", "coisas", "detalhe", "detalhes", "forma", "formas", "jeito", "jeitos",
+	"maneira", "maneiras", "modo", "modos", "suijeto", "sujeitos", "tópico", "tópicos", "vez", "vezes" ];
 
 let miscellaneous = [ "sim", "não", "ok", "amém", "etc", "euro", "euros", "adeus", "jeitos" ];
 

--- a/src/researches/portuguese/functionWords.js
+++ b/src/researches/portuguese/functionWords.js
@@ -1,13 +1,14 @@
 let transitionWords = require( "./transitionWords.js" )().singleWords;
 
 /**
- * Returns an array with exceptions for the prominent words researcher
+ * Returns an array with exceptions for the prominent words researcher.
+ *
  * @returns {Array} The array filled with exceptions.
  */
 
 let articles = [ "o", "a", "os", "as", "um", "uns", "uma", "umas" ];
 
-// "Um" is already included in the articles.
+// "um" is already included in the articles.
 let cardinalNumerals = [ "uma", "duas", "dois", "três", "cuatro", "cinco", "seis", "sete", "oito", "nove", "dez", "onze", "doze",
 	"treze", "quatorze", "catorze", "quinze", "dezesseis", "dezessete", "dezasseis", "dezassete", "dezoito", "dezenove", "dezanove",
 	"vinte", "cem", "cento", "mil", "milhão", "milhões", "bilhão", "bilhões" ];
@@ -19,7 +20,7 @@ let ordinalNumerals = [ "primeiro", "primeiros", "primeira", "primeiras", "segun
 
 let personalPronounsNominative = [ "eu", "tu", "ele", "ela", "nós", "vós", "você", "vocês", "eles", "elas" ];
 
-// "o", "a", "os", "as" are already included in the articles
+// "o", "a", "os", "as" are already included in the articles.
 let personalPronounsAccusative = [ "me", "te", "lhe", "nos", "vos", "lhes" ];
 
 let personalPronounsPrepositional = [ "dele", "dela", "deles", "delas", "nele", "nela", "neles", "nelas", "mim", "ti", "si" ];
@@ -59,7 +60,7 @@ let otherAuxiliaries = [ "tenho", "tens", "tem", "temos", "tendes", "têm", "tiv
 
 let otherAuxiliariesInfinitive = [ "ter", "haver" ];
 
-// "são", "era", "estado" are not included because of other meanings
+// "são", "era", "estado" are not included because of other meanings.
 let copula = [ "sou", "és", "é", "somos", "sois", "fui", "foste", "foi", "fomos", "fostes", "foram", "eras", "éramos", "éreis", "eram",
 	"fôramos", "fôreis", "fora", "foras", "foram", "serei", "serás", "será", "seremos", "sereis", "serão", "seria", "serias", "seríamos",
 	"seríeis", "seriam", "seja", "sejas", "seja", "sejamos", "sejais", "sejam", "fosse", "fosses", "fôssemos", "fôsseis", "fossem", "for",
@@ -109,8 +110,11 @@ let delexicalizedVerbs = [ "dou", "dás", "dá", "damos", "dais", "dão", "dei",
 
 let delexicalizedVerbsInfinitive = [ "dar", "fazer" ];
 
-// These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
-// Keyword combinations containing these adjectives/adverbs are fine.
+
+/*
+ * These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
+ * Keyword combinations containing these adjectives/adverbs are fine.
+ */
 let generalAdjectivesAdverbs = [ "devagar", "rapidamente", "grande", "grandes", "depressa", "claramente", "effectivamente", "realmente",
 	"exclusivamente", "simplesemente", "somente", "unicamente", "lentamente", "raramente", "certamente", "talvez", "actualmente", "dificilmente",
 	"principalmente", "gerlamente", "enorme", "enormes", "pequeno", "pequena", "pequenos", "pequenas", "minúsculo", "minúsculos", "minúscula",
@@ -120,7 +124,7 @@ let generalAdjectivesAdverbs = [ "devagar", "rapidamente", "grande", "grandes", 
 	"capazes", "certo", "certa", "certos", "certas", "usual", "usuals", "ultimamente", "possível", "possíveis", "comum", "comuns", "freqüentemente",
 	"constantemente", "continuamente", "diretamente", "levemente", "algures", "semelhante", "semelhantes", "similar", "similares" ];
 
-// "grande", "velho" and "pequeno" can appear both before and after nouns and are therefore on both lists
+// "grande", "velho" and "pequeno" can appear both before and after nouns and are therefore on both lists.
 let generalAdjectivesPreceding = [ "pior", "melhor", "melhores", "bom", "boa", "bons", "boas", "bonito", "bonita", "bonitos", "bonitas", "grande",
 	"grandes", "pequeno", "pequena", "pequenos", "pequenas", "velho", "velhos", "velha", "velhas", "mau", "má", "maus", "más" ];
 
@@ -129,11 +133,10 @@ let interjections = [ "ai", "ah", "ih", "alô", "oi", "olá", "ui", "uf", "psiu"
 // These words and abbreviations are frequently used in recipes in lists of ingredients.
 let recipeWords = [ "kg", "mg", "gr", "g", "km", "m", "l", "ml", "cl" ];
 
-// "segundo" is already included in cardinal numbers
+// "segundo" is already included in cardinal numbers.
 let timeWords = [ "segundos", "minuto", "minutos", "hora", "horas", "dia", "dias", "semana", "semanas", "mes", "meses", "ano", "anos", "hoje",
 	"amanhã", "ontem" ];
 
-// 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
 let vagueNouns = [ "caso", "casos", "coisa", "coisas", "detalhe", "detalhes", "forma", "formas", "jeito", "jeitos", "maneira", "maneiras", "suijeto",
 	"sujeitos", "tópico", "tópicos" ];
 

--- a/src/researches/portuguese/functionWords.js
+++ b/src/researches/portuguese/functionWords.js
@@ -1,0 +1,172 @@
+let transitionWords = require( "./transitionWords.js" )().singleWords;
+
+/**
+ * Returns an array with exceptions for the prominent words researcher
+ * @returns {Array} The array filled with exceptions.
+ */
+
+let articles = [ "o", "a", "os", "as", "um", "uns", "uma", "umas" ];
+
+// "Um" is already included in the articles.
+let cardinalNumerals = [ "uma", "duas", "dois", "três", "cuatro", "cinco", "seis", "sete", "oito", "nove", "dez", "onze", "doze",
+	"treze", "quatorze", "catorze", "quinze", "dezesseis", "dezessete", "dezasseis", "dezassete", "dezoito", "dezenove", "dezanove",
+	"vinte", "cem", "cento", "mil", "milhão", "milhões", "bilhão", "bilhões" ];
+
+let ordinalNumerals = [ "primeiro", "primeiros", "primeira", "primeiras", "segundo", "segunda", "segundos", "segundas", "terceiro",
+	"terceira", "terceiros", "terceiras", "quarto", "quartos", "quarta", "quartas", "quinto", "quintos", "quinta", "quintas",
+	"sexto", "sextos", "sexta", "sextas", "sétimo", "sétimos", "sétima", "sétimas", "oitavo", "oitavos", "oitava", "oitavas",
+	"nono", "nonos", "nona", "nonas", "décimo", "décimos", "décima", "décimas", "vigésimo", "vigésimos", "vigésima", "vigésimas" ];
+
+let personalPronounsNominative = [ "eu", "tu", "ele", "ela", "nós", "vós", "você", "vocês", "eles", "elas" ];
+
+// "o", "a", "os", "as" are already included in the articles
+let personalPronounsAccusative = [ "me", "te", "lhe", "nos", "vos", "lhes" ];
+
+let personalPronounsPrepositional = [ "dele", "dela", "deles", "delas", "nele", "nela", "neles", "nelas", "mim", "ti", "si" ];
+
+let personalPronounsComitative = [ "conmigo", "contigo", "consigo", "convosco", "conosco", "connosco" ];
+
+let reflexivePronouns = [ "se" ];
+
+let demonstrativePronouns = [ "aquilo", "àquele", "àquela", "àqueles", "àquelas", "àquilo", "este", "estes", "esta", "estas",
+	"àqueles", "aqueles", "aquele", "aquela", "aquelas", "aquilo", "esse", "esses", "essa", "essas", "isto", "isso" ];
+
+let possessivePronouns = [ "minhas", "tuas", "suas", "minha", "tua", "sua", "minhas", "tuas", "suas", "vossa", "vossas", "meu",
+	"meus", "teu", "teus", "seu", "seus", "nosso", "nossos", "nossa", "nossas" ];
+
+let quantifiers = [ "vário", "vários", "vária", "várias", "muito", "muitos", "muita", "muitas", "puoco", "puocos", "puoca",
+	"puocas", "bastante" ];
+
+let indefinitePronouns = [ "alguma", "algumas", "nenhuns", "nenhumas", "todo", "toda", "todas", "outro", "outra", "outros", "outras",
+	"qualquer", "quaisquer", "outrem", "tudo", "nada", "algo", "tanto", "tanta", "tantos", "tantas", "quanto", "quanta", "quantos",
+	"quantas", "ninguém", "cada" ];
+
+let interrogativePronouns = [ "quais", "qual", "quem", "cujo", "cuja", "cujos", "cujas" ];
+
+let interrogativeProAdverbs = [ "como", "porque", "quanto", "quanta", "onde", "quando", "quão", "quantos", "quantas", "donde", "aonde", "que" ];
+
+let locativeAdverbs = [ "cá", "além", "aqui", "ali", "lá", "acolá", "aí" ];
+
+let otherAuxiliaries = [ "tenho", "tens", "tem", "temos", "tendes", "têm", "tive", "tiveste", "teve", "tivemos", "tivestes", "tiveram",
+	"tínhamos", "tínheis", "tinham", "tivera", "tiveras", "tivéramos", "tivéreis", "tiveram", "terei", "terás", "terá", "teremos",
+	"tereis", "terão", "teria", "terias", "teríamos", "teríeis", "teriam", "tenha", "tenhas", "tenhamos", "tenhais", "tenham", "tivesse",
+	"tivesses", "tivéssemos", "tivésseis", "tivessem", "tiver", "tiveres", "tivermos", "tiverdes", "tiverem", "tende", "teres", "termos",
+	"terdes", "terem", "tido", "hei", "hás", "há", "havemos", "hemos", "haveis", "heis", "hão", "houve", "houveste", "houvemos", "houvestes",
+	"houveram", "havia", "havias", "havíamos", "havíeis", "haviam", "houvera", "houveras", "houvéramos", "houvéreis", "houveram", "haverei",
+	"haverás", "haverá", "haveremos", "havereis", "haverão", "haveria", "haverias", "haveríamos", "haveríeis", "haveriam", "haja", "hajas",
+	"hajamos", "hajais", "hajam", "houvesse", "houvesses", "houvéssemos", "houvésseis", "houvessem", "houver", "houveres", "houvermos",
+	"houverdes", "houverem", "havei", "hajais", "haveres", "havermos", "haverdes", "haverem", "havido" ];
+
+let otherAuxiliariesInfinitive = [ "ter", "haver" ];
+
+// "são", "era", "estado" are not included because of other meanings
+let copula = [ "sou", "és", "é", "somos", "sois", "fui", "foste", "foi", "fomos", "fostes", "foram", "eras", "éramos", "éreis", "eram",
+	"fôramos", "fôreis", "fora", "foras", "foram", "serei", "serás", "será", "seremos", "sereis", "serão", "seria", "serias", "seríamos",
+	"seríeis", "seriam", "seja", "sejas", "seja", "sejamos", "sejais", "sejam", "fosse", "fosses", "fôssemos", "fôsseis", "fossem", "for",
+	"fores", "formos", "fordes", "forem", "sê", "sede", "sermos", "serdes", "serem", "seres", "sido", "estou", "está", "estamos", "estás",
+	"estás", "estais", "estão", "estive", "estiveste", "esteve", "estivemos", "estivestes", "estiveram", "estava", "estavas", "estávamos",
+	"estáveis", "estavam", "estivera", "estiveras", "estivéramos", "estivéreis", "estiveram", "estarei", "estarás", "estará", "estaremos",
+	"estareis", "estarão", "estaria", "estarias", "estaríamos", "estaríeis", "estariam", "esteja", "estejas", "estejamos", "estejais",
+	"estejam", "estivesse", "estivesses", "estivéssemos", "estivésseis", "estivessem", "estiver", "estiveres", "estivermos", "estiverdes",
+	"estiverem", "estai", "estejas", "estejais", "estares", "estarmos", "estardes", "estarem" ];
+
+let copulaInfinitive = [ "estar", "ser" ];
+
+let prepositions = [ "a", "ante", "após", "até", "com", "contra", "desde", "sem", "entre", "para", "perante", "sob", "sobre", "trás", "de",
+	"por", "em", "ao", "à", "aos", "às", "do", "da", "dos", "das", "dum", "duma", "duns", "dumas", "no", "na", "nos", "nas", "num", "numa",
+	"nuns", "numas", "pelo", "pela", "pelos", "pelas", "deste", "desse", "daquele", "desta", "dessa", "daquela", "destes", "desses",
+	"daqueles", "destas", "dessas", "daquelas", "neste", "nesse", "naquele", "nesta", "nessa", "naquela", "nestes", "nesses", "naqueles",
+	"nestas", "nessas", "naquelas", "disto", "disso", "daquilo", "nisto", "nisso", "naquilo" ];
+
+let coordinatingConjunctions = [ "também", "e", "ou", "nem" ];
+
+let subordinatingConjunctions = [ "agora", "conforme", "conquanto", "contanto", "embora", "enquanto", "então", "entretanto", "malgrado",
+	"mas", "pois", "porém", "porquanto", "porque", "senão", "contudo" ];
+
+// These verbs are frequently used in interviews to indicate questions and answers.
+let interviewVerbs = [ "diz", "dizem", "disse", "disseram", "dizia", "diziam", "reivindica", "reivindicam", "reivindicou", "reivindicaram",
+	"reivindicava", "reivindicavam", "requer", "requerem", "requereu", "requereram", "requeria", "requeriam", "afirma", "afirmam",
+	"afirmou", "afirmaram", "afirmava", "afirmavam", "reivindica", "reivindicam", "reivindicou", "reivindicaram", "reivindicava",
+	"reivindicavam", "perguntam", "perguntou", "perguntaram", "perguntava", "perguntavam", "explica", "explicam", "explicou", "explicaram",
+	"explicava", "explicavam" ];
+
+// These transition words were not included in the list for the transition word assessment for various reasons.
+let additionalTransitionWords = [ "provavelmente", "imediatamente", "ocasionalmente", "indubitavelmente", "para", "possivelmente",
+	"logo", "simultaneamente", "exceto", "inquestionavelmente" ];
+
+let intensifiers = [ "extremamente", "bem", "completamente", "totalmente", "grandemente", "seriamente", "absolutamente", "bastante",
+	"sobremodo", "sobremaneira" ];
+
+// These verbs convey little meaning.
+let delexicalizedVerbs = [ "dou", "dás", "dá", "damos", "dais", "dão", "dei", "deu", "demos", "deram", "dava", "davas", "dávamos", "dáveis",
+	"davam", "dera", "deras", "déramos", "déreis", "deram", "darei", "darás", "dará", "daremos", "dareis", "darão", "daria", "darias",
+	"daríamos", "daríeis", "dariam", "dê", "dês", "dêmos", "deis", "deem", "déssemos", "désseis", "dessem", "der", "deres", "dermos", "derdes",
+	"derem", "dai", "deis", "dares", "darmos", "dardes", "darem", "fazendo", "faço", "fazes", "faz", "fazemos", "fazeis", "fazem", "fiz",
+	"fizeste", "fez", "fizemos", "fizestes", "fizeram", "fazia", "fazias", "fazíamos", "fazíeis", "faziam", "fizera", "fizeras", "fizéramos",
+	"fizéreis", "farei", "farás", "fará", "faremos", "fareis", "faria", "farias", "faríamos", "faríeis", "fariam", "faça", "faças", "façamos",
+	"façais", "façam", "fizesse", "fizesses", "fizéssemos", "fizésseis", "fizessem", "fizer", "fizeres", "fizermos", "fizerdes", "fizerem",
+	"fazei", "fazeres", "fazermos", "fazerdes", "fazerem" ];
+
+let delexicalizedVerbsInfinitive = [ "dar", "fazer" ];
+
+// These adjectives and adverbs are so general, they should never be suggested as a (single) keyword.
+// Keyword combinations containing these adjectives/adverbs are fine.
+let generalAdjectivesAdverbs = [ "devagar", "rapidamente", "grande", "grandes", "depressa", "claramente", "effectivamente", "realmente",
+	"exclusivamente", "simplesemente", "somente", "unicamente", "lentamente", "raramente", "certamente", "talvez", "actualmente", "dificilmente",
+	"principalmente", "gerlamente", "enorme", "enormes", "pequeno", "pequena", "pequenos", "pequenas", "minúsculo", "minúsculos", "minúscula",
+	"minúsculas", "velho", "velhos", "velha", "velhas", "lindo", "linda", "lindos", "lindas", "alto", "alta", "altos", "altas", "baixo", "baixa",
+	"baixos", "baixas", "longo", "longa", "longos", "longas", "curto", "curta", "curtos", "curtas", "fácil", "fáceis", "difícil", "difíceis",
+	"simples", "mesmo", "mesma", "mesmos", "mesmas", "mêsmo", "mêsmos", "mêsma", "mêsmas", "cedo", "tarde", "importante", "importantes", "capaz",
+	"capazes", "certo", "certa", "certos", "certas", "usual", "usuals", "ultimamente", "possível", "possíveis", "comum", "comuns", "freqüentemente",
+	"constantemente", "continuamente", "diretamente", "levemente", "algures", "semelhante", "semelhantes", "similar", "similares" ];
+
+// "grande", "velho" and "pequeno" can appear both before and after nouns and are therefore on both lists
+let generalAdjectivesPreceding = [ "pior", "melhor", "melhores", "bom", "boa", "bons", "boas", "bonito", "bonita", "bonitos", "bonitas", "grande",
+	"grandes", "pequeno", "pequena", "pequenos", "pequenas", "velho", "velhos", "velha", "velhas", "mau", "má", "maus", "más" ];
+
+let interjections = [ "ai", "ah", "ih", "alô", "oi", "olá", "ui", "uf", "psiu", "mau", "olha", "viva", "uau", "wow", "oh", "shi" ];
+
+// These words and abbreviations are frequently used in recipes in lists of ingredients.
+let recipeWords = [ "kg", "mg", "gr", "g", "km", "m", "l", "ml", "cl" ];
+
+// "segundo" is already included in cardinal numbers
+let timeWords = [ "segundos", "minuto", "minutos", "hora", "horas", "dia", "dias", "semana", "semanas", "mes", "meses", "ano", "anos", "hoje",
+	"amanhã", "ontem" ];
+
+// 'People' should only be removed in combination with 'some', 'many' and 'few' (and is therefore not yet included in the list below).
+let vagueNouns = [ "caso", "casos", "coisa", "coisas", "detalhe", "detalhes", "forma", "formas", "jeito", "jeitos", "maneira", "maneiras", "suijeto",
+	"sujeitos", "tópico", "tópicos" ];
+
+let miscellaneous = [ "sim", "não", "ok", "amém", "etc", "euro", "euros", "adeus", "jeitos" ];
+
+let titles = [ "sr", "sra", "sras", "dr", "dra", "prof" ];
+
+module.exports = function() {
+	return {
+
+		// These word categories are filtered at the beginning of word combinations.
+		filteredAtBeginning: generalAdjectivesAdverbs,
+
+		// These word categories are filtered at the ending of word combinations.
+		filteredAtEnding: [].concat( ordinalNumerals, otherAuxiliariesInfinitive, copulaInfinitive, delexicalizedVerbsInfinitive,
+			generalAdjectivesPreceding ),
+
+		// These word categories are filtered at the beginning and ending of word combinations.
+		filteredAtBeginningAndEnding: [].concat( articles, prepositions, coordinatingConjunctions, demonstrativePronouns, intensifiers,
+			quantifiers, possessivePronouns ),
+
+		// These word categories are filtered everywhere within word combinations.
+		filteredAnywhere: [].concat( transitionWords, cardinalNumerals, personalPronounsNominative, personalPronounsAccusative,
+			personalPronounsPrepositional, personalPronounsComitative, reflexivePronouns, indefinitePronouns, interrogativePronouns,
+			interrogativeProAdverbs, locativeAdverbs, otherAuxiliaries, copula, subordinatingConjunctions, interviewVerbs, additionalTransitionWords,
+			delexicalizedVerbs, interjections, recipeWords, timeWords, vagueNouns, miscellaneous, titles ),
+
+		// This export contains all of the above words.
+		all: [].concat( articles, cardinalNumerals, ordinalNumerals, personalPronounsNominative, personalPronounsAccusative,
+			personalPronounsPrepositional, personalPronounsComitative, reflexivePronouns, demonstrativePronouns, possessivePronouns, quantifiers,
+			indefinitePronouns, interrogativePronouns, interrogativeProAdverbs, locativeAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive,
+			copula, copulaInfinitive, prepositions, coordinatingConjunctions, subordinatingConjunctions, interviewVerbs, additionalTransitionWords,
+			intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive, generalAdjectivesAdverbs, generalAdjectivesPreceding, interjections,
+			recipeWords, timeWords, vagueNouns, miscellaneous, titles ),
+	};
+};

--- a/src/stringProcessing/relevantWords.js
+++ b/src/stringProcessing/relevantWords.js
@@ -8,6 +8,7 @@ let dutchFunctionWords = require( "../researches/dutch/functionWords.js" );
 let spanishFunctionWords = require( "../researches/spanish/functionWords.js" );
 let italianFunctionWords = require( "../researches/italian/functionWords.js" );
 let frenchFunctionWords = require( "../researches/french/functionWords.js" );
+let portugueseFunctionWords = require( "../researches/portuguese/functionWords.js" );
 let getLanguage = require( "../helpers/getLanguage.js" );
 
 let filter = require( "lodash/filter" );
@@ -252,6 +253,9 @@ function getRelevantWords( text, locale ) {
 			break;
 		case "it":
 			functionWords = italianFunctionWords;
+			break;
+		case "pt":
+			functionWords = portugueseFunctionWords;
 			break;
 		default:
 		case "en":


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Adds prominent words for Portuguese.

## Technical choices
* Additionally adds some missing specs for the transition word researcher.

## Test instructions

This PR can be tested by following these steps:

* Run `grunt build:js`.
* Use the prominent word example in your browser.
* Set language to pt_PT.
* Paste a Portuguese text into the example.
* Make sure you see no strange word combinations, counts, etc.

This PR has also be tested on a more extensive variety of tests by @agnieszkaszuba 

Fixes #1412
