### PR TITLE
Add Catalan transition words

### DIFF
--- a/spec/helpers/getTransitionWordsSpec.js
+++ b/spec/helpers/getTransitionWordsSpec.js
@@ -37,6 +37,11 @@ describe( "gets transition words, based on language", function() {
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
+	it( "checks if all properties are set for Catalan", function() {
+		var transitionWords = getTransitionWords( "ca_ES" );
+		expect( Object.keys( transitionWords ) ).toEqual( properties );
+	} );
+
 	it( "checks if all properties are set if no locale is given", function() {
 		var transitionWords = getTransitionWords( "" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -315,6 +315,37 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 0 );
 	} );
 
+	it( "returns 1 when a transition word is found in a sentence (Catalan)", function() {
+		// Transition word: en primer lloc
+		mockPaper = new Paper( "En primer lloc, permetin-me presentar-me.", { locale: "ca_ES" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+
+	it( "returns 1 when a transition word with an apostrophe is found in a sentence (Catalan)", function() {
+		// Transition word: a tall d'exemple.
+		mockPaper = new Paper( "A tall d'exemple, pensem en aquest gat.", { locale: "ca_ES" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+
+	it( "returns 1 when a two-part transition word is found in a sentence (Catalan)", function() {
+		// Transition word: ni...ni
+		mockPaper = new Paper( "No era ni un gat ni un gos.", { locale: "ca_ES" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+
+	it( "returns 0 when no transition words are present in a sentence (Catalan)", function() {
+		mockPaper = new Paper( "Anem a la platja.", { locale: "ca_ES" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
+
 	it( "defaults to English in case of a bogus locale", function() {
 		// Transition word: because.
 		mockPaper = new Paper( "Because of a bogus locale.", { locale: "xx_YY" } );

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ let Mark = require( "../../values/Mark.js" );
 let marker = require( "../../markers/addMark.js" );
 
 let getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
-let availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru" ];
+let availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/src/helpers/getTransitionWords.js
+++ b/src/helpers/getTransitionWords.js
@@ -14,6 +14,8 @@ let transitionWordsPortuguese = require( "../researches/portuguese/transitionWor
 let twoPartTransitionWordsPortuguese = require( "../researches/portuguese/twoPartTransitionWords.js" );
 let transitionWordsRussian = require( "../researches/russian/transitionWords.js" )().allWords;
 let twoPartTransitionWordsRussian = require( "../researches/russian/twoPartTransitionWords.js" );
+let transitionWordsCatalan = require( "../researches/catalan/transitionWords.js" )().allWords;
+let twoPartTransitionWordsCatalan = require( "../researches/catalan/twoPartTransitionWords.js" );
 
 let getLanguage = require( "./getLanguage.js" );
 
@@ -53,6 +55,11 @@ module.exports = function( locale ) {
 			return {
 				transitionWords: transitionWordsRussian,
 				twoPartTransitionWords: twoPartTransitionWordsRussian,
+			};
+		case "ca":
+			return {
+				transitionWords: transitionWordsCatalan,
+				twoPartTransitionWords: twoPartTransitionWordsCatalan,
 			};
 		default:
 		case "en":

--- a/src/researches/catalan/transitionWords.js
+++ b/src/researches/catalan/transitionWords.js
@@ -1,0 +1,35 @@
+/** @module config/transitionWords */
+
+let singleWords = [	"així",	"altrament", "anteriorment", "breument", "contràriament", "després", "doncs", "efectivament",
+	"endemés", "finalment", "generalment", "igualment", "malgrat", "mentre", "parallelament", "però", "perquè",
+	"primerament", "resumidament", "resumint", "sinó", "sobretot", "també", "tanmateix" ];
+
+let multipleWords = [ "a banda d'això", "a continuació", "a fi de", "a fi que", "a força de", "a manera de resum", "a més",
+	"a tall d'exemple", "a tall de recapitulació", "a tall de resum", "al capdavall", "al contrari", "al mateix temps",
+	"amb relació a", "amb tot plegat", "ara bé", "atès que", "com a conseqüència", "com a exemple", "com a resultat",
+	"com a resum", "com que", "comptat i debatut", "considerant que", "convé destacar", "convé recalcar",
+	"convé ressaltar que", "d'altra banda", "d’una banda", "d’una forma breu", "de la mateixa manera", "de manera parallela",
+	"de manera que", "degut a", "deixant de banda", "dit d'una altra manera", "donat que", "en a resum", "en altres paraules",
+	"en canvi", "en conclusió", "en conjunt", "en conseqüència", "encara que", "en darrer lloc", "en darrer terme",
+	"en definitiva", "en efect", "en general", "en particular", "en pocs mots", "en poques paraules", "en primer lloc",
+	"en relació amb", "en resum", "en segon lloc", "en síntesi", "en suma", "en tercer lloc", "en últim terme", "és a dir",
+	"és més", "és per això que", "fins i tot", "gràcies a", "gràcies de", "igual com", "igual que", "ja que", "llevat que",
+	"més aviat", "més tard", "no obstant", "o sia", "o sigui", "pel fet que", "pel general", "pel que", "per acabar",
+	"per això", "per altra banda", "per aquest motiu", "per causa de", "per causa que", "per cert", "per començar",
+	"per concloure", "per concretar", "per contra", "per exemple", "per illustrar", "per l'altra part", "per l'altre cantó",
+	"per la qual cosa", "per posar un exemple", "per raó de", "per raó que", "per tal de", "per tal que", "per tant",
+	"per últim", "per un cantó", "per un costat", "per una altra banda", "per una part", "quant a", "recapitulant",
+	"respecte de", "s'ha de tenir en compte que", "sempre que", "tal com s’ha dit", "tan bon punt", "tenint en compte que",
+	"tot i", "tot seguit", "val la pena dir que", "vist que" ];
+
+/**
+ * Returns lists with transition words to be used by the assessments.
+ * @returns {Object} The object with transition word lists.
+ */
+module.exports = function() {
+	return {
+		singleWords: singleWords,
+		multipleWords: multipleWords,
+		allWords: singleWords.concat( multipleWords ),
+	};
+};

--- a/src/researches/catalan/transitionWords.js
+++ b/src/researches/catalan/transitionWords.js
@@ -1,8 +1,8 @@
 /** @module config/transitionWords */
 
-let singleWords = [	"així",	"altrament", "anteriorment", "breument", "contràriament", "després", "doncs", "efectivament",
-	"endemés", "finalment", "generalment", "igualment", "malgrat", "mentre", "parallelament", "però", "perquè",
-	"primerament", "resumidament", "resumint", "sinó", "sobretot", "també", "tanmateix" ];
+let singleWords = [	"abans", "així", "altrament", "anteriorment", "breument", "contràriament", "després", "doncs",
+	"efectivament", "endemés", "finalment", "generalment", "igualment", "malgrat", "mentre", "parallelament", "però",
+	"perquè", "primerament", "resumidament", "resumint", "sinó", "sobretot", "també", "tanmateix" ];
 
 let multipleWords = [ "a banda d'això", "a continuació", "a fi de", "a fi que", "a força de", "a manera de resum", "a més",
 	"a tall d'exemple", "a tall de recapitulació", "a tall de resum", "al capdavall", "al contrari", "al mateix temps",

--- a/src/researches/catalan/twoPartTransitionWords.js
+++ b/src/researches/catalan/twoPartTransitionWords.js
@@ -1,0 +1,9 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @returns {Array} The array filled with two-part transition words.
+ */
+module.exports = function() {
+	return [ [ "ara", "ara" ], [ "ni", "ni" ] ];
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds transition words for Catalan 

## Relevant technical choices

* Specifically addresses a question of transition words with apostrophes. 


## Test instructions

This PR can be tested by following these steps:

### Browserified

- check out the branch
- use the browserfied example. Don't forget to run a grunt build:js
- Set locale to ca_ES
- Write a Catalan sentence containing a one or two-part transition word (see list of transition words in the code files)
- Hit the mark transition word sentences button to check if the sentences are correctly marked.

### WordPress

- In your WordPress SEO testing environment, ensure you've already run yarn install once in the plugin's directory.
- Run yarn add "git+https://github.com/Yoast/yoastseo.js#stories/1484-add-transition-words-catalan" in the plugin's directory.
- Navigate to node_modules/yoastseo and run yarn install and grunt build:js.
- Navigate back to the plugin's directory and run grunt build:js.
- In your testing environment, set the language to Catalan ("ca").
- Write a Catalan text.
- Determine that the transition word assessments appears in the list and no error occur.

Fixes #1484 
