### PR TITLE
Changed height value for meta description box

### DIFF
--- a/css/_snippet-editor.scss
+++ b/css/_snippet-editor.scss
@@ -417,7 +417,7 @@ $snippet_width: 600px;
 }
 
 .snippet-editor__meta-description {
-	height: 70px;
+	height: 84px;
 }
 
 .snippet-editor__submit {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Slightly increased the height of the meta description box so it matches the maximum amount of characters without needing a scrollbar. 

## Test instructions

This PR can be tested by following these steps:

* Go to the meta description box under Pages->Enter your focus keyword->Edit snippet. Type in 320 characters. There should be no scrollbar anymore. You can also inspect and see the css value changed from 70 to 84. 

Fixes #[8509](https://github.com/Yoast/wordpress-seo/issues/8509)
