### PR TITLE
Add language-specific config to Russian Flesch assessment

### DIFF
--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -1,4 +1,4 @@
-import FleschReadingAssessment from "../../js/assessments/readability/fleschReadingEaseAssessment.js";
+const FleschReadingAssessment = require ( "../../js/assessments/readability/fleschReadingEaseAssessment.js" );
 let Paper = require( "../../js/values/Paper.js" );
 
 const factory = require( "../helpers/factory.js" );
@@ -15,7 +15,7 @@ describe( "An assessment for the flesch reading", function() {
 		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
 	} );
 
-	it( "returns a 'difficult' score and the associated feedback text for a paper.", function() {
+	it( "returns an 'easy' score and the associated feedback text for a paper.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 82.0 ), i18n );
 
@@ -55,15 +55,7 @@ describe( "An assessment for the flesch reading", function() {
 		expect( result.getText() ).toBe( "The copy scores 55 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
 	} );
 
-	it( "returns a 'fairly difficult' score for a Russian paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
-		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
-		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
-
-		expect( result.getScore() ).toBe( 6 );
-		expect( result.getText() ).toBe( "The copy scores 45 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
-	} );
-
-	it( "returns a 'difficult' score for a non-Russian paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
+	it( "returns a 'difficult' score for a paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
 
@@ -87,6 +79,86 @@ describe( "An assessment for the flesch reading", function() {
 		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 	} );
 
+	it( "returns a 'very easy' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 100.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
+	} );
+
+	it( "returns a 'very easy' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" }  );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 85 ), i18n );
+
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The copy scores 85 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
+	} );
+
+	it( "returns an 'easy' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" }  );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 72.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The copy scores 72 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered easy to read. " );
+	} );
+
+	it( "returns a 'fairly easy' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "A piece of text to calculate scores.", { locale: "ru_RU" }  );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 68.9 ), i18n );
+
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The copy scores 68.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. " );
+	} );
+
+	it( "returns an 'ok' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop and people were actually in a bit of trouble", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 53.9 ), i18n );
+
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The copy scores 53.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
+	} );
+
+	it( "returns an 'ok' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 50.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The copy scores 50 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
+	} );
+
+	it( "returns a 'fairly difficult' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 6 );
+		expect( result.getText() ).toBe( "The copy scores 45 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
+	} );
+
+	it( "returns a 'difficult' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 35.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 3 );
+		expect( result.getText() ).toBe( "The copy scores 35 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+	} );
+
+	it( "returns a 'difficult' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 26.6 ), i18n );
+
+		expect( result.getScore() ).toBe( 3 );
+		expect( result.getText() ).toBe( "The copy scores 26.6 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+	} );
+
+	it( "returns a 'very difficult' score and the associated feedback text for a Russian paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
+
+		expect( result.getScore() ).toBe( 3 );
+		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+	} );
+
 	it( "returns a feedback text containing '100' for a paper with a flesch score above 100.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 103.0 ), i18n );
@@ -101,6 +173,12 @@ describe( "An assessment for the flesch reading", function() {
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+	} );
+
+	it( "returns a null result for the assessment for an Afrikaans paper with text.", function() {
+		const paper = new Paper( "Hierdie is 'n interessante papier.", { locale: "af_ZA" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher(0 ), i18n );
+		expect( result ).toBe( null );
 	} );
 
 	it( "returns true for isApplicable for an English paper with text.", function() {

--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -1,107 +1,109 @@
-var fleschReadingAssessment = require( "../../js/assessments/readability/fleschReadingEaseAssessment.js" );
-var Paper = require( "../../js/values/Paper.js" );
+import FleschReadingAssessment from "../../js/assessments/readability/fleschReadingEaseAssessment.js";
+let Paper = require( "../../js/values/Paper.js" );
 
-var factory = require( "../helpers/factory.js" );
-var i18n = factory.buildJed();
+const factory = require( "../helpers/factory.js" );
+const i18n = factory.buildJed();
+
+let contentConfiguration = require( "../../src/config/content/combinedConfig.js" );
 
 describe( "An assessment for the flesch reading", function() {
 	it( "returns a 'very easy' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100.0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 100.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 82.0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 82.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 82 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered easy to read. " );
 	} );
 
 	it( "returns a 'fairly easy' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "A piece of text to calculate scores." );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 78.9 ), i18n );
+		const paper = new Paper( "A piece of text to calculate scores." );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 78.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 78.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. " );
 	} );
 
 	it( "returns an 'ok' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop and people were actually in a bit of trouble" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 63.9 ), i18n );
+		const paper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop and people were actually in a bit of trouble" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 63.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 63.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
 	} );
 
 	it( "returns an 'ok' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 60.0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 60.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 60 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
 	} );
 
 	it( "returns a 'fairly difficult' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 55.0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 55.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 6 );
 		expect( result.getText() ).toBe( "The copy scores 55 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 36.6 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 36.6 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 36.6 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 	} );
 
 	it( "returns a 'very difficult' score and the associated feedback text for a paper.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 	} );
 
 	it( "returns a feedback text containing '100' for a paper with a flesch score above 100.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 103.0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 103.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
 	} );
 
 	it( "returns a feedback text containing '0' for a paper with a flesch score under 0.", function() {
-		var paper = new Paper( "This is a very interesting paper" );
-		var result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( -3.0 ), i18n );
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( -3.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
 	} );
 
 	it( "returns true for isApplicable for an English paper with text.", function() {
-		var paper = new Paper( "This is a very interesting paper.", { locale: "en_EN" } );
-		expect( fleschReadingAssessment.isApplicable( paper ) ).toBe( true );
+		const paper = new Paper( "This is a very interesting paper.", { locale: "en_EN" } );
+		expect( new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).isApplicable( paper ) ).toBe( true );
 	} );
 
 	it( "returns false for isApplicable for an Afrikaans paper with text.", function() {
-		var paper = new Paper( "Hierdie is 'n interessante papier.", { locale: "af_ZA" } );
-		expect( fleschReadingAssessment.isApplicable( paper ) ).toBe( false );
+		const paper = new Paper( "Hierdie is 'n interessante papier.", { locale: "af_ZA" } );
+		expect( new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).isApplicable( paper ) ).toBe( false );
 	} );
 
 	it( "returns false for isApplicable for an English paper without text.", function() {
-		var paper = new Paper( "", { locale: "en_EN" } );
-		expect( fleschReadingAssessment.isApplicable( paper ) ).toBe( false );
+		const paper = new Paper( "", { locale: "en_EN" } );
+		expect( new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).isApplicable( paper ) ).toBe( false );
 	} );
 
 	it( "returns false for isApplicable for an Afrikaans paper without text.", function() {
-		var paper = new Paper( "", { locale: "af_ZA" } );
-		expect( fleschReadingAssessment.isApplicable( paper ) ).toBe( false );
+		const paper = new Paper( "", { locale: "af_ZA" } );
+		expect( new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).isApplicable( paper ) ).toBe( false );
 	} );
 } );

