### PR TITLE
Change boundaries of outbound link assessment

### DIFF
--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -57,7 +57,7 @@ describe( "An assessor running the linkStatistics", function(){
 		var mockPaper = new Paper( "" );
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher({ externalTotal: 0 }), i18n );
 
-		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual ( 'No outbound links appear in this page, consider adding some as appropriate.' );
 	} );
 } );

--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -20,7 +20,7 @@ class OutboundLinksAssessment extends Assessment {
 
 		let defaultConfig = {
 			scores: {
-				noLinks: 6,
+				noLinks: 3,
 				allNofollowed: 7,
 				moreNoFollowed: 8,
 				allFollowed: 9,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: When there are no outbound links in the text, the feedback bullet is red instead of orange.

## Test instructions

This PR can be tested by following these steps:

* Check out the branch.
* Use the browserified example. Don't forget to run a `grunt build:js`.
* Add a text without an outbound link.
* Make sure that you get a feedback string about the missing outbound link with a red bullet.

Fixes #1301