### PR TITLE
Handle sentences with multiple sentence delimiters

### DIFF
--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -28,6 +28,16 @@ describe("Get sentences from text", function(){
 		expect( getSentences( sentence ) ).toEqual( [ "It was a lot.","Approx!", "two hundred" ] );
 	});
 
+	it("returns sentences with multiple sentence delimiters at the end", function () {
+		var sentence = "Was it a lot!?!??! Yes, it was!";
+		expect( getSentences( sentence ) ).toEqual( [ "Was it a lot!?!??!", "Yes, it was!" ] );
+	});
+
+	it("returns sentences with multiple periods at the end", function () {
+		var sentence = "It was a lot... Approx. two hundred.";
+		expect( getSentences( sentence ) ).toEqual( [ "It was a lot...","Approx. two hundred." ] );
+	});
+
 	it( "returns sentences, with :", function() {
 		var sentence = "One. Two. Three: Four! Five."
 		expect( getSentences( sentence ).length ).toBe ( 4 );

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -28,15 +28,15 @@ describe("Get sentences from text", function(){
 		expect( getSentences( sentence ) ).toEqual( [ "It was a lot.","Approx!", "two hundred" ] );
 	});
 
-	it("returns sentences with multiple sentence delimiters at the end", function () {
+	it( "returns sentences with multiple sentence delimiters at the end", function() {
 		var sentence = "Was it a lot!?!??! Yes, it was!";
 		expect( getSentences( sentence ) ).toEqual( [ "Was it a lot!?!??!", "Yes, it was!" ] );
-	});
+	} );
 
-	it("returns sentences with multiple periods at the end", function () {
+	it( "returns sentences with multiple periods at the end", function() {
 		var sentence = "It was a lot... Approx. two hundred.";
-		expect( getSentences( sentence ) ).toEqual( [ "It was a lot...","Approx. two hundred." ] );
-	});
+		expect( getSentences( sentence ) ).toEqual( [ "It was a lot...", "Approx. two hundred." ] );
+	} );
 
 	it( "returns sentences, with :", function() {
 		var sentence = "One. Two. Three: Four! Five."

--- a/src/stringProcessing/getSentences.js
+++ b/src/stringProcessing/getSentences.js
@@ -235,7 +235,7 @@ function getSentencesFromTokens( tokens ) {
 			case "sentence-delimiter":
 				currentSentence += token.src;
 
-				if ( ! isUndefined( nextToken ) && "block-end" !== nextToken.type ) {
+				if ( ! isUndefined( nextToken ) && "block-end" !== nextToken.type && "sentence-delimiter" !== nextToken.type ) {
 					tokenSentences.push( currentSentence );
 					currentSentence = "";
 				}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where sentences ending in multiple sentence marks, exclamation marks or ellipses were treated as multiple sentences.

## Technical choices
- I've also added a test with a sentence ending in multiple periods (= not an ellipses). Sentences like those were already truncated correctly, but I added the test just to be sure we don't break it in the future.

## Test instructions

This PR can be tested by following these steps:

* Check out this branch. Don't forget to run `yarn install` and `grunt build:js`.
* Go to getSentences and add a `console.log` to log (the number of) sentences. 
* Type some sentences in the browserified example. Make sure some of them end in series of !, ?, ;, and/or …
* Make sure the sentences are counted/truncated correctly.

Fixes #1450
