### PR TITLE
Fix some no-useless-escapes warnings

### DIFF
--- a/spec/assessments/introductionKeywordSpec.js
+++ b/spec/assessments/introductionKeywordSpec.js
@@ -23,6 +23,6 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The focus keyword doesn\'t appear in the first paragraph of the copy. Make sure the topic is clear immediately." );
+		expect( assessment.getText() ).toBe( "The focus keyword doesn't appear in the first paragraph of the copy. Make sure the topic is clear immediately." );
 	} );
 } );

--- a/spec/stringProcessing/sanitizeStringSpec.js
+++ b/spec/stringProcessing/sanitizeStringSpec.js
@@ -3,7 +3,7 @@ var sanitizeString = require( "../../js/stringProcessing/sanitizeString.js" );
 describe( "Test for removing unwanted characters", function() {
 	it( "returns cleaned string", function() {
 		// Because regexes are now properly escaped, there is no need to strip characters like * from the keyword.
-		expect( sanitizeString( "keyword*?!.+-[]()<>«»:;\/\\‹›" ) ).toBe( "keyword*?!.+-[]()<>«»:;\/\\‹›" );
+		expect( sanitizeString( "keyword*?!.+-[]()<>«»:;/\\‹›" ) ).toBe( "keyword*?!.+-[]()<>«»:;/\\‹›" );
 		expect( sanitizeString( "keyword<p></p>" ) ).toBe( "keyword" );
 	} );
 	it( "returns cleaned string containing /", function() {

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -17,7 +17,7 @@ var calculateFirstParagraphResult = function( firstParagraphMatches, i18n ) {
 
 	return {
 		score: 3,
-		text: i18n.dgettext( "js-text-analysis", "The focus keyword doesn\'t appear in the first paragraph of the copy. " +
+		text: i18n.dgettext( "js-text-analysis", "The focus keyword doesn't appear in the first paragraph of the copy. " +
 			"Make sure the topic is clear immediately." ),
 	};
 };

--- a/src/assessments/seo/textCompetingLinksAssessment.js
+++ b/src/assessments/seo/textCompetingLinksAssessment.js
@@ -17,7 +17,7 @@ var calculateLinkCountResult = function( linkStatistics, i18n ) {
 		return {
 			score: 2,
 			hasMarks: true,
-			text: i18n.dgettext( "js-text-analysis", "You\'re linking to another page with the focus keyword you want this page to rank for. " +
+			text: i18n.dgettext( "js-text-analysis", "You're linking to another page with the focus keyword you want this page to rank for. " +
 				"Consider changing that if you truly want this page to rank." ),
 		};
 	}

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -14,7 +14,7 @@ var blockElementEndRegex = new RegExp( "^</(" + blockElements.join( "|" ) + ")[^
 var inlineElementStartRegex = new RegExp( "^<(" + inlineElements.join( "|" ) + ")[^>]*>$", "i" );
 var inlineElementEndRegex = new RegExp( "^</(" + inlineElements.join( "|" ) + ")[^>]*>$", "i" );
 
-var otherElementStartRegex = /^<([^>\s\/]+)[^>]*>$/;
+var otherElementStartRegex = /^<([^>\s/]+)[^>]*>$/;
 var otherElementEndRegex = /^<\/([^>\s]+)[^>]*>$/;
 
 var contentRegex = /^[^<]+$/;

--- a/src/researches/german/passiveVoice/GermanParticiple.js
+++ b/src/researches/german/passiveVoice/GermanParticiple.js
@@ -6,7 +6,7 @@ var exceptionsParticiplesActive = require( "./exceptionsParticiplesActive.js" )(
 var auxiliaries = require( "./auxiliaries.js" )().participleLike;
 
 var exceptionsRegex =
-	/\S+(apparat|arbeit|dienst|haft|halt|keit|kraft|not|pflicht|schaft|schrift|tät|wert|zeit)($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
+	/\S+(apparat|arbeit|dienst|haft|halt|keit|kraft|not|pflicht|schaft|schrift|tät|wert|zeit)($|[ \n\r\t.,'()"+-;!?:/»«‹›<>])/ig;
 
 var includes = require( "lodash/includes" );
 var map = require( "lodash/map" );

--- a/src/researches/german/passiveVoice/regex.js
+++ b/src/researches/german/passiveVoice/regex.js
@@ -1,10 +1,10 @@
-var verbsBeginningWithGeRegex = /^((ge)\S+t($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>]))/ig;
-var verbsBeginningWithErVerEntBeZerHerUberRegex = /^(((be|ent|er|her|ver|zer|über|ueber)\S+([^s]t|sst))($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>]))/ig;
-var verbsWithGeInMiddleRegex = /(ab|an|auf|aus|vor|wieder|zurück)(ge)\S+t($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
+var verbsBeginningWithGeRegex = /^((ge)\S+t($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>]))/ig;
+var verbsBeginningWithErVerEntBeZerHerUberRegex = /^(((be|ent|er|her|ver|zer|über|ueber)\S+([^s]t|sst))($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>]))/ig;
+var verbsWithGeInMiddleRegex = /(ab|an|auf|aus|vor|wieder|zurück)(ge)\S+t($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig;
 var verbsWithErVerEntBeZerHerUberInMiddleRegex =
-	/((ab|an|auf|aus|vor|wieder|zurück)(be|ent|er|her|ver|zer|über|ueber)\S+([^s]t|sst))($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
-var verbsEndingWithIertRegex = /\S+iert($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
-var exceptionsRegex = /\S+(apparat|arbeit|dienst|haft|halt|kraft|not|pflicht|schaft|schrift|tät|wert|zeit)($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
+	/((ab|an|auf|aus|vor|wieder|zurück)(be|ent|er|her|ver|zer|über|ueber)\S+([^s]t|sst))($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig;
+var verbsEndingWithIertRegex = /\S+iert($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig;
+var exceptionsRegex = /\S+(apparat|arbeit|dienst|haft|halt|kraft|not|pflicht|schaft|schrift|tät|wert|zeit)($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig;
 
 /**
  * Checks if the word starts with 'ge'.

--- a/src/researches/passiveVoice/periphrastic/getSentenceParts.js
+++ b/src/researches/passiveVoice/periphrastic/getSentenceParts.js
@@ -19,15 +19,15 @@ const forEach = require( "lodash/forEach" );
 const SentencePartEnglish = require( "../../english/passiveVoice/SentencePart" );
 const auxiliariesEnglish = require( "../../english/passiveVoice/auxiliaries.js" )().all;
 const stopwordsEnglish = require( "../../english/passiveVoice/stopwords.js" )();
-const stopCharacterRegexEnglish = /([:,]|('ll)|('ve))(?=[ \n\r\t\'\"\+\-»«‹›<>])/ig;
-const verbEndingInIngRegex = /\w+ing(?=$|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig;
+const stopCharacterRegexEnglish = /([:,]|('ll)|('ve))(?=[ \n\r\t'"+\-»«‹›<>])/ig;
+const verbEndingInIngRegex = /\w+ing(?=$|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig;
 const ingExclusionArray = [ "king", "cling", "ring", "being", "thing", "something", "anything" ];
 
 // French-specific variables and imports.
 const SentencePartFrench = require( "../../french/passiveVoice/SentencePart" );
 const auxiliariesFrench = require( "../../french/passiveVoice/auxiliaries.js" )();
 const stopwordsFrench = require( "../../french/passiveVoice/stopwords.js" )();
-const stopCharacterRegexFrench = /(,)(?=[ \n\r\t\'\"\+\-»«‹›<>])/ig;
+const stopCharacterRegexFrench = /(,)(?=[ \n\r\t'"+\-»«‹›<>])/ig;
 const followingAuxiliaryExceptionWordsFrench = [ "le", "la", "les", "une", "l'un", "l'une" ];
 const reflexivePronounsFrench = [ "se", "me", "te", "s'y", "m'y", "t'y", "nous nous", "vous vous" ];
 const directPrecedenceExceptionRegex = arrayToRegex( reflexivePronounsFrench );
@@ -38,7 +38,7 @@ const elisionAuxiliaryExceptionRegex = arrayToRegex( elisionAuxiliaryExceptionWo
 const SentencePartSpanish = require( "../../spanish/passiveVoice/SentencePart" );
 const auxiliariesSpanish = require( "../../spanish/passiveVoice/auxiliaries.js" )();
 const stopwordsSpanish = require( "../../spanish/passiveVoice/stopwords.js" )();
-const stopCharacterRegexSpanish = /([:,])(?=[ \n\r\t\'\"\+\-»«‹›<>])/ig;
+const stopCharacterRegexSpanish = /([:,])(?=[ \n\r\t'"+\-»«‹›<>])/ig;
 const followingAuxiliaryExceptionWordsSpanish = [ "el", "la", "los", "las", "una" ];
 
 

--- a/src/researches/passiveVoice/periphrastic/matchParticiples.js
+++ b/src/researches/passiveVoice/periphrastic/matchParticiples.js
@@ -12,10 +12,10 @@ const spanishParticiples = require( "../../spanish/passiveVoice/participles" )()
 // The language-specific participle regexes.
 const languageVariables = {
 	en: {
-		regularParticiplesRegex: /\w+ed($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig,
+		regularParticiplesRegex: /\w+ed($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig,
 	},
 	fr: {
-		regularParticiplesRegex: /\S+(é|ée|és|ées)($|[ \n\r\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])/ig,
+		regularParticiplesRegex: /\S+(é|ée|és|ées)($|[ \n\r\t.,'()"+\-;!?:/»«‹›<>])/ig,
 	},
 };
 

--- a/src/stringProcessing/getSentences.js
+++ b/src/stringProcessing/getSentences.js
@@ -24,12 +24,12 @@ var newLines = "\n\r|\n|\r";
 var fullStopRegex = new RegExp( "^[" + fullStop + "]$" );
 var sentenceDelimiterRegex = new RegExp( "^[" + sentenceDelimiters + "]$" );
 var sentenceRegex = new RegExp( "^[^" + fullStop + sentenceDelimiters + "<\\(\\)\\[\\]]+$" );
-var htmlStartRegex = /^<([^>\s\/]+)[^>]*>$/mi;
+var htmlStartRegex = /^<([^>\s/]+)[^>]*>$/mi;
 var htmlEndRegex = /^<\/([^>\s]+)[^>]*>$/mi;
 var newLineRegex = new RegExp( newLines );
 
-var blockStartRegex = /^\s*[\[\(\{]\s*$/;
-var blockEndRegex = /^\s*[\]\)}]\s*$/;
+var blockStartRegex = /^\s*[[({]\s*$/;
+var blockEndRegex = /^\s*[\])}]\s*$/;
 
 var tokens = [];
 var sentenceTokenizer;

--- a/src/stringProcessing/removeNonWordCharacters.js
+++ b/src/stringProcessing/removeNonWordCharacters.js
@@ -7,5 +7,5 @@
  * @returns {string} string The string without spaces.
  */
 module.exports = function( string ) {
-	return string.replace( /[\s\n\r\t\.,'\(\)\"\+;!?:\/]/g, "" );
+	return string.replace( /[\s\n\r\t.,'()"+;!?:/]/g, "" );
 };

--- a/src/stringProcessing/stripHTMLTags.js
+++ b/src/stringProcessing/stripHTMLTags.js
@@ -15,7 +15,7 @@ var blockElementEndRegex = new RegExp( "</(" + blockElements.join( "|" ) + ")[^>
  */
 var stripIncompleteTags = function( text ) {
 	text = text.replace( /^(<\/([^>]+)>)+/i, "" );
-	text = text.replace( /(<([^\/>]+)>)+$/i, "" );
+	text = text.replace( /(<([^/>]+)>)+$/i, "" );
 	return text;
 };
 

--- a/src/stringProcessing/stripNonTextTags.js
+++ b/src/stringProcessing/stripNonTextTags.js
@@ -9,7 +9,7 @@ var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
  * @returns {string} The text stripped of tags, except for li, p, dd and h1-h6 tags.
  */
 module.exports = function( text ) {
-	text = text.replace( /<(?!li|\/li|p|\/p|h1|\/h1|h2|\/h2|h3|\/h3|h4|\/h4|h5|\/h5|h6|\/h6|dd).*?\>/g, "" );
+	text = text.replace( /<(?!li|\/li|p|\/p|h1|\/h1|h2|\/h2|h3|\/h3|h4|\/h4|h5|\/h5|h6|\/h6|dd).*?>/g, "" );
 	text = stripSpaces( text );
 	return text;
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* A lot of superfluous escapes in regexes were fixed to get rid of warnings at `grunt check` and builds.
* The rest of the warnings do not seem to be legit, because removing escapes changes regex processing.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test` in the branch to make sure these escapes were indeed superfluous and that processing works well without them.

Fixes #1481 
