### PR TITLE
Change default values for Russian sentence length

### DIFF
--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -5,6 +5,7 @@ import Mark from "../../js/values/Mark.js";
 let i18n = Factory.buildJed();
 
 let sentenceLengthInTextAssessment = new SentenceLengthInTextAssessment();
+let contentConfiguration = require( "../../src/config/content/combinedConfig.js" );
 
 describe( "An assessment for sentence length", function(){
 	let mockPaper, assessment;
@@ -88,6 +89,54 @@ describe( "An assessment for sentence length", function(){
 		expect( assessment.getText() ).toEqual ( "30% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is more than the recommended maximum of 25%. Try to shorten the sentences." )
 		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for 100% long sentences in Russian", function(){
+		mockPaper = new Paper( "text", { locale: "ru_RU" } );
+		let sentenceLengthInTextAssessmentRussian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		assessment = sentenceLengthInTextAssessmentRussian.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 16 }
+
+		] ), i18n );
+
+		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual ( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 15 words</a>, " +
+			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for 100% long sentences in Italian", function(){
+		mockPaper = new Paper( "text", { locale: "it_IT" } );
+		let sentenceLengthInTextAssessmentItalian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		assessment = sentenceLengthInTextAssessmentItalian.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 26 }
+
+		] ), i18n );
+
+		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual ( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
+			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for all short sentences in Italian", function(){
+		let mockPaper = new Paper("text", { locale: "it_IT" } );
+		let sentenceLengthInTextAssessmentItalian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		assessment = sentenceLengthInTextAssessmentItalian.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 24 }
+
+		] ), i18n );
+
+		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual ( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
+			"which is less than or equal to the recommended maximum of 25%." );
+		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
 	it( "is not applicable for empty papers", function(){

--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -7,10 +7,10 @@ let i18n = Factory.buildJed();
 let sentenceLengthInTextAssessment = new SentenceLengthInTextAssessment();
 let contentConfiguration = require( "../../src/config/content/combinedConfig.js" );
 
-describe( "An assessment for sentence length", function(){
+describe( "An assessment for sentence length", function() {
 	let mockPaper, assessment;
 
-	it( "returns the score for all short sentences", function(){
+	it( "returns the score for all short sentences", function() {
 		let mockPaper = new Paper();
 		let assessment = sentenceLengthInTextAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 1 },
@@ -19,41 +19,41 @@ describe( "An assessment for sentence length", function(){
 			{ sentence: "", sentenceLength: 1 }
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
+		expect( assessment.getText() ).toEqual( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is less than or equal to the recommended maximum of 25%." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
-	it( "returns the score for 50% long sentences", function(){
+	it( "returns the score for 50% long sentences", function() {
 		mockPaper = new Paper();
 		assessment = sentenceLengthInTextAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 30 },
 			{ sentence: "", sentenceLength: 1 }
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual ( "50% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
+		expect( assessment.getText() ).toEqual( "50% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 100% long sentences", function(){
+	it( "returns the score for 100% long sentences", function() {
 		mockPaper = new Paper();
 		assessment = sentenceLengthInTextAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 30 }
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual ( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
+		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 25% long sentences", function(){
+	it( "returns the score for 25% long sentences", function() {
 		mockPaper = new Paper();
 		assessment = sentenceLengthInTextAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 30 },
@@ -64,12 +64,12 @@ describe( "An assessment for sentence length", function(){
 
 		expect( assessment.hasScore()).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "25% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
+		expect( assessment.getText() ).toEqual( "25% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
 			"which is less than or equal to the recommended maximum of 25%." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 30% long sentences", function(){
+	it( "returns the score for 30% long sentences", function() {
 		mockPaper = new Paper();
 		assessment = sentenceLengthInTextAssessment.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 30 },
@@ -84,47 +84,45 @@ describe( "An assessment for sentence length", function(){
 			{ sentence: "", sentenceLength: 1 }
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual ( "30% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%. Try to shorten the sentences." )
+		expect( assessment.getText() ).toEqual( "30% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
+			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 100% long sentences in Russian", function(){
+	it( "returns the score for 100% long sentences in Russian", function() {
 		mockPaper = new Paper( "text", { locale: "ru_RU" } );
 		let sentenceLengthInTextAssessmentRussian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
 
 		assessment = sentenceLengthInTextAssessmentRussian.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 16 }
-
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual ( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 15 words</a>, " +
+		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 15 words</a>, " +
 			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 100% long sentences in Italian", function(){
+	it( "returns the score for 100% long sentences in Italian", function() {
 		mockPaper = new Paper( "text", { locale: "it_IT" } );
 		let sentenceLengthInTextAssessmentItalian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
 
 		assessment = sentenceLengthInTextAssessmentItalian.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 26 }
-
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual ( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
+		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
 			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for all short sentences in Italian", function(){
-		let mockPaper = new Paper("text", { locale: "it_IT" } );
+	it( "returns the score for all short sentences in Italian", function() {
+		let mockPaper = new Paper( "text", { locale: "it_IT" } );
 		let sentenceLengthInTextAssessmentItalian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
 
 		assessment = sentenceLengthInTextAssessmentItalian.getResult( mockPaper, Factory.buildMockResearcher( [
@@ -132,14 +130,14 @@ describe( "An assessment for sentence length", function(){
 
 		] ), i18n );
 
-		expect( assessment.hasScore()).toBe( true );
+		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual ( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
+		expect( assessment.getText() ).toEqual( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
 			"which is less than or equal to the recommended maximum of 25%." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
-	it( "is not applicable for empty papers", function(){
+	it( "is not applicable for empty papers", function() {
 		mockPaper = new Paper();
 		assessment = sentenceLengthInTextAssessment.isApplicable( mockPaper );
 		expect( assessment ).toBe( false );
@@ -151,7 +149,7 @@ describe( "A test for marking too long sentences", function() {
 		let paper = new Paper( "This is a too long sentence, because it has over twenty words, and that is hard too read, don't you think?" );
 		let sentenceLengthInText = Factory.buildMockResearcher( [ { sentence: "This is a too long sentence, because it has over twenty words, and that is hard too read, don't you think?", sentenceLength: 21 } ] );
 		let expected = [
-			new Mark({ original: "This is a too long sentence, because it has over twenty words, and that is hard too read, don't you think?", marked: "<yoastmark class='yoast-text-mark'>This is a too long sentence, because it has over twenty words, and that is hard too read, don't you think?</yoastmark>" })
+			new Mark( { original: "This is a too long sentence, because it has over twenty words, and that is hard too read, don't you think?", marked: "<yoastmark class='yoast-text-mark'>This is a too long sentence, because it has over twenty words, and that is hard too read, don't you think?</yoastmark>" } )
 		];
 		expect( sentenceLengthInTextAssessment.getMarks( paper, sentenceLengthInText ) ).toEqual( expected );
 	} );

--- a/src/config/content/combinedConfig.js
+++ b/src/config/content/combinedConfig.js
@@ -2,9 +2,11 @@ let defaultsDeep = require( "lodash/defaultsDeep" );
 let getLanguage = require( "./../../helpers/getLanguage" );
 let defaultConfig = require( "./default" );
 let it = require( "./it" );
+let ru = require( "./ru" );
 
 let configurations = {
 	it: it,
+	ru: ru,
 };
 
 module.exports = function( locale ) {

--- a/src/config/content/ru.js
+++ b/src/config/content/ru.js
@@ -1,0 +1,7 @@
+module.exports = {
+	sentenceLength: {
+		recommendedWordCount: 25,
+		slightlyTooMany: 20,
+		farTooMany: 25,
+	},
+};

--- a/src/config/content/ru.js
+++ b/src/config/content/ru.js
@@ -1,7 +1,5 @@
 module.exports = {
 	sentenceLength: {
-		recommendedWordCount: 25,
-		slightlyTooMany: 20,
-		farTooMany: 25,
+		recommendedWordCount: 15,
 	},
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Changes recommended maximum sentence length for Russian from 20 to 15 words, based on more [in-depth research](https://github.com/Yoast/research/wiki/Sentence-Length-Russian).

## Relevant technical choices:

* Added a sentence length test for Italian

## Test instructions

This PR can be tested by following these steps:

### In Wordpress
- Set the language to something that isn't Russian.
- Write a text with long sentences.
- The sentence length assessment should use a 20-word limit.
- Change the language to Russian.
- The sentence length assessment should use a 15-word limit, both for the regular as well as the cornerstone content assessor.

### In the browserified example
- Set the language to something that isn't Russian/use the default en_US
- Write a text with long sentences.
- The sentence length assessment should use a 20-word limit.
- Change the language to ru_RU.
- The sentence length assessment should use a 15-word limit.

Fixes #1434 