--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -55,6 +55,22 @@ describe( "An assessment for the flesch reading", function() {
 		expect( result.getText() ).toBe( "The copy scores 55 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
 	} );
 
+	it( "returns a 'fairly difficult' score for a Russian paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
+		const paper = new Paper( "This is a very interesting paper", { locale: "ru_RU" } );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 6 );
+		expect( result.getText() ).toBe( "The copy scores 45 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
+	} );
+
+	it( "returns a 'difficult' score for a non-Russian paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
+		const paper = new Paper( "This is a very interesting paper" );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
+
+		expect( result.getScore() ).toBe( 3 );
+		expect( result.getText() ).toBe( "The copy scores 45 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+	} );
+
 	it( "returns a 'difficult' score and the associated feedback text for a paper.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 36.6 ), i18n );

--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -177,7 +177,7 @@ describe( "An assessment for the flesch reading", function() {
 
 	it( "returns a null result for the assessment for an Afrikaans paper with text.", function() {
 		const paper = new Paper( "Hierdie is 'n interessante papier.", { locale: "af_ZA" } );
-		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher(0 ), i18n );
+		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 		expect( result ).toBe( null );
 	} );
 

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -1,114 +1,151 @@
-var AssessmentResult = require( "../../values/AssessmentResult.js" );
-var inRange = require( "lodash/inRange" );
+let AssessmentResult = require( "../../values/AssessmentResult.js" );
+let Assessment = require( "../../assessment.js" );
+const inRange = require( "lodash/inRange" );
+const isEmpty = require( "lodash/isEmpty" );
 
-var getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
+const getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 
-var availableLanguages = [ "en", "nl", "de", "it" ];
+const availableLanguages = [ "en", "nl", "de", "it" ];
 
-/**
- * Calculates the assessment result based on the fleschReadingScore
- * @param {int} fleschReadingScore The score from the fleschReadingtest
- * @param {object} i18n The i18n-object used for parsing translations
- * @returns {object} object with score, resultText and note
- */
-var calculateFleschReadingResult = function( fleschReadingScore, i18n ) {
-	if ( fleschReadingScore > 90 ) {
-		return {
-			score: 9,
-			resultText: i18n.dgettext( "js-text-analysis", "very easy" ),
-			note: "",
-		};
+class FleschReadingEaseAssessment extends Assessment {
+	/**
+	 * Sets the identifier and the config.
+	 *
+	 * @param {object} config The configuration to use.
+	 * @returns {void}
+	 */
+	constructor( config ) {
+		super();
+
+		this.identifier = "fleschReadingEase";
+		this._config = config;
 	}
 
-	if ( inRange( fleschReadingScore, 80, 90 ) ) {
-		return {
-			score: 9,
-			resultText: i18n.dgettext( "js-text-analysis", "easy" ),
-			note: "",
-		};
+	/**
+	 * The assessment that runs the FleschReading on the paper.
+	 *
+	 * @param {Object} paper The paper to run this assessment on.
+	 * @param {Object} researcher The researcher used for the assessment.
+	 * @param {Object} i18n The i18n-object used for parsing translations.
+	 * @returns {Object} an assessmentResult with the score and formatted text.
+	 */
+	getResult( paper, researcher, i18n ) {
+		this.fleschReadingResult = researcher.getResearch( "calculateFleschReading" );
+		if ( this.isApplicable( paper ) ) {
+			let assessmentResult =  new AssessmentResult();
+			const calculatedScore = this.calculateScore();
+			assessmentResult.setScore( calculatedScore.score );
+			assessmentResult.setText( this.translateScore( calculatedScore, i18n ) );
+
+			return assessmentResult;
+		}
 	}
 
-	if ( inRange( fleschReadingScore, 70, 80 ) ) {
-		return {
-			score: 9,
-			resultText: i18n.dgettext( "js-text-analysis", "fairly easy" ),
-			note: "",
-		};
+	/**
+	 * Calculates the assessment result based on the fleschReadingScore.
+	 * @returns {object} object with score, resultText and note.
+	 */
+	calculateScore() {
+		if ( this.fleschReadingResult > this._config.borders.veryEasy ) {
+			return {
+				score: this._config.scores.good,
+				resultText: this._config.resultTexts.veryEasy,
+				note: "",
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.easy, this._config.borders.veryEasy ) ) {
+			return {
+				score: this._config.scores.good,
+				resultText: this._config.resultTexts.easy,
+				note: "",
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyEasy, this._config.borders.easy ) ) {
+			return {
+				score: this._config.scores.good,
+				resultText: this._config.resultTexts.fairlyEasy,
+				note: "",
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.okay, this._config.borders.fairlyEasy ) ) {
+			return {
+				score: this._config.scores.good,
+				resultText: this._config.resultTexts.okay,
+				note: "",
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyDifficult, this._config.borders.okay ) ) {
+			return {
+				score: this._config.scores.fine,
+				resultText: this._config.resultTexts.fairlyDifficult,
+				note: this._config.notes.fairlyDifficult,
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.difficult, this._config.borders.fairlyDifficult ) ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: this._config.resultTexts.difficult,
+				note: this._config.notes.difficult,
+			};
+		}
+
+		if ( this.fleschReadingResult < this._config.borders.difficult ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: this._config.resultTexts.veryDifficult,
+				note: this._config.notes.difficult,
+			};
+		}
 	}
 
-	if ( inRange( fleschReadingScore, 60, 70 ) ) {
-		return {
-			score: 9,
-			resultText: i18n.dgettext( "js-text-analysis", "ok" ),
-			note: "",
-		};
+	/**
+	 * Translates the FleschReading score into a specific feedback text.
+	 *
+	 * @param {Object} calculatedScore The Flesch reading score for the paper.
+	 * @param {Object} i18n The i18n-object used for parsing translations.
+	 * @returns {string} text Feedback text.
+	 */
+	translateScore( calculatedScore, i18n ) {
+		/* Translators: %1$s expands to the numeric flesch reading ease score, %2$s to a link to a Yoast.com article about Flesch ease reading score,
+		 %3$s to the easyness of reading, %4$s expands to a note about the flesch reading score. */
+		let text = i18n.dgettext( "js-text-analysis", "The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s" );
+		const feedback = i18n.dgettext( "js-text-analysis", calculatedScore.resultText );
+		const url = "<a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a>";
+
+		let note = "";
+		if ( ! isEmpty( calculatedScore.note ) ) {
+			note = i18n.dgettext( "js-text-analysis", calculatedScore.note );
+		}
+
+		// Results must be between 0 and 100;
+		if ( this.fleschReadingResult < 0 ) {
+			this.fleschReadingResult = 0;
+		}
+		if ( this.fleschReadingResult > 100 ) {
+			this.fleschReadingResult = 100;
+		}
+
+		text = i18n.sprintf( text, this.fleschReadingResult, url, feedback, note );
+
+		return text;
 	}
 
-	if ( inRange( fleschReadingScore, 50, 60 ) ) {
-		return {
-			score: 6,
-			resultText: i18n.dgettext( "js-text-analysis", "fairly difficult" ),
-			note: i18n.dgettext( "js-text-analysis", "Try to make shorter sentences to improve readability." ),
-		};
-	}
-
-	if ( inRange( fleschReadingScore, 30, 50 ) ) {
-		return {
-			score: 3,
-			resultText: i18n.dgettext( "js-text-analysis", "difficult" ),
-			note: i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." ),
-		};
-	}
-
-	if ( fleschReadingScore < 30 ) {
-		return {
-			score: 3,
-			resultText: i18n.dgettext( "js-text-analysis", "very difficult" ),
-			note: i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." ),
-		};
-	}
-};
-
-/**
- * The assessment that runs the FleschReading on the paper.
- *
- * @param {object} paper The paper to run this assessment on
- * @param {object} researcher The researcher used for the assessment
- * @param {object} i18n The i18n-object used for parsing translations
- * @returns {object} an assessmentresult with the score and formatted text.
- */
-var fleschReadingEaseAssessment = function( paper, researcher, i18n ) {
-	var fleschReadingScore = researcher.getResearch( "calculateFleschReading" );
-
-	/* Translators: %1$s expands to the numeric flesch reading ease score, %2$s to a link to a Yoast.com article about Flesch ease reading score,
-	 %3$s to the easyness of reading, %4$s expands to a note about the flesch reading score. */
-	var text = i18n.dgettext( "js-text-analysis", "The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s" );
-	var url = "<a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a>";
-
-	// Scores must be between 0 and 100;
-	if ( fleschReadingScore < 0 ) {
-		fleschReadingScore = 0;
-	}
-	if ( fleschReadingScore > 100 ) {
-		fleschReadingScore = 100;
-	}
-
-	var fleschReadingResult = calculateFleschReadingResult( fleschReadingScore, i18n );
-
-	text = i18n.sprintf( text, fleschReadingScore, url, fleschReadingResult.resultText, fleschReadingResult.note );
-
-	var assessmentResult =  new AssessmentResult();
-	assessmentResult.setScore( fleschReadingResult.score );
-	assessmentResult.setText( text );
-
-	return assessmentResult;
-};
-
-module.exports = {
-	identifier: "fleschReadingEase",
-	getResult: fleschReadingEaseAssessment,
-	isApplicable: function( paper ) {
-		var isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
+	/**
+	 * Checks if Flesch reading analysis is available for the language of the paper.
+	 *
+	 * @param {Object} paper The paper to have the Flesch score to be calculated for.
+	 * @returns {boolean} If the language is available and the paper is not empty.
+	 */
+	isApplicable( paper ) {
+		const isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
 		return ( isLanguageAvailable && paper.hasText() );
-	},
-};
+	}
+
+}
+
+module.exports = FleschReadingEaseAssessment;

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -5,7 +5,7 @@ const isEmpty = require( "lodash/isEmpty" );
 
 const getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 
-const availableLanguages = [ "en", "nl", "de", "it" ];
+const availableLanguages = [ "en", "nl", "de", "it", "ru" ];
 
 class FleschReadingEaseAssessment extends Assessment {
 	/**

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -11,7 +11,7 @@ class FleschReadingEaseAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 * @returns {void}
 	 */
 	constructor( config ) {
@@ -27,25 +27,26 @@ class FleschReadingEaseAssessment extends Assessment {
 	 * @param {Object} paper The paper to run this assessment on.
 	 * @param {Object} researcher The researcher used for the assessment.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
-	 * @returns {Object} an assessmentResult with the score and formatted text.
+	 * @returns {Object} An assessmentResult with the score and formatted text.
 	 */
 	getResult( paper, researcher, i18n ) {
 		this.fleschReadingResult = researcher.getResearch( "calculateFleschReading" );
 		if ( this.isApplicable( paper ) ) {
 			let assessmentResult =  new AssessmentResult();
-			const calculatedScore = this.calculateScore();
-			assessmentResult.setScore( calculatedScore.score );
-			assessmentResult.setText( this.translateScore( calculatedScore.resultText, calculatedScore.note, i18n ) );
+			const calculatedResult = this.calculateResult();
+			assessmentResult.setScore( calculatedResult.score );
+			assessmentResult.setText( this.translateScore( calculatedResult.resultText, calculatedResult.note, i18n ) );
 
 			return assessmentResult;
 		}
+		return null;
 	}
 
 	/**
 	 * Calculates the assessment result based on the fleschReadingScore.
-	 * @returns {object} object with score, resultText and note.
+	 * @returns {Object} Object with score, resultText and note.
 	 */
-	calculateScore() {
+	calculateResult() {
 		if ( this.fleschReadingResult > this._config.borders.veryEasy ) {
 			return this._config.veryEasy;
 		}
@@ -70,9 +71,7 @@ class FleschReadingEaseAssessment extends Assessment {
 			return this._config.difficult;
 		}
 
-		if ( this.fleschReadingResult < this._config.borders.difficult ) {
-			return this._config.veryDifficult;
-		}
+		return this._config.veryDifficult;
 	}
 
 	/**
@@ -112,7 +111,7 @@ class FleschReadingEaseAssessment extends Assessment {
 	 * Checks if Flesch reading analysis is available for the language of the paper.
 	 *
 	 * @param {Object} paper The paper to have the Flesch score to be calculated for.
-	 * @returns {boolean} If the language is available and the paper is not empty.
+	 * @returns {boolean} Returns true if the language is available and the paper is not empty.
 	 */
 	isApplicable( paper ) {
 		const isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -35,7 +35,7 @@ class FleschReadingEaseAssessment extends Assessment {
 			let assessmentResult =  new AssessmentResult();
 			const calculatedScore = this.calculateScore();
 			assessmentResult.setScore( calculatedScore.score );
-			assessmentResult.setText( this.translateScore( calculatedScore, i18n ) );
+			assessmentResult.setText( this.translateScore( calculatedScore.resultText, calculatedScore.note, i18n ) );
 
 			return assessmentResult;
 		}
@@ -47,79 +47,52 @@ class FleschReadingEaseAssessment extends Assessment {
 	 */
 	calculateScore() {
 		if ( this.fleschReadingResult > this._config.borders.veryEasy ) {
-			return {
-				score: this._config.scores.good,
-				resultText: this._config.resultTexts.veryEasy,
-				note: "",
-			};
+			return this._config.veryEasy;
 		}
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.easy, this._config.borders.veryEasy ) ) {
-			return {
-				score: this._config.scores.good,
-				resultText: this._config.resultTexts.easy,
-				note: "",
-			};
+			return this._config.easy;
 		}
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyEasy, this._config.borders.easy ) ) {
-			return {
-				score: this._config.scores.good,
-				resultText: this._config.resultTexts.fairlyEasy,
-				note: "",
-			};
+			return this._config.fairlyEasy;
 		}
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.okay, this._config.borders.fairlyEasy ) ) {
-			return {
-				score: this._config.scores.good,
-				resultText: this._config.resultTexts.okay,
-				note: "",
-			};
+			return this._config.okay;
 		}
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyDifficult, this._config.borders.okay ) ) {
-			return {
-				score: this._config.scores.fine,
-				resultText: this._config.resultTexts.fairlyDifficult,
-				note: this._config.notes.fairlyDifficult,
-			};
+			return this._config.fairlyDifficult;
 		}
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.difficult, this._config.borders.fairlyDifficult ) ) {
-			return {
-				score: this._config.scores.bad,
-				resultText: this._config.resultTexts.difficult,
-				note: this._config.notes.difficult,
-			};
+			return this._config.difficult;
 		}
 
 		if ( this.fleschReadingResult < this._config.borders.difficult ) {
-			return {
-				score: this._config.scores.bad,
-				resultText: this._config.resultTexts.veryDifficult,
-				note: this._config.notes.difficult,
-			};
+			return this._config.veryDifficult;
 		}
 	}
 
 	/**
 	 * Translates the FleschReading score into a specific feedback text.
 	 *
-	 * @param {Object} calculatedScore The Flesch reading score for the paper.
+	 * @param {string} resultText The feedback for a range of Flesch reading results from the config.
+	 * @param {string} noteText The note for a range of Flesch reading results from the config.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
 	 * @returns {string} text Feedback text.
 	 */
-	translateScore( calculatedScore, i18n ) {
+	translateScore( resultText, noteText, i18n ) {
 		/* Translators: %1$s expands to the numeric flesch reading ease score, %2$s to a link to a Yoast.com article about Flesch ease reading score,
 		 %3$s to the easyness of reading, %4$s expands to a note about the flesch reading score. */
 		let text = i18n.dgettext( "js-text-analysis", "The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s" );
-		const feedback = i18n.dgettext( "js-text-analysis", calculatedScore.resultText );
+		const feedback = i18n.dgettext( "js-text-analysis", resultText );
 		const url = "<a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a>";
 
 		let note = "";
-		if ( ! isEmpty( calculatedScore.note ) ) {
-			note = i18n.dgettext( "js-text-analysis", calculatedScore.note );
+		if ( ! isEmpty( noteText ) ) {
+			note = i18n.dgettext( "js-text-analysis", noteText );
 		}
 
 		// Results must be between 0 and 100;

--- a/src/config/content/default.js
+++ b/src/config/content/default.js
@@ -4,4 +4,32 @@ module.exports = {
 		slightlyTooMany: 25,
 		farTooMany: 30,
 	},
+	fleschReading: {
+		scores: {
+			bad: 3,
+			fine: 6,
+			good: 9,
+		},
+		borders: {
+			veryEasy: 90,
+			easy: 80,
+			fairlyEasy: 70,
+			okay: 60,
+			fairlyDifficult: 50,
+			difficult: 30,
+		},
+		resultTexts: {
+			veryEasy: "very easy",
+			easy: "easy",
+			fairlyEasy: "fairly easy",
+			okay: "ok",
+			fairlyDifficult: "fairly difficult",
+			difficult: "difficult",
+			veryDifficult: "very difficult",
+		},
+		notes: {
+			fairlyDifficult: "Try to make shorter sentences to improve readability.",
+			difficult: "Try to make shorter sentences, using less difficult words to improve readability.",
+		},
+	},
 };

--- a/src/config/content/default.js
+++ b/src/config/content/default.js
@@ -5,11 +5,6 @@ module.exports = {
 		farTooMany: 30,
 	},
 	fleschReading: {
-		scores: {
-			bad: 3,
-			fine: 6,
-			good: 9,
-		},
 		borders: {
 			veryEasy: 90,
 			easy: 80,
@@ -17,19 +12,42 @@ module.exports = {
 			okay: 60,
 			fairlyDifficult: 50,
 			difficult: 30,
+			veryDifficult: 0,
 		},
-		resultTexts: {
-			veryEasy: "very easy",
-			easy: "easy",
-			fairlyEasy: "fairly easy",
-			okay: "ok",
-			fairlyDifficult: "fairly difficult",
-			difficult: "difficult",
-			veryDifficult: "very difficult",
+		veryEasy: {
+			score: 9,
+			resultText: "very easy",
+			note: "",
 		},
-		notes: {
-			fairlyDifficult: "Try to make shorter sentences to improve readability.",
-			difficult: "Try to make shorter sentences, using less difficult words to improve readability.",
+		easy: {
+			score: 9,
+			resultText: "easy",
+			note: "",
+		},
+		fairlyEasy: {
+			score: 9,
+			resultText: "fairly easy",
+			note: "",
+		},
+		okay: {
+			score: 9,
+			resultText: "ok",
+			note: "",
+		},
+		fairlyDifficult: {
+			score: 6,
+			resultText: "fairly difficult",
+			note: "Try to make shorter sentences to improve readability.",
+		},
+		difficult: {
+			score: 3,
+			resultText: "difficult",
+			note: "Try to make shorter sentences, using less difficult words to improve readability.",
+		},
+		veryDifficult: {
+			score: 3,
+			resultText: "very difficult",
+			note: "Try to make shorter sentences, using less difficult words to improve readability.",
 		},
 	},
 };

--- a/src/config/content/ru.js
+++ b/src/config/content/ru.js
@@ -2,4 +2,9 @@ module.exports = {
 	sentenceLength: {
 		recommendedWordCount: 15,
 	},
+	fleschReading: {
+		borders: {
+			fairlyDifficult: 40,
+		},
+	},
 };

--- a/src/config/content/ru.js
+++ b/src/config/content/ru.js
@@ -4,7 +4,12 @@ module.exports = {
 	},
 	fleschReading: {
 		borders: {
+			veryEasy: 80,
+			easy: 70,
+			fairlyEasy: 60,
+			okay: 50,
 			fairlyDifficult: 40,
+			difficult: 20,
 		},
 	},
 };

--- a/src/contentAssessor.js
+++ b/src/contentAssessor.js
@@ -1,6 +1,6 @@
 let Assessor = require( "./assessor.js" );
 
-let fleschReadingEase = require( "./assessments/readability/fleschReadingEaseAssessment.js" );
+let FleschReadingEase = require( "./assessments/readability/fleschReadingEaseAssessment.js" );
 let paragraphTooLong = require( "./assessments/readability/paragraphTooLongAssessment.js" );
 let SentenceLengthInText = require( "./assessments/readability/sentenceLengthInTextAssessment.js" );
 let SubheadingDistributionTooLong = require( "./assessments/readability/subheadingDistributionTooLongAssessment.js" );
@@ -39,7 +39,7 @@ let ContentAssessor = function( i18n, options = {} ) {
 
 	this._assessments = [
 
-		fleschReadingEase,
+		new FleschReadingEase( contentConfiguration( locale ).fleschReading ),
 		new SubheadingDistributionTooLong(),
 		paragraphTooLong,
 		new SentenceLengthInText( contentConfiguration( locale ).sentenceLength ),

--- a/src/cornerstone/contentAssessor.js
+++ b/src/cornerstone/contentAssessor.js
@@ -1,7 +1,7 @@
 let Assessor = require( "../assessor.js" );
 let ContentAssessor = require( "../contentAssessor" );
 
-let fleschReadingEase = require( "../assessments/readability/fleschReadingEaseAssessment.js" );
+let FleschReadingEase = require( "../assessments/readability/fleschReadingEaseAssessment.js" );
 let paragraphTooLong = require( "../assessments/readability/paragraphTooLongAssessment.js" );
 let SentenceLengthInText = require( "../assessments/readability/sentenceLengthInTextAssessment.js" );
 let SubheadingDistributionTooLong = require( "../assessments/readability/subheadingDistributionTooLongAssessment.js" );
@@ -35,7 +35,7 @@ let CornerStoneContentAssessor = function( i18n, options = {} ) {
 
 	this._assessments = [
 
-		fleschReadingEase,
+		new FleschReadingEase( contentConfiguration( locale ).fleschReading ),
 		new SubheadingDistributionTooLong(
 			{
 				slightlyTooMany: 250,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The Flesch reading ease assessment is added for Russian

## Relevant technical choices:

* The Flesch reading ease assessment is transformed in a class. 
* A default config consists of exact values previously used for this assessment.
* A language-specific config for Russian is provided, so that the assessment is somewhat less harsh on the Russian texts, than it used to be.

## Test instructions

This PR can be tested by following these steps:

### Browserified

- Checkout the branch
- Run yarn install followed by grunt build:js.
- Open the browserified example in examples/browserified/index.html.
- Set locale to Russian (ru_RU).
- Write a Russian text.
- Determine whether the Flesch Reading score appears.
- Try merging sentences (erase full stop) and see if the Flesch Reading score changes.
- Try getting a text that scores between 40 and 50 in Flesch Reading assessment. It should get an orange bullet and an "ok" feedback.

### WordPress

- In your WordPress SEO testing environment, ensure you've already run yarn install once in the plugin's directory.
- Run yarn add "git+https://github.com/Yoast/yoastseo.js#stories/1438-add-flesch-reading-ease-assessment-for-russian" in the plugin's directory.
- Navigate to node_modules/yoastseo and run yarn install and grunt build:js.
- Navigate back to the plugin's directory and run grunt build:js.
- In your testing environment, set the language to Russian.
- Write a Russian text.
- Determine whether the Flesch Reading score appears.
- Try merging sentences (erase full stop) and see if the Flesch Reading score changes.
- Try getting a text that scores between 40 and 50 in Flesch Reading assessment. It should get an orange bullet and an "ok" feedback.



Fixes #1472 
