### PR TITLE
Strip out question mark and hash characters from the snippet preview …

### DIFF
--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -647,6 +647,8 @@ SnippetPreview.prototype.formatCite = function() {
 
 	// URL's cannot contain whitespace so replace it by dashes.
 	cite = cite.replace( /\s/g, "-" );
+	// Strip out question mark and hash characters from the raw URL.
+	cite = cite.replace( /\?|#/g, "" );
 
 	return cite;
 };


### PR DESCRIPTION
For consistency with the React snippet preview, see https://github.com/Yoast/yoast-components/pull/495

Strips out any `?` and `#` from the snippet preview URL.

To test:
- yarn link YoastSEO to wpseo
- build the JS
- in the wpseo classic snippet preview:
- edit the snippet preview
- in the slug field, enter a slug that contains `?` and `#` characters
- check the slug in the classic snippet preview is rendered correctly, without `?` and `#` and with no missing parts

Fixes https://github.com/Yoast/yoast-components/issues/485