### PR TITLE
Refactor many SEO assessments

### DIFF
--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -23,7 +23,6 @@ describe( "running assessments in the assessor", function() {
 		let assessments = getResults( assessor.getValidResults() );
 
 		expect( assessments ).toEqual( [
-			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
@@ -37,7 +36,6 @@ describe( "running assessments in the assessor", function() {
 		let assessments = getResults( assessor.getValidResults() );
 
 		expect( assessments ).toEqual( [
-			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
@@ -62,7 +60,7 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a keyword", function() {
+	it( "additionally runs assessments that require a text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );
 
@@ -79,7 +77,7 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a url and a keyword", function() {
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
 		assessor.assess( new Paper( "text", { url: "https://www.website.com", keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );
 

--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -74,6 +74,24 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments that require a keyword and subheadings in the text", function() {
+		assessor.assess( new Paper( "text <h2> subheading </h2> more text", { keyword: "keyword" } ) );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"subheadingsKeyword",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a text, a url and a keyword", function() {
 		assessor.assess( new Paper( "text", { url: "https://www.website.com", keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );

--- a/spec/assessments/internalLinksSpec.js
+++ b/spec/assessments/internalLinksSpec.js
@@ -44,11 +44,4 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const isApplicableResult = new LinkStatisticAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( false );
 	} );
-
-	it( "A paper with a broken researcher", function() {
-		const mockPaper = new Paper( "some text" );
-		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( {} ), i18n );
-
-		expect( assessment.hasScore() ).toEqual( false );
-	} );
 } );

--- a/spec/assessments/internalLinksSpec.js
+++ b/spec/assessments/internalLinksSpec.js
@@ -1,61 +1,56 @@
-var linkStatisticAssessment = require( "../../js/assessments/seo/internalLinksAssessment.js" );
-var Paper = require( "../../js/values/Paper.js" );
+const LinkStatisticAssessment = require( "../../js/assessments/seo/internalLinksAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
 
-var factory = require( "../helpers/factory.js" );
-var i18n = factory.buildJed();
+const factory = require( "../helpers/factory.js" );
+const i18n = factory.buildJed();
 
 describe( "An assessor running the linkStatistics for internal links", function() {
-	it( "Accepts a paper and i18nobject  ", function() {
-		var attributes = {
-			keyword: "keyword",
-			url: "http://yoast.com",
-		};
-		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
+	it( "A paper with one internal link, which is do-follow", function() {
+		const mockPaper = new Paper( "some text" );
 
-		var mockResult = { externalDofollow: 0,
-			externalNofollow: 0,
-			externalTotal: 0,
-			internalDofollow: 1,
-			internalNofollow: 0,
-			internalTotal: 1,
-			otherDofollow: 0,
-			otherNofollow: 0,
-			otherTotal: 0,
-			total: 1,
-			totalKeyword: 0,
-			totalNaKeyword: 1 };
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1, internalNofollow: 0, internalTotal: 1 } ), i18n );
 
-		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "This page has 1 internal link(s)." );
+	} );
+
+	it( "A paper with one internal link which is do-follow, and one internal link which is no-follow", function() {
+		const mockPaper = new Paper( "some text" );
+
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1, internalNofollow: 1, internalTotal: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed internal link(s) and 1 normal internal link(s)." );
+		expect( assessment.getText() ).toEqual( "This page has 1 nofollowed internal link(s) and 1 normal internal link(s)." );
+	} );
 
-		mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
+	it( "A paper with one internal link, which is no-follow", function() {
+		const mockPaper = new Paper( "some text" );
 
-		var mockResult = { externalDofollow: 0,
-			externalNofollow: 0,
-			externalTotal: 0,
-			internalDofollow: 0,
-			internalNofollow: 1,
-			internalTotal: 1,
-			otherDofollow: 0,
-			otherNofollow: 0,
-			otherTotal: 0,
-			total: 1,
-			totalKeyword: 0,
-			totalNaKeyword: 0 };
-
-		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 0, internalNofollow: 1, internalTotal: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
 		expect( assessment.getText() ).toEqual( "This page has 1 internal link(s), all nofollowed." );
 	} );
 
-	it( "Accepts a paper and i18nobject  ", function() {
-		var mockPaper = new Paper( "" );
-		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
+	it( "A paper without internal links", function() {
+		const mockPaper = new Paper( "some text" );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "No internal links appear in this page, consider adding some as appropriate." );
+	} );
+
+	it( "A paper without text", function() {
+		const mockPaper = new Paper( "" );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
+
+		expect( assessment.hasScore() ).toEqual( false );
+	} );
+
+	it( "A paper with a broken researcher", function() {
+		const mockPaper = new Paper( "some text" );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( {} ), i18n );
+
+		expect( assessment.hasScore() ).toEqual( false );
 	} );
 } );

--- a/spec/assessments/internalLinksSpec.js
+++ b/spec/assessments/internalLinksSpec.js
@@ -41,10 +41,8 @@ describe( "An assessor running the linkStatistics for internal links", function(
 	} );
 
 	it( "A paper without text", function() {
-		const mockPaper = new Paper( "" );
-		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
-
-		expect( assessment.hasScore() ).toEqual( false );
+		const isApplicableResult = new LinkStatisticAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( false );
 	} );
 
 	it( "A paper with a broken researcher", function() {

--- a/spec/assessments/introductionKeywordSpec.js
+++ b/spec/assessments/introductionKeywordSpec.js
@@ -36,20 +36,12 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 	} );
 
 	it( "returns no score if no keyword is defined", function() {
-		const assessment = new FirstParagraphAssessment().getResult(
-			new Paper( "some text" ),
-			Factory.buildMockResearcher( 0 ),
-			i18n
-		);
-		expect( assessment.hasScore() ).toBe( false );
+		const isApplicableResult = new FirstParagraphAssessment().isApplicable( new Paper( "some text" ) );
+		expect( isApplicableResult ).toBe( false );
 	} );
 
 	it( "returns no score if no text is defined", function() {
-		const assessment = new FirstParagraphAssessment().getResult(
-			new Paper( "", { keyword: "some keyword" } ),
-			Factory.buildMockResearcher( 0 ),
-			i18n
-		);
-		expect( assessment.hasScore() ).toBe( false );
+		const isApplicableResult = new FirstParagraphAssessment().isApplicable( new Paper( "" ), { keyword: "some keyword" } );
+		expect( isApplicableResult ).toBe( false );
 	} );
 } );

--- a/spec/assessments/introductionKeywordSpec.js
+++ b/spec/assessments/introductionKeywordSpec.js
@@ -1,28 +1,55 @@
-var firstParagraphAssessment = require( "../../js/assessments/seo/introductionKeywordAssessment.js" );
-var Paper = require( "../../js/values/Paper.js" );
-var Factory = require( "../helpers/factory.js" );
-var i18n = Factory.buildJed();
+const FirstParagraphAssessment = require( "../../js/assessments/seo/introductionKeywordAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
+const Factory = require( "../helpers/factory.js" );
+const i18n = Factory.buildJed();
 
-var paper = new Paper();
 describe( "An assessment for finding the keyword in the first paragraph", function() {
 	it( "returns a keyword found in the first paragraph", function() {
-		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 1 ), i18n );
-
+		const assessment = new FirstParagraphAssessment().getResult(
+			new Paper( "some text with some keyword", { keyword: "some keyword" } ),
+			Factory.buildMockResearcher( 1 ),
+			i18n
+		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The focus keyword appears in the first paragraph of the copy." );
 	} );
 
 	it( "returns multiple keywords found in the first paragraph", function() {
-		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 10 ), i18n );
-
+		const assessment = new FirstParagraphAssessment().getResult(
+			new Paper( "some text, more text, even more text", { keyword: "text" } ),
+			Factory.buildMockResearcher( 3 ),
+			i18n
+		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The focus keyword appears in the first paragraph of the copy." );
 	} );
 
 	it( "returns no keyword found in the first paragraph", function() {
-		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 0 ), i18n );
-
+		const assessment = new FirstParagraphAssessment().getResult(
+			new Paper( "some text", { keyword: "some keyword" } ),
+			Factory.buildMockResearcher( 0 ),
+			i18n
+		);
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The focus keyword doesn't appear in the first paragraph of the copy. Make sure the topic is clear immediately." );
+		expect( assessment.getText() ).toBe( "The focus keyword doesn't appear in the first paragraph of the copy. " +
+			"Make sure the topic is clear immediately." );
+	} );
+
+	it( "returns no score if no keyword is defined", function() {
+		const assessment = new FirstParagraphAssessment().getResult(
+			new Paper( "some text" ),
+			Factory.buildMockResearcher( 0 ),
+			i18n
+		);
+		expect( assessment.hasScore() ).toBe( false );
+	} );
+
+	it( "returns no score if no text is defined", function() {
+		const assessment = new FirstParagraphAssessment().getResult(
+			new Paper( "", { keyword: "some keyword" } ),
+			Factory.buildMockResearcher( 0 ),
+			i18n
+		);
+		expect( assessment.hasScore() ).toBe( false );
 	} );
 } );

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -37,4 +37,10 @@ describe( "An descriptionLength assessment", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "The meta description has a nice length." );
 	} );
+
+	it( "checks if getMaximumLength function returns a correct value", function() {
+		var getMaximumLengthResult = descriptionLengthAssessment.getMaximumLength();
+
+		expect( getMaximumLengthResult ).toEqual( 156 );
+	} );
 } );

--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -44,12 +44,5 @@ describe( "An assessor running the linkStatistics for external links", function(
 		const isApplicableResult = new LinkStatisticAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( false );
 	} );
-
-	it( "A paper with a broken researcher", function() {
-		const mockPaper = new Paper( "some text" );
-		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( {} ), i18n );
-
-		expect( assessment.hasScore() ).toEqual( false );
-	} );
 } );
 

--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -1,63 +1,55 @@
-let OutboundLinksAssessment = require( "../../js/assessments/seo/outboundLinksAssessment.js" );
-var Paper = require( "../../js/values/Paper.js" );
+const LinkStatisticAssessment = require( "../../js/assessments/seo/outboundLinksAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
 
-var factory = require( "../helpers/factory.js" );
-var i18n = factory.buildJed();
+const factory = require( "../helpers/factory.js" );
+const i18n = factory.buildJed();
 
-let linkStatisticAssessment = new OutboundLinksAssessment();
+describe( "An assessor running the linkStatistics for external links", function() {
+	it( "A paper with one external link, which is do-follow", function() {
+		const mockPaper = new Paper( "some text" );
 
-describe( "An assessor running the linkStatistics", function() {
-	it( "Accepts a paper and i18nobject  ", function() {
-		var attributes = {
-			keyword: "keyword",
-			url: "http://example.com",
-		};
-		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { externalDofollow: 1, externalNofollow: 0, externalTotal: 1 } ), i18n );
 
-		var mockResult = { externalDofollow: 1,
-			externalNofollow: 0,
-			externalTotal: 1,
-			internalDofollow: 0,
-			internalNofollow: 0,
-			internalTotal: 0,
-			otherDofollow: 0,
-			otherNofollow: 0,
-			otherTotal: 0,
-			total: 1,
-			totalKeyword: 0,
-			totalNaKeyword: 1 };
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "This page has 1 outbound link(s)." );
+	} );
 
-		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+	it( "A paper with one external link which is do-follow, and one external link which is no-follow", function() {
+		const mockPaper = new Paper( "some text" );
+
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { externalDofollow: 1, externalNofollow: 1, externalTotal: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed outbound link(s) and 1 normal outbound link(s)." );
+		expect( assessment.getText() ).toEqual( "This page has 1 nofollowed outbound link(s) and 1 normal outbound link(s)." );
+	} );
 
-		mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
+	it( "A paper with one external link, which is no-follow", function() {
+		const mockPaper = new Paper( "some text" );
 
-		var mockResult = { externalDofollow: 0,
-			externalNofollow: 1,
-			externalTotal: 1,
-			internalDofollow: 0,
-			internalNofollow: 0,
-			internalTotal: 0,
-			otherDofollow: 0,
-			otherNofollow: 0,
-			otherTotal: 0,
-			total: 1,
-			totalKeyword: 0,
-			totalNaKeyword: 0 };
-
-		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { externalDofollow: 0, externalNofollow: 1, externalTotal: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
 		expect( assessment.getText() ).toEqual( "This page has 1 outbound link(s), all nofollowed." );
 	} );
 
-	it( "Accepts a paper and i18nobject  ", function() {
-		var mockPaper = new Paper( "" );
-		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
+	it( "A paper without external links", function() {
+		const mockPaper = new Paper( "some text" );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "No outbound links appear in this page, consider adding some as appropriate." );
 	} );
+
+	it( "A paper without text", function() {
+		const isApplicableResult = new LinkStatisticAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "A paper with a broken researcher", function() {
+		const mockPaper = new Paper( "some text" );
+		const assessment = new LinkStatisticAssessment().getResult( mockPaper, factory.buildMockResearcher( {} ), i18n );
+
+		expect( assessment.hasScore() ).toEqual( false );
+	} );
 } );
+

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -42,4 +42,10 @@ describe( "the SEO title length assessment", function() {
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "The SEO title is wider than the viewable limit." );
 	} );
+
+	it( "checks if getMaximumLength function returns a correct value", function() {
+		var getMaximumLengthResult = pageTitleLengthAssessment.getMaximumLength();
+
+		expect( getMaximumLengthResult ).toEqual( 600 );
+	} );
 } );

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -1,38 +1,48 @@
-var SubheadingsKeywordAssessment = require( "../../js/assessments/seo/subheadingsKeywordAssessment.js" );
-var Paper = require( "../../js/values/Paper.js" );
-var Factory = require( "../helpers/factory.js" );
-var i18n = Factory.buildJed();
+const SubheadingsKeywordAssessment = require( "../../js/assessments/seo/subheadingsKeywordAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
+const Factory = require( "../helpers/factory.js" );
+const i18n = Factory.buildJed();
 
 let matchKeywordAssessment = new SubheadingsKeywordAssessment();
 
 describe( "An assessment for matching keywords in subheadings", function() {
 	it( "assesses a string without subheadings", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 0 } ), i18n );
+		const mockPaper = new Paper( "some text without subheadings" );
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 0 } ), i18n );
 
 		expect( assessment.hasScore() ).toBe( false );
-		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual( "" );
 	} );
 	it( "assesses a string with subheadings without keywords", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
+		const mockPaper = new Paper( "some text without subheadings" );
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "You have not used the focus keyword in any subheading (such as an H2) in your copy." );
 	} );
 	it( "assesses a string with subheadings and keywords", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
+		const mockPaper = new Paper( "some text without subheadings" );
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 1) subheadings in your copy." );
 	} );
 	it( "assesses a string with subheadings and keywords", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 10, matches: 1 } ), i18n );
+		const mockPaper = new Paper( "some text without subheadings" );
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 10, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 10) subheadings in your copy." );
+	} );
+	it( "checks isApplicable for a paper without text", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+	it( "checks isApplicable for  a paper without keyword", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+	it( "checks isApplicable for  a paper without text", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( true );
 	} );
 } );

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -63,7 +63,7 @@ describe( "An assessment for matching keywords in subheadings", function() {
 		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "" } ) );
 		expect( isApplicableResult ).toBe( false );
 	} );
-	
+
 	it( "checks isApplicable for a paper with text and keyword", function() {
 		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( true );

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -37,11 +37,11 @@ describe( "An assessment for matching keywords in subheadings", function() {
 		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( false );
 	} );
-	it( "checks isApplicable for  a paper without keyword", function() {
+	it( "checks isApplicable for a paper without keyword", function() {
 		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "" } ) );
 		expect( isApplicableResult ).toBe( false );
 	} );
-	it( "checks isApplicable for  a paper without text", function() {
+	it( "checks isApplicable for a paper with text and keyword", function() {
 		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( true );
 	} );

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -6,13 +6,6 @@ const i18n = Factory.buildJed();
 let matchKeywordAssessment = new SubheadingsKeywordAssessment();
 
 describe( "An assessment for matching keywords in subheadings", function() {
-	it( "returns the default assessment values for a string without subheadings", function() {
-		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 0 } ), i18n );
-
-		expect( assessment.hasScore() ).toBe( false );
-	} );
-
 	it( "returns a bad score and appropriate feedback when none of the subheadings contain the keyword", function() {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
@@ -60,12 +53,17 @@ describe( "An assessment for matching keywords in subheadings", function() {
 	} );
 
 	it( "checks isApplicable for a paper without keyword", function() {
-		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "" } ) );
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "<p>some text</p><h2>heading</h2><p>some more text</p>", { keyword: "" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "checks isApplicable for a paper without subheadings", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "<p>some text</p><p>some more text</p>", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( false );
 	} );
 
 	it( "checks isApplicable for a paper with text and keyword", function() {
-		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "some text", { keyword: "some keyword" } ) );
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "<p>some text</p><h2>heading</h2><p>some more text</p>", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( true );
 	} );
 } );

--- a/spec/assessments/textCompetingLinksSpec.js
+++ b/spec/assessments/textCompetingLinksSpec.js
@@ -49,6 +49,5 @@ describe( "An assessment for the text competing links", function() {
 	it( "is not applicable for papers without keyword and text", function() {
 		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( new Paper( "", { keyword: "" } ) );
 		expect( isApplicableResult ).toBe( false );
-
 	} );
 } );

--- a/spec/assessments/textCompetingLinksSpec.js
+++ b/spec/assessments/textCompetingLinksSpec.js
@@ -1,0 +1,134 @@
+const TextCompetingLinksAssessment = require( "../../js/assessments/seo/textCompetingLinksAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
+
+const factory = require( "../helpers/factory.js" );
+const i18n = factory.buildJed();
+
+describe( "An assessment for the text competing links", function() {
+	it( "returns a 'bad' score if a paper is referring to another paper with the same keyword", function() {
+		const paper = new Paper( "This is a very interesting paper", { keyword: "some keyword" } );
+		const result = new TextCompetingLinksAssessment().getResult(
+			paper,
+			factory.buildMockResearcher(
+				{
+					total: 0,
+					totalNaKeyword: 0,
+					keyword: {
+						totalKeyword: 1,
+						matchedAnchors: [],
+					},
+					internalTotal: 0,
+					internalDofollow: 0,
+					internalNofollow: 0,
+					externalTotal: 0,
+					externalDofollow: 0,
+					externalNofollow: 0,
+					otherTotal: 0,
+					otherDofollow: 0,
+					otherNofollow: 0,
+				}
+			),
+			i18n
+		);
+
+		expect( result.getScore() ).toBe( 2 );
+		expect( result.getText() ).toBe( "You're linking to another page with the focus keyword you want this page to rank for. " +
+			"Consider changing that if you truly want this page to rank." );
+	} );
+
+	it( "is not applicable for papers without text", function() {
+		const paper = new Paper( "", { keyword: "some keyword" } );
+		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( paper );
+		const assessmentResult = new TextCompetingLinksAssessment().getResult(
+			paper,
+			factory.buildMockResearcher(
+				{
+					total: 0,
+					totalNaKeyword: 0,
+					keyword: {
+						totalKeyword: 1,
+						matchedAnchors: [],
+					},
+					internalTotal: 0,
+					internalDofollow: 0,
+					internalNofollow: 0,
+					externalTotal: 0,
+					externalDofollow: 0,
+					externalNofollow: 0,
+					otherTotal: 0,
+					otherDofollow: 0,
+					otherNofollow: 0,
+				}
+			),
+			i18n
+		);
+
+		expect( isApplicableResult ).toBe( false );
+		expect( assessmentResult.hasScore() ).toBe( false );
+		expect( assessmentResult.hasMarks() ).toBe( false );
+	} );
+
+	it( "is not applicable for papers without keyword", function() {
+		const paper = new Paper( "some text", { keyword: "" } );
+		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( paper );
+		const assessmentResult = new TextCompetingLinksAssessment().getResult(
+			paper,
+			factory.buildMockResearcher(
+				{
+					total: 0,
+					totalNaKeyword: 0,
+					keyword: {
+						totalKeyword: 1,
+						matchedAnchors: [],
+					},
+					internalTotal: 0,
+					internalDofollow: 0,
+					internalNofollow: 0,
+					externalTotal: 0,
+					externalDofollow: 0,
+					externalNofollow: 0,
+					otherTotal: 0,
+					otherDofollow: 0,
+					otherNofollow: 0,
+				}
+			),
+			i18n
+		);
+
+		expect( isApplicableResult ).toBe( false );
+		expect( assessmentResult.hasScore() ).toBe( false );
+		expect( assessmentResult.hasMarks() ).toBe( false );
+	} );
+
+	it( "is not applicable for papers without keyword and text", function() {
+		const paper = new Paper( "", { keyword: "" } );
+		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( paper );
+		const assessmentResult = new TextCompetingLinksAssessment().getResult(
+			paper,
+			factory.buildMockResearcher(
+				{
+					total: 0,
+					totalNaKeyword: 0,
+					keyword: {
+						totalKeyword: 1,
+						matchedAnchors: [],
+					},
+					internalTotal: 0,
+					internalDofollow: 0,
+					internalNofollow: 0,
+					externalTotal: 0,
+					externalDofollow: 0,
+					externalNofollow: 0,
+					otherTotal: 0,
+					otherDofollow: 0,
+					otherNofollow: 0,
+				}
+			),
+			i18n
+		);
+
+		expect( isApplicableResult ).toBe( false );
+		expect( assessmentResult.hasScore() ).toBe( false );
+		expect( assessmentResult.hasMarks() ).toBe( false );
+	} );
+} );

--- a/spec/assessments/textCompetingLinksSpec.js
+++ b/spec/assessments/textCompetingLinksSpec.js
@@ -1,10 +1,12 @@
+import Mark from "../../js/values/Mark";
+
 const TextCompetingLinksAssessment = require( "../../js/assessments/seo/textCompetingLinksAssessment.js" );
 const Paper = require( "../../js/values/Paper.js" );
 
 const factory = require( "../helpers/factory.js" );
 const i18n = factory.buildJed();
 
-describe( "An assessment for the text competing links", function() {
+describe( "An assessment for competing links in the text", function() {
 	it( "returns a 'bad' score if a paper is referring to another paper with the same keyword", function() {
 		const paper = new Paper( "This is a very interesting paper", { keyword: "some keyword" } );
 		const result = new TextCompetingLinksAssessment().getResult(
@@ -49,5 +51,39 @@ describe( "An assessment for the text competing links", function() {
 	it( "is not applicable for papers without keyword and text", function() {
 		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( new Paper( "", { keyword: "" } ) );
 		expect( isApplicableResult ).toBe( false );
+	} );
+} );
+
+describe( "A test for marking competing links", function() {
+	it( "returns markers for links to posts that rank for the same keyword", function() {
+		let paper = new Paper( "some text", { keyword: "some keyword" } );
+		const result = new TextCompetingLinksAssessment().getResult(
+			paper,
+			factory.buildMockResearcher(
+				{
+					total: 0,
+					totalNaKeyword: 0,
+					keyword: {
+						totalKeyword: 1,
+						matchedAnchors: [ "http://www.mywebsite.com/competing_content" ],
+					},
+					internalTotal: 0,
+					internalDofollow: 0,
+					internalNofollow: 0,
+					externalTotal: 0,
+					externalDofollow: 0,
+					externalNofollow: 0,
+					otherTotal: 0,
+					otherDofollow: 0,
+					otherNofollow: 0,
+				}
+			),
+			i18n
+		);
+
+		let expected = [
+			new Mark( { original: "http://www.mywebsite.com/competing_content", marked: "<yoastmark class='yoast-text-mark'>http://www.mywebsite.com/competing_content</yoastmark>" } ),
+		];
+		expect( result._marker ).toEqual( expected );
 	} );
 } );

--- a/spec/assessments/textCompetingLinksSpec.js
+++ b/spec/assessments/textCompetingLinksSpec.js
@@ -37,98 +37,18 @@ describe( "An assessment for the text competing links", function() {
 	} );
 
 	it( "is not applicable for papers without text", function() {
-		const paper = new Paper( "", { keyword: "some keyword" } );
-		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( paper );
-		const assessmentResult = new TextCompetingLinksAssessment().getResult(
-			paper,
-			factory.buildMockResearcher(
-				{
-					total: 0,
-					totalNaKeyword: 0,
-					keyword: {
-						totalKeyword: 1,
-						matchedAnchors: [],
-					},
-					internalTotal: 0,
-					internalDofollow: 0,
-					internalNofollow: 0,
-					externalTotal: 0,
-					externalDofollow: 0,
-					externalNofollow: 0,
-					otherTotal: 0,
-					otherDofollow: 0,
-					otherNofollow: 0,
-				}
-			),
-			i18n
-		);
-
+		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
 		expect( isApplicableResult ).toBe( false );
-		expect( assessmentResult.hasScore() ).toBe( false );
-		expect( assessmentResult.hasMarks() ).toBe( false );
 	} );
 
 	it( "is not applicable for papers without keyword", function() {
-		const paper = new Paper( "some text", { keyword: "" } );
-		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( paper );
-		const assessmentResult = new TextCompetingLinksAssessment().getResult(
-			paper,
-			factory.buildMockResearcher(
-				{
-					total: 0,
-					totalNaKeyword: 0,
-					keyword: {
-						totalKeyword: 1,
-						matchedAnchors: [],
-					},
-					internalTotal: 0,
-					internalDofollow: 0,
-					internalNofollow: 0,
-					externalTotal: 0,
-					externalDofollow: 0,
-					externalNofollow: 0,
-					otherTotal: 0,
-					otherDofollow: 0,
-					otherNofollow: 0,
-				}
-			),
-			i18n
-		);
-
+		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( new Paper( "some text", { keyword: "" } ) );
 		expect( isApplicableResult ).toBe( false );
-		expect( assessmentResult.hasScore() ).toBe( false );
-		expect( assessmentResult.hasMarks() ).toBe( false );
 	} );
 
 	it( "is not applicable for papers without keyword and text", function() {
-		const paper = new Paper( "", { keyword: "" } );
-		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( paper );
-		const assessmentResult = new TextCompetingLinksAssessment().getResult(
-			paper,
-			factory.buildMockResearcher(
-				{
-					total: 0,
-					totalNaKeyword: 0,
-					keyword: {
-						totalKeyword: 1,
-						matchedAnchors: [],
-					},
-					internalTotal: 0,
-					internalDofollow: 0,
-					internalNofollow: 0,
-					externalTotal: 0,
-					externalDofollow: 0,
-					externalNofollow: 0,
-					otherTotal: 0,
-					otherDofollow: 0,
-					otherNofollow: 0,
-				}
-			),
-			i18n
-		);
-
+		const isApplicableResult = new TextCompetingLinksAssessment().isApplicable( new Paper( "", { keyword: "" } ) );
 		expect( isApplicableResult ).toBe( false );
-		expect( assessmentResult.hasScore() ).toBe( false );
-		expect( assessmentResult.hasMarks() ).toBe( false );
+
 	} );
 } );

--- a/spec/assessments/titleKeywordSpec.js
+++ b/spec/assessments/titleKeywordSpec.js
@@ -1,41 +1,49 @@
-var PageTitleKeywordAssessment = require( "../../js/assessments/seo/titleKeywordAssessment.js" );
-var Paper = require( "../../js/values/Paper.js" );
-var Factory = require( "../helpers/factory.js" );
-var i18n = Factory.buildJed();
-
-let pageTitleKeywordAssessment = new PageTitleKeywordAssessment();
+const PageTitleKeywordAssessment = require( "../../js/assessments/seo/titleKeywordAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
+const Factory = require( "../helpers/factory.js" );
+const i18n = Factory.buildJed();
 
 describe( "an assessment to check if the keyword is in the pageTitle", function() {
 	it( "returns an assementresult with keyword not found", function() {
-		var paper = new Paper( "", {
+		const paper = new Paper( "", {
 			keyword: "keyword",
 			title: "a non-empty title",
 		} );
-		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { matches: 0 } ), i18n );
+		const assessment = new PageTitleKeywordAssessment().getResult( paper, Factory.buildMockResearcher( { matches: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe( "The focus keyword 'keyword' does not appear in the SEO title." );
 	} );
 
 	it( "returns an assementresult with keyword found at start", function() {
-		var paper = new Paper( "", {
+		const paper = new Paper( "", {
 			keyword: "keyword",
 			title: "a non-empty title",
 		} );
-		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { matches: 1, position: 0 } ), i18n );
+		const assessment = new PageTitleKeywordAssessment().getResult( paper, Factory.buildMockResearcher( { matches: 1, position: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "The SEO title contains the focus keyword, at the beginning which is considered to improve rankings." );
 	} );
 
 	it( "returns an assementresult with keyword found at start", function() {
-		var paper = new Paper( "", {
+		const paper = new Paper( "", {
 			keyword: "keyword",
 			title: "a non-empty title",
 		} );
-		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { matches: 1, position: 2 } ), i18n );
+		const assessment = new PageTitleKeywordAssessment().getResult( paper, Factory.buildMockResearcher( { matches: 1, position: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "The SEO title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning." );
+	} );
+
+	it( "returns false isApplicable for a paper without title", function() {
+		const isApplicableResult = new PageTitleKeywordAssessment().isApplicable( new Paper( "", { keyword: "some keyword", title: "" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "returns false isApplicable for a paper without keyword", function() {
+		const isApplicableResult = new PageTitleKeywordAssessment().isApplicable( new Paper( "", { keyword: "", title: "some title" } ) );
+		expect( isApplicableResult ).toBe( false );
 	} );
 } );

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -23,7 +23,6 @@ describe( "running assessments in the assessor", function() {
 		let assessments = getResults( assessor.getValidResults() );
 
 		expect( assessments ).toEqual( [
-			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
@@ -37,7 +36,6 @@ describe( "running assessments in the assessor", function() {
 		let assessments = getResults( assessor.getValidResults() );
 
 		expect( assessments ).toEqual( [
-			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
@@ -62,7 +60,7 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a keyword", function() {
+	it( "additionally runs assessments that require a text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );
 
@@ -79,7 +77,7 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a url and a keyword", function() {
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
 		assessor.assess( new Paper( "text", { url: "https://www.website.com", keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );
 

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -43,6 +43,24 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments that require a keyword and subheadings in the text", function() {
+		assessor.assess( new Paper( "text <h2> subheading </h2> more text", { keyword: "keyword" } ) );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"subheadingsKeyword",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
 	it( "runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
 		let assessments = getResults( assessor.getValidResults() );

--- a/src/assessments/seo/internalLinksAssessment.js
+++ b/src/assessments/seo/internalLinksAssessment.js
@@ -63,10 +63,6 @@ class TextHasInternalLinksAssessment extends Assessment {
 		this.linkStatistics = researcher.getResearch( "getLinkStatistics" );
 		let assessmentResult = new AssessmentResult();
 
-		if ( ! this.isApplicable( paper ) ) {
-			return assessmentResult;
-		}
-
 		if ( ! isEmpty( this.linkStatistics ) ) {
 			const calculatedResult = this.calculateResult();
 			assessmentResult.setScore( calculatedResult.score );

--- a/src/assessments/seo/internalLinksAssessment.js
+++ b/src/assessments/seo/internalLinksAssessment.js
@@ -1,76 +1,148 @@
-var AssessmentResult = require( "../../values/AssessmentResult.js" );
-var isEmpty = require( "lodash/isEmpty" );
+const Assessment = require( "../../assessment.js" );
+const AssessmentResult = require( "../../values/AssessmentResult.js" );
+const merge = require( "lodash/merge" );
+const isEmpty = require( "lodash/isEmpty" );
 
 /**
- * Returns a score and text based on the linkStatistics object.
- *
- * @param {object} linkStatistics The object with all linkstatistics.
- * @param {object} i18n The object used for translations
- * @returns {object} resultObject with score and text
+ * Assessment to check whether the text has internal links and whether they are followed or no-followed.
  */
-var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
-	if ( linkStatistics.internalTotal === 0 ) {
-		return {
-			score: 3,
-			text: i18n.dgettext( "js-text-analysis", "No internal links appear in this page, consider adding some as appropriate." ),
+class TextHasInternalLinksAssessment extends Assessment {
+	/**
+	 * Sets the identifier and the config.
+	 *
+	 * @param {Object} config The configuration to use.
+	 *
+	 * @returns {void}
+	 */
+	constructor( config = {} ) {
+		super();
+
+		let defaultConfig = {
+			parameters: {
+				recommendedMinimum: 1,
+			},
+			allInternalFollow: {
+				score: 9,
+				resultText: "This page has %1$s internal link(s).",
+				requiresInternalDofollow: true,
+				requiresInternalNofollow: false,
+			},
+			someInternalFollow: {
+				score: 8,
+				resultText: "This page has %1$s nofollowed internal link(s) and %2$s normal internal link(s).",
+				requiresInternalDofollow: true,
+				requiresInternalNofollow: true,
+			},
+			noneInternalFollow: {
+				score: 7,
+				resultText: "This page has %1$s internal link(s), all nofollowed.",
+				requiresInternalDofollow: false,
+				requiresInternalNofollow: true,
+			},
+			noInternal: {
+				score: 3,
+				resultText: "No internal links appear in this page, consider adding some as appropriate.",
+				requiresInternalDofollow: false,
+				requiresInternalNofollow: false,
+			},
 		};
+
+		this.identifier = "internalLinks";
+		this._config = merge( defaultConfig, config );
 	}
 
-	if ( linkStatistics.internalNofollow === linkStatistics.total ) {
-		return {
-			score: 7,
-			/* Translators: %1$s expands the number of internal links */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s internal link(s), all nofollowed." ),
-				linkStatistics.internalNofollow ),
-		};
+	/**
+	 * Runs the getLinkStatistics module, based on this returns an assessment result with score.
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 * @param {Object} researcher The researcher used for calling research.
+	 * @param {Object} i18n The object used for translations
+	 * @returns {Object} the AssessmentResult.
+	 */
+	getResult( paper, researcher, i18n ) {
+		this.linkStatistics = researcher.getResearch( "getLinkStatistics" );
+		let assessmentResult = new AssessmentResult();
+
+		if ( ! this.isApplicable( paper ) ) {
+			return assessmentResult;
+		}
+
+		if ( ! isEmpty( this.linkStatistics ) ) {
+			const calculatedResult = this.calculateResult();
+			assessmentResult.setScore( calculatedResult.score );
+			assessmentResult.setText( this.translateScore( calculatedResult.resultText, calculatedResult.requiresInternalDofollow,
+				calculatedResult.requiresInternalNofollow, i18n ) );
+		}
+
+		return assessmentResult;
 	}
 
-	if ( linkStatistics.internalNofollow < linkStatistics.internalTotal ) {
-		return {
-			score: 8,
-			/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of internal links */
-			text: i18n.sprintf( i18n.dgettext(
-				"js-text-analysis",
-				"This page has %1$s nofollowed internal link(s) and %2$s normal internal link(s)."
-			),
-			linkStatistics.internalNofollow, linkStatistics.internalDofollow ),
-		};
-	}
-
-	if ( linkStatistics.internalDofollow === linkStatistics.total ) {
-		return {
-			score: 9,
-			/* Translators: %1$s expands to the number of internal links */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s internal link(s)." ), linkStatistics.internalTotal ),
-		};
-	}
-
-	return {};
-};
-
-/**
- * Runs the getLinkStatistics module, based on this returns an assessment result with score.
- *
- * @param {object} paper The paper to use for the assessment.
- * @param {object} researcher The researcher used for calling research.
- * @param {object} i18n The object used for translations
- * @returns {object} the Assessmentresult
- */
-var textHasInternalLinksAssessment = function( paper, researcher, i18n ) {
-	var linkStatistics = researcher.getResearch( "getLinkStatistics" );
-	var assessmentResult = new AssessmentResult();
-	if ( ! isEmpty( linkStatistics ) ) {
-		var linkStatisticsResult = calculateLinkStatisticsResult( linkStatistics, i18n );
-		assessmentResult.setScore( linkStatisticsResult.score );
-		assessmentResult.setText( linkStatisticsResult.text );
-	}
-	return assessmentResult;
-};
-
-module.exports = {
-	identifier: "internalLinks",
-	getResult: textHasInternalLinksAssessment,
-	isApplicable: function( paper ) {
+	/**
+	 * Checks if assessment is applicable to the paper.
+	 *
+	 * @param {Paper} paper The paper to be analysed.
+	 *
+	 * @returns {boolean} Whether the paper has text.
+	 */
+	isApplicable( paper ) {
 		return paper.hasText();
-	},
-};
+	}
+
+	/**
+	 * Returns a score and text based on the linkStatistics object.
+	 *
+	 * @returns {object} resultObject with score and text
+	 */
+	calculateResult() {
+		if ( this.linkStatistics.internalTotal === 0 ) {
+			return this._config.noInternal;
+		}
+
+		if ( this.linkStatistics.internalNofollow === this.linkStatistics.internalTotal ) {
+			return this._config.noneInternalFollow;
+		}
+
+		if ( this.linkStatistics.internalDofollow === this.linkStatistics.internalTotal ) {
+			return this._config.allInternalFollow;
+		}
+
+		return this._config.someInternalFollow;
+	}
+
+	/**
+	 * Translates the score into a specific feedback to the user.
+	 *
+	 * @param {string} resultText The text string from the config to be returned for this number of occurrences of keyphrase
+	 * in the first paragraph.
+	 * @param {boolean} requiresInternalDofollow Whether the translated score needs to include the number of follow-links
+	 * @param {boolean} requiresInternalNofollow Whether the translated score needs to include the number of no-follow-links
+	 * @param {Object} i18n The i18n-object used for parsing translations.
+	 *
+	 * @returns {string} Text feedback.
+	 */
+	translateScore( resultText, requiresInternalDofollow, requiresInternalNofollow, i18n ) {
+		if ( requiresInternalDofollow === false && requiresInternalNofollow === false ) {
+			return i18n.sprintf( i18n.dgettext( "js-text-analysis", resultText ) );
+		}
+
+		if ( requiresInternalDofollow === true && requiresInternalNofollow === false ) {
+			/* Translators: %1$s expands the number of internal links */
+			return i18n.sprintf(
+				i18n.dgettext( "js-text-analysis", resultText ),
+				this.linkStatistics.internalDofollow );
+		}
+		if ( requiresInternalDofollow === false && requiresInternalNofollow === true ) {
+			/* Translators: %1$s expands the number of internal no-follow links */
+			return i18n.sprintf(
+				i18n.dgettext( "js-text-analysis", resultText ),
+				this.linkStatistics.internalNofollow );
+		}
+		/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of internal links */
+		return i18n.sprintf(
+			i18n.dgettext( "js-text-analysis", resultText ),
+			this.linkStatistics.internalNofollow, this.linkStatistics.internalDofollow
+		);
+	}
+}
+
+module.exports = TextHasInternalLinksAssessment;

--- a/src/assessments/seo/internalLinksAssessment.js
+++ b/src/assessments/seo/internalLinksAssessment.js
@@ -56,7 +56,8 @@ class TextHasInternalLinksAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Object} i18n The object used for translations
+	 * @param {Object} i18n The object used for translations.
+	 *
 	 * @returns {Object} The AssessmentResult.
 	 */
 	getResult( paper, researcher, i18n ) {
@@ -66,8 +67,14 @@ class TextHasInternalLinksAssessment extends Assessment {
 		if ( ! isEmpty( this.linkStatistics ) ) {
 			const calculatedResult = this.calculateResult();
 			assessmentResult.setScore( calculatedResult.score );
-			assessmentResult.setText( this.translateScore( calculatedResult.resultText, calculatedResult.requiresInternalDofollow,
-				calculatedResult.requiresInternalNofollow, i18n ) );
+			assessmentResult.setText(
+				this.translateScore(
+					calculatedResult.resultText,
+					calculatedResult.requiresInternalDofollow,
+					calculatedResult.requiresInternalNofollow,
+					i18n
+				)
+			);
 		}
 
 		return assessmentResult;
@@ -126,12 +133,14 @@ class TextHasInternalLinksAssessment extends Assessment {
 				i18n.dgettext( "js-text-analysis", resultText ),
 				this.linkStatistics.internalDofollow );
 		}
+
 		if ( requiresInternalDofollow === false && requiresInternalNofollow === true ) {
 			/* Translators: %1$s expands the number of internal no-follow links */
 			return i18n.sprintf(
 				i18n.dgettext( "js-text-analysis", resultText ),
 				this.linkStatistics.internalNofollow );
 		}
+
 		/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of internal links */
 		return i18n.sprintf(
 			i18n.dgettext( "js-text-analysis", resultText ),

--- a/src/assessments/seo/internalLinksAssessment.js
+++ b/src/assessments/seo/internalLinksAssessment.js
@@ -55,9 +55,9 @@ class TextHasInternalLinksAssessment extends Assessment {
 	 * Runs the getLinkStatistics module, based on this returns an assessment result with score.
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
-	 * @param {Object} researcher The researcher used for calling research.
+	 * @param {Researcher} researcher The researcher used for calling research.
 	 * @param {Object} i18n The object used for translations
-	 * @returns {Object} the AssessmentResult.
+	 * @returns {Object} The AssessmentResult.
 	 */
 	getResult( paper, researcher, i18n ) {
 		this.linkStatistics = researcher.getResearch( "getLinkStatistics" );
@@ -76,7 +76,7 @@ class TextHasInternalLinksAssessment extends Assessment {
 	/**
 	 * Checks if assessment is applicable to the paper.
 	 *
-	 * @param {Paper} paper The paper to be analysed.
+	 * @param {Paper} paper The paper to be analyzed.
 	 *
 	 * @returns {boolean} Whether the paper has text.
 	 */
@@ -87,7 +87,7 @@ class TextHasInternalLinksAssessment extends Assessment {
 	/**
 	 * Returns a score and text based on the linkStatistics object.
 	 *
-	 * @returns {object} resultObject with score and text
+	 * @returns {Object} ResultObject with score and text
 	 */
 	calculateResult() {
 		if ( this.linkStatistics.internalTotal === 0 ) {
@@ -108,10 +108,9 @@ class TextHasInternalLinksAssessment extends Assessment {
 	/**
 	 * Translates the score into a specific feedback to the user.
 	 *
-	 * @param {string} resultText The text string from the config to be returned for this number of occurrences of keyphrase
-	 * in the first paragraph.
-	 * @param {boolean} requiresInternalDofollow Whether the translated score needs to include the number of follow-links
-	 * @param {boolean} requiresInternalNofollow Whether the translated score needs to include the number of no-follow-links
+	 * @param {string} resultText The feedback string.
+	 * @param {boolean} requiresInternalDofollow Whether the translated score needs to include the number of follow-links.
+	 * @param {boolean} requiresInternalNofollow Whether the translated score needs to include the number of no-follow-links.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
 	 *
 	 * @returns {string} Text feedback.

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -59,7 +59,7 @@ class IntroductionHasKeywordAssessment extends Assessment {
 	/**
 	 * Checks if assessment is applicable to the paper.
 	 *
-	 * @param {Paper} paper The paper to be analysed.
+	 * @param {Paper} paper The paper to be analyzed.
 	 *
 	 * @returns {boolean} Whether the paper has both keyword and text.
 	 */
@@ -70,7 +70,7 @@ class IntroductionHasKeywordAssessment extends Assessment {
 	/**
 	 * Returns a result based on the number of occurrences of keyphrase in the first paragraph.
 	 *
-	 * @returns {object} Result object with a score and translation text.
+	 * @returns {Object} ResultObject with a score and translation text.
 	 */
 	calculateResult() {
 		if ( this._firstParagraphMatches >= this._config.parameters.recommendedMinimum ) {
@@ -82,8 +82,7 @@ class IntroductionHasKeywordAssessment extends Assessment {
 	/**
 	 * Translates the score into a specific feedback to the user.
 	 *
-	 * @param {string} resultText The text string from the config to be returned for this number of occurrences of keyphrase
-	 * in the first paragraph.
+	 * @param {string} resultText The feedback string.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
 	 *
 	 * @returns {string} Text feedback.

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -57,11 +57,11 @@ class IntroductionHasKeywordAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks if assessment is applicable to the paper.
+	 * Checks if the paper has both keyword and text.
 	 *
 	 * @param {Paper} paper The paper to be analyzed.
 	 *
-	 * @returns {boolean} Whether the paper has both keyword and text.
+	 * @returns {boolean} Whether the assessment is applicable or not.
 	 */
 	isApplicable( paper ) {
 		return paper.hasKeyword() && paper.hasText();

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -47,10 +47,6 @@ class IntroductionHasKeywordAssessment extends Assessment {
 	getResult( paper, researcher, i18n ) {
 		let assessmentResult = new AssessmentResult();
 
-		if ( ! this.isApplicable( paper ) ) {
-			return assessmentResult;
-		}
-
 		this._firstParagraphMatches = researcher.getResearch( "firstParagraph" );
 		const calculatedResult = this.calculateResult();
 

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -20,14 +20,9 @@ class IntroductionHasKeywordAssessment extends Assessment {
 			parameters: {
 				recommendedMinimum: 1,
 			},
-			good: {
-				score: 9,
-				resultText: "The focus keyword appears in the first paragraph of the copy.",
-			},
-			bad: {
-				score: 3,
-				resultText: "The focus keyword doesn't appear in the first paragraph of the copy. " +
-				"Make sure the topic is clear immediately.",
+			scores: {
+				good: 9,
+				bad: 3,
 			},
 		};
 
@@ -48,10 +43,10 @@ class IntroductionHasKeywordAssessment extends Assessment {
 		let assessmentResult = new AssessmentResult();
 
 		this._firstParagraphMatches = researcher.getResearch( "firstParagraph" );
-		const calculatedResult = this.calculateResult();
+		const calculatedResult = this.calculateResult( i18n );
 
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText( this.translateScore( calculatedResult.resultText, i18n ) );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
@@ -70,25 +65,32 @@ class IntroductionHasKeywordAssessment extends Assessment {
 	/**
 	 * Returns a result based on the number of occurrences of keyphrase in the first paragraph.
 	 *
-	 * @returns {Object} ResultObject with a score and translation text.
+	 * @param {Jed} i18n The object used for translations.
+	 *
+	 * @returns {Object} result object with a score and translation text.
 	 */
-	calculateResult() {
+	calculateResult( i18n ) {
 		if ( this._firstParagraphMatches >= this._config.parameters.recommendedMinimum ) {
-			return this._config.good;
+			return {
+				score: this._config.scores.good,
+				resultText: i18n.sprintf(
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword appears in the first paragraph of the copy."
+					)
+				),
+			};
 		}
-		return this._config.bad;
-	}
 
-	/**
-	 * Translates the score into a specific feedback to the user.
-	 *
-	 * @param {string} resultText The feedback string.
-	 * @param {Object} i18n The i18n-object used for parsing translations.
-	 *
-	 * @returns {string} Text feedback.
-	 */
-	translateScore( resultText, i18n ) {
-		return i18n.sprintf( i18n.dgettext( "js-text-analysis", resultText ) );
+		return {
+			score: this._config.scores.bad,
+			resultText: i18n.sprintf(
+				i18n.dgettext(
+					"js-text-analysis",
+					"The focus keyword doesn't appear in the first paragraph of the copy. Make sure the topic is clear immediately."
+				)
+			),
+		};
 	}
 }
 

--- a/src/assessments/seo/keyphraseLengthAssessment.js
+++ b/src/assessments/seo/keyphraseLengthAssessment.js
@@ -23,29 +23,6 @@ class KeyphraseLengthAssessment extends Assessment {
 				recommendedMaximum: 4,
 				acceptableMaximum: 8,
 			},
-			good: {
-				score: 9,
-				resultText: "Your keyphrase has a nice length.",
-				requiresLengthAndMax: false,
-			},
-			okay: {
-				score: 6,
-				resultText: "Your keyphrase is %1$d words long. That's more than the recommended maximum of %2$d words. " +
-				"You might want to make the keyphrase a bit shorter.",
-				requiresLengthAndMax: true,
-			},
-			bad: {
-				score: 3,
-				resultText: "Your keyphrase is %1$d words long. That's way more than the recommended maximum of %2$d " +
-				"words. Make the keyphrase shorter.",
-				requiresLengthAndMax: true,
-			},
-			veryBad: {
-				score: -999,
-				resultText: "No focus keyword was set for this page. If you do not set a focus keyword, no score can " +
-				"be calculated.",
-				requiresLengthAndMax: false,
-			},
 		};
 
 		this.identifier = "keyphraseLength";
@@ -65,9 +42,9 @@ class KeyphraseLengthAssessment extends Assessment {
 		this._keyphraseLength = researcher.getResearch( "keyphraseLength" );
 		let assessmentResult =  new AssessmentResult();
 
-		const calculatedResult = this.calculateResult();
+		const calculatedResult = this.calculateResult( i18n );
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText( this.translateScore( calculatedResult.resultText, calculatedResult.requiresLengthAndMax, i18n ) );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
@@ -75,45 +52,66 @@ class KeyphraseLengthAssessment extends Assessment {
 	/**
 	 * Calculates the result based on the keyphraseLength research.
 	 *
+	 * @param {Jed} i18n The object used for translations.
+	 *
 	 * @returns {Object} Object with score and text.
 	 */
-	calculateResult() {
+	calculateResult( i18n ) {
 		if ( this._keyphraseLength < this._config.parameters.recommendedMinimum ) {
-			return this._config.veryBad;
+			return {
+				score: -999,
+				resultText: i18n.sprintf(
+					i18n.dgettext(
+						"js-text-analysis",
+						"No focus keyword was set for this page. If you do not set a focus keyword, no score can be calculated."
+					)
+				),
+			};
 		}
 
 		if ( inRange( this._keyphraseLength, this._config.parameters.recommendedMinimum, this._config.parameters.recommendedMaximum + 1 ) ) {
-			return this._config.good;
+			return {
+				score: 9,
+				resultText: i18n.sprintf(
+					i18n.dgettext(
+						"js-text-analysis",
+						"Your keyphrase has a nice length."
+					)
+				),
+			};
 		}
 
 		if ( inRange( this._keyphraseLength, this._config.parameters.recommendedMaximum + 1, this._config.parameters.acceptableMaximum + 1 ) ) {
-			return this._config.okay;
-		}
-
-		return this._config.bad;
-	}
-
-	/**
-	 * Translates the score into a specific feedback to the user.
-	 *
-	 * @param {text} resultText The text of feedback for a given range of values of the assessment result.
-	 * @param {boolean} requiresLengthAndMax Whether feedback needs to include keyphraseLength and recommendedMaximum.
-	 * @param {Object} i18n The i18n-object used for parsing translations.
-	 *
-	 * @returns {string} Text feedback.
-	 */
-	translateScore( resultText, requiresLengthAndMax, i18n ) {
-		if ( requiresLengthAndMax ) {
-			return i18n.sprintf(
-				i18n.dgettext(
-					"js-text-analysis",
+			return {
+				score: 6,
+				resultText: i18n.sprintf(
 					/* Translators: %1$d expands to the number of words in the keyphrase,
 					%2$d expands to the recommended maximum of words in the keyphrase. */
-					resultText
-				), this._keyphraseLength, this._config.parameters.recommendedMaximum
-			);
+					i18n.dgettext(
+						"js-text-analysis",
+						"Your keyphrase is %1$d words long. That's more than the recommended maximum of %2$d words. " +
+							"You might want to make the keyphrase a bit shorter.",
+					),
+					this._keyphraseLength,
+					this._config.parameters.recommendedMaximum
+				),
+			};
 		}
-		return i18n.dgettext( "js-text-analysis", resultText );
+
+		return {
+			score: 3,
+			resultText: i18n.sprintf(
+				/* Translators: %1$d expands to the number of words in the keyphrase,
+				%2$d expands to the recommended maximum of words in the keyphrase. */
+				i18n.dgettext(
+					"js-text-analysis",
+					"Your keyphrase is %1$d words long. That's way more than the recommended maximum of %2$d " +
+					"words. Make the keyphrase shorter."
+				),
+				this._keyphraseLength,
+				this._config.parameters.recommendedMaximum
+			),
+		};
 	}
 }
 

--- a/src/assessments/seo/keyphraseLengthAssessment.js
+++ b/src/assessments/seo/keyphraseLengthAssessment.js
@@ -23,6 +23,12 @@ class KeyphraseLengthAssessment extends Assessment {
 				recommendedMaximum: 4,
 				acceptableMaximum: 8,
 			},
+			scores: {
+				veryBad: -999,
+				bad: 3,
+				okay: 6,
+				good: 9,
+			},
 		};
 
 		this.identifier = "keyphraseLength";
@@ -59,7 +65,7 @@ class KeyphraseLengthAssessment extends Assessment {
 	calculateResult( i18n ) {
 		if ( this._keyphraseLength < this._config.parameters.recommendedMinimum ) {
 			return {
-				score: -999,
+				score: this._config.scores.veryBad,
 				resultText: i18n.sprintf(
 					i18n.dgettext(
 						"js-text-analysis",
@@ -71,7 +77,7 @@ class KeyphraseLengthAssessment extends Assessment {
 
 		if ( inRange( this._keyphraseLength, this._config.parameters.recommendedMinimum, this._config.parameters.recommendedMaximum + 1 ) ) {
 			return {
-				score: 9,
+				score: this._config.scores.good,
 				resultText: i18n.sprintf(
 					i18n.dgettext(
 						"js-text-analysis",
@@ -83,7 +89,7 @@ class KeyphraseLengthAssessment extends Assessment {
 
 		if ( inRange( this._keyphraseLength, this._config.parameters.recommendedMaximum + 1, this._config.parameters.acceptableMaximum + 1 ) ) {
 			return {
-				score: 6,
+				score: this._config.scores.okay,
 				resultText: i18n.sprintf(
 					/* Translators: %1$d expands to the number of words in the keyphrase,
 					%2$d expands to the recommended maximum of words in the keyphrase. */
@@ -99,7 +105,7 @@ class KeyphraseLengthAssessment extends Assessment {
 		}
 
 		return {
-			score: 3,
+			score: this._config.scores.bad,
 			resultText: i18n.sprintf(
 				/* Translators: %1$d expands to the number of words in the keyphrase,
 				%2$d expands to the recommended maximum of words in the keyphrase. */

--- a/src/assessments/seo/keyphraseLengthAssessment.js
+++ b/src/assessments/seo/keyphraseLengthAssessment.js
@@ -90,7 +90,7 @@ class KeyphraseLengthAssessment extends Assessment {
 					i18n.dgettext(
 						"js-text-analysis",
 						"Your keyphrase is %1$d words long. That's more than the recommended maximum of %2$d words. " +
-							"You might want to make the keyphrase a bit shorter.",
+							"You might want to make the keyphrase a bit shorter."
 					),
 					this._keyphraseLength,
 					this._config.parameters.recommendedMaximum

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -16,7 +16,7 @@ class KeywordDensityAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
@@ -44,7 +44,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling the research.
-	 * @param {object} i18n The object used for translations
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
@@ -56,8 +56,9 @@ class KeywordDensityAssessment extends Assessment {
 		this._minRecommendedKeywordCount = recommendedKeywordCount( paper, this._config.minimum, "min" );
 		this._maxRecommendedKeywordCount = recommendedKeywordCount( paper, this._config.maximum, "max" );
 
-		assessmentResult.setScore( this.calculateScore() );
-		assessmentResult.setText( this.translateScore( i18n ) );
+		const calculatedScore = this.calculateResult( i18n );
+		assessmentResult.setScore( calculatedScore.score );
+		assessmentResult.setText( calculatedScore.resultText );
 
 		return assessmentResult;
 	}
@@ -109,101 +110,86 @@ class KeywordDensityAssessment extends Assessment {
 	/**
 	 * Returns the score for the keyword density.
 	 *
-	 * @returns {number} The calculated score.
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} The object with calculated score and resultText.
 	 */
-	calculateScore() {
-		const {
-			wayOverMaximum,
-			overMaximum,
-			correctDensity,
-			underMinimum,
-		} = this._config.scores;
-
-		if ( this.hasNoMatches() || this.hasTooFewMatches() ) {
-			return underMinimum;
+	calculateResult( i18n ) {
+		if ( this.hasNoMatches() ) {
+			return {
+				score: this._config.scores.underMinimum,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the recommended keyword count. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword was found 0 times. That's less than the recommended minimum of %1$d times for a text of this length.",
+						this._keywordCount
+					),
+					this._minRecommendedKeywordCount
+				),
+			};
+		}
+		if ( this.hasTooFewMatches() ) {
+			return {
+				score: this._config.scores.underMinimum,
+				resultText: i18n.sprintf(
+					/* Translators: Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The focus keyword was found %1$d time. That's less than the recommended minimum of %2$d times for a text of this length.",
+						"The focus keyword was found %1$d times. That's less than the recommended minimum of %2$d times for a text of this length.",
+						this._keywordCount
+					),
+					this._keywordCount,
+					this._minRecommendedKeywordCount
+				),
+			};
 		}
 
 		if ( this.hasGoodNumberOfMatches()  ) {
-			return correctDensity;
+			return {
+				score: this._config.scores.correctDensity,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the keyword count. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword was found %1$d times. That's great for a text of this length."
+					),
+					this._keywordCount
+				),
+			};
 		}
 
 		if ( this.hasTooManyMatches() ) {
-			return overMaximum;
+			return {
+				score: this._config.scores.overMaximum,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword was found %1$d times." +
+						" That's more than the recommended maximum of %2$d times for a text of this length."
+					),
+					this._keywordCount,
+					this._maxRecommendedKeywordCount
+				),
+			};
 		}
 
 		// Implicitly returns this if the rounded keyword density is higher than overMaximum.
-		return wayOverMaximum;
-	}
-
-	/**
-	 * Translates the keyword density assessment to a message the user can understand.
-	 *
-	 * @param {object} i18n The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( i18n ) {
-		if( this.hasNoMatches() ) {
-			return i18n.sprintf(
-				/* Translators: %1$d expands to the recommended keyword count. */
-				i18n.dgettext(
-					"js-text-analysis",
-					"The focus keyword was found 0 times. That's less than the recommended minimum of %1$d times for a text of this length.",
-					this._keywordCount
-				),
-				this._minRecommendedKeywordCount
-			);
-		}
-
-		if( this.hasTooFewMatches() ) {
-			return i18n.sprintf(
-				/* Translators: Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
-				i18n.dngettext(
-					"js-text-analysis",
-					"The focus keyword was found %1$d time. That's less than the recommended minimum of %2$d times for a text of this length.",
-					"The focus keyword was found %1$d times. That's less than the recommended minimum of %2$d times for a text of this length.",
-					this._keywordCount
-				),
-				this._keywordCount,
-				this._minRecommendedKeywordCount
-			);
-		}
-
-		if ( this.hasGoodNumberOfMatches() ) {
-			return i18n.sprintf(
-				/* Translators: %1$d expands to the keyword count. */
-				i18n.dgettext(
-					"js-text-analysis",
-					"The focus keyword was found %1$d times. That's great for a text of this length."
-				),
-				this._keywordCount
-			);
-		}
-
-		if ( this.hasTooManyMatches() ) {
-			return i18n.sprintf(
+		return {
+			score: this._config.scores.wayOverMaximum,
+			resultText: i18n.sprintf(
 				/* Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
 				i18n.dgettext(
 					"js-text-analysis",
 					"The focus keyword was found %1$d times." +
-					" That's more than the recommended maximum of %2$d times for a text of this length."
+					" That's way more than the recommended maximum of %2$d times for a text of this length."
 				),
 				this._keywordCount,
 				this._maxRecommendedKeywordCount
-			);
-		}
-
-		// Implicitly returns this if the rounded keyword density is higher than overMaximum.
-		return i18n.sprintf(
-			/* Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
-			i18n.dgettext(
-				"js-text-analysis",
-				"The focus keyword was found %1$d times." +
-				" That's way more than the recommended maximum of %2$d times for a text of this length."
 			),
-			this._keywordCount,
-			this._maxRecommendedKeywordCount
-		);
+		};
 	}
 
 	/**

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -144,48 +144,66 @@ class KeywordDensityAssessment extends Assessment {
 	 */
 	translateScore( i18n ) {
 		if( this.hasNoMatches() ) {
-			return i18n.sprintf( i18n.dgettext(
-				"js-text-analysis",
+			return i18n.sprintf(
 				/* Translators: %1$d expands to the recommended keyword count. */
-				"The focus keyword was found 0 times. That's less than the recommended minimum of %1$d times for a text of this length.",
-				this._keywordCount
-			), this._minRecommendedKeywordCount );
+				i18n.dgettext(
+					"js-text-analysis",
+					"The focus keyword was found 0 times. That's less than the recommended minimum of %1$d times for a text of this length.",
+					this._keywordCount
+				),
+				this._minRecommendedKeywordCount
+			);
 		}
 
 		if( this.hasTooFewMatches() ) {
-			return i18n.sprintf( i18n.dngettext(
-				"js-text-analysis",
+			return i18n.sprintf(
 				/* Translators: Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
-				"The focus keyword was found %1$d time. That's less than the recommended minimum of %2$d times for a text of this length.",
-				"The focus keyword was found %1$d times. That's less than the recommended minimum of %2$d times for a text of this length.",
-				this._keywordCount
-			), this._keywordCount, this._minRecommendedKeywordCount );
+				i18n.dngettext(
+					"js-text-analysis",
+					"The focus keyword was found %1$d time. That's less than the recommended minimum of %2$d times for a text of this length.",
+					"The focus keyword was found %1$d times. That's less than the recommended minimum of %2$d times for a text of this length.",
+					this._keywordCount
+				),
+				this._keywordCount,
+				this._minRecommendedKeywordCount
+			);
 		}
 
 		if ( this.hasGoodNumberOfMatches() ) {
-			return i18n.sprintf( i18n.dgettext(
-				"js-text-analysis",
+			return i18n.sprintf(
 				/* Translators: %1$d expands to the keyword count. */
-				"The focus keyword was found %1$d times. That's great for a text of this length."
-			), this._keywordCount );
+				i18n.dgettext(
+					"js-text-analysis",
+					"The focus keyword was found %1$d times. That's great for a text of this length."
+				),
+				this._keywordCount
+			);
 		}
 
 		if ( this.hasTooManyMatches() ) {
-			return i18n.sprintf( i18n.dgettext(
-				"js-text-analysis",
+			return i18n.sprintf(
 				/* Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
-				"The focus keyword was found %1$d times." +
-				" That's more than the recommended maximum of %2$d times for a text of this length."
-			), this._keywordCount, this._maxRecommendedKeywordCount );
+				i18n.dgettext(
+					"js-text-analysis",
+					"The focus keyword was found %1$d times." +
+					" That's more than the recommended maximum of %2$d times for a text of this length."
+				),
+				this._keywordCount,
+				this._maxRecommendedKeywordCount
+			);
 		}
 
 		// Implicitly returns this if the rounded keyword density is higher than overMaximum.
-		return i18n.sprintf( i18n.dgettext(
-			"js-text-analysis",
+		return i18n.sprintf(
 			/* Translators: %1$d expands to the keyword count. %2$d expands to the recommended keyword count. */
-			"The focus keyword was found %1$d times." +
-			" That's way more than the recommended maximum of %2$d times for a text of this length."
-		), this._keywordCount, this._maxRecommendedKeywordCount );
+			i18n.dgettext(
+				"js-text-analysis",
+				"The focus keyword was found %1$d times." +
+				" That's way more than the recommended maximum of %2$d times for a text of this length."
+			),
+			this._keywordCount,
+			this._maxRecommendedKeywordCount
+		);
 	}
 
 	/**

--- a/src/assessments/seo/metaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/metaDescriptionKeywordAssessment.js
@@ -95,26 +95,36 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 */
 	translateScore( i18n ) {
 		if ( this.hasTooFewMatches() ) {
-			return i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it does not contain the focus keyword." );
+			return i18n.dgettext(
+				"js-text-analysis",
+				"A meta description has been specified, but it does not contain the focus keyword."
+			);
 		}
 
 		if ( this.hasGoodNumberOfMatches() ) {
-			return i18n.sprintf( i18n.dngettext(
-				"js-text-analysis",
+			return i18n.sprintf(
 				/* Translators: %1$d expands to the keyword count in the meta description. */
-				"The meta description contains the focus keyword. That's great.",
-				"The meta description contains the focus keyword %1$d times. That's great.",
-				this._keywordMatches ), this._keywordMatches );
+				i18n.dngettext(
+					"js-text-analysis",
+					"The meta description contains the focus keyword. That's great.",
+					"The meta description contains the focus keyword %1$d times. That's great.",
+					this._keywordMatches
+				),
+				this._keywordMatches
+			);
 		}
 
 		// Implicitly returns this if the number of matches is more than the recommended maximum.
-		return i18n.sprintf( i18n.dgettext(
-			"js-text-analysis",
+		return i18n.sprintf(
 			/* Translators: %1$d expands to the keyword count in the meta description. %2$d expands to the
 			maximum recommended keyword count in the meta description. */
-			"The meta description contains the focus keyword %1$d times, " +
-			"which is over the advised maximum of %2$d times." ),
-			this._keywordMatches, this._config.recommendedMaximumMatches );
+			i18n.dgettext(
+				"js-text-analysis",
+				"The meta description contains the focus keyword %1$d times, which is over the advised maximum of %2$d times."
+			),
+			this._keywordMatches,
+			this._config.recommendedMaximumMatches
+		);
 	}
 
 	/**

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -2,8 +2,6 @@ let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let Assessment = require( "../../assessment.js" );
 let merge = require( "lodash/merge" );
 
-const maximumLength = 320;
-
 /**
  * Assessment for calculating the length of the meta description.
  */
@@ -33,15 +31,6 @@ class MetaDescriptionLengthAssessment extends Assessment {
 
 		this.identifier = "metaDescriptionLength";
 		this._config = merge( defaultConfig, config );
-	}
-
-	/**
-	 * Returns the maximum length.
-	 *
-	 * @returns {number} The maximum length.
-	 */
-	getMaximumLength() {
-		return maximumLength;
 	}
 
 	/**

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -79,8 +79,14 @@ class MetaDescriptionLengthAssessment extends Assessment {
 		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText( this.translateScore( calculatedResult.resultText, calculatedResult.requiresRecommendedMax,
-			calculatedResult.requiresMax, i18n ) );
+		assessmentResult.setText(
+			this.translateScore(
+				calculatedResult.resultText,
+				calculatedResult.requiresRecommendedMax,
+				calculatedResult.requiresMax,
+				i18n
+			)
+		);
 
 		// Max and actual are used in the snippet editor progress bar.
 		assessmentResult.max = this._config.maximumLength;

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -37,6 +37,15 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	}
 
 	/**
+	 * Returns the maximum length. The function is needed for the snippet preview, so don't delete it.
+	 *
+	 * @returns {number} The maximum length.
+	 */
+	getMaximumLength() {
+		return this._config.parameters.maximumLength;
+	}
+
+	/**
 	 * Runs the metaDescriptionLength module, based on this returns an assessment result with score.
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -9,7 +9,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
@@ -57,7 +57,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {object} i18n The object used for translations
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
@@ -99,9 +99,9 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	 * Translates the descriptionLength to a message the user can understand.
 	 *
 	 * @param {string} resultText The text of the result from the configuration.
-	 * @param {boolean} requiresRecommendedMax Whether the translation requires the recommended maximum length of the metadescription
-	 * @param {boolean} requiresMax Whether the translation requires the maximum length of the metadescription
-	 * @param {object} i18n The object used for translations.
+	 * @param {boolean} requiresRecommendedMax Whether the translation requires the recommended maximum length of the metadescription.
+	 * @param {boolean} requiresMax Whether the translation requires the maximum length of the metadescription.
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */

--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -53,7 +53,7 @@ class OutboundLinksAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {object} i18n The object used for translations
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
@@ -106,8 +106,8 @@ class OutboundLinksAssessment extends Assessment {
 	 * Translates the score to a message the user can understand.
 	 *
 	 * @param {string} resultText The text of the result from the configuration.
-	 * @param {boolean} requiresExternalDofollow Whether the translation requires the number of do-follow external links
-	 * @param {boolean} requiresExternalNofollow Whether the translation requires the number of no-follow external links
+	 * @param {boolean} requiresExternalDofollow Whether the translation requires the number of do-follow external links.
+	 * @param {boolean} requiresExternalNofollow Whether the translation requires the number of no-follow external links.
 	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {string} The translated string.
@@ -141,7 +141,7 @@ class OutboundLinksAssessment extends Assessment {
 			i18n.dgettext(
 				"js-text-analysis",
 				/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of outbound links */
-				"This page has %1$s nofollowed outbound link(s) and %2$s normal outbound link(s)."
+				resultText
 			),
 			this.linkStatistics.externalNofollow,
 			this.linkStatistics.externalDofollow

--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -9,7 +9,7 @@ class OutboundLinksAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
@@ -17,12 +17,6 @@ class OutboundLinksAssessment extends Assessment {
 		super();
 
 		let defaultConfig = {
-			noLinks: {
-				score: 3,
-				resultText: "No outbound links appear in this page, consider adding some as appropriate.",
-				requiresExternalDofollow: false,
-				requiresExternalNofollow: false,
-			},
 			scores: {
 				allExternalFollow: 9,
 				someExternalFollow: 8,
@@ -67,7 +61,7 @@ class OutboundLinksAssessment extends Assessment {
 	}
 
 	/**
-	 * Returns a score based on the linkStatistics.
+	 * Returns a score and a result text based on the linkStatistics.
 	 *
 	 * @param {Object} i18n The object used for translations.
 	 *

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -37,9 +37,9 @@ class PageTitleWidthAssessment extends Assessment {
 	}
 
 	/**
-	 * Returns the maximum length.
+	 * Returns the maximum length. The function is needed for the snippet preview, so don't delete it.
 	 *
-	 * @returns {number} The maximum length. The function is needed for the snippet preview, so don't delete it.
+	 * @returns {number} The maximum length.
 	 */
 	getMaximumLength() {
 		return maximumLength;

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -3,6 +3,8 @@ let Assessment = require( "../../assessment.js" );
 let inRange = require( "../../helpers/inRange" ).inRangeEndInclusive;
 let merge = require( "lodash/merge" );
 
+const maximumLength = 600;
+
 /**
  * Represents the assessment that will calculate if the width of the page title is correct.
  */
@@ -20,7 +22,7 @@ class PageTitleWidthAssessment extends Assessment {
 		let defaultConfig = {
 			parameters: {
 				minLength: 400,
-				maxLength: 600,
+				maxLength: maximumLength,
 			},
 			scores: {
 				noTitle: 1,
@@ -32,6 +34,15 @@ class PageTitleWidthAssessment extends Assessment {
 
 		this.identifier = "titleWidth";
 		this._config = merge( defaultConfig, config );
+	}
+
+	/**
+	 * Returns the maximum length.
+	 *
+	 * @returns {number} The maximum length. The function is needed for the snippet preview, so don't delete it.
+	 */
+	getMaximumLength() {
+		return maximumLength;
 	}
 
 	/**

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -2,6 +2,7 @@ const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );
 const merge = require( "lodash/merge" );
 const inRangeStartEndInclusive = require( "../../helpers/inRange.js" ).inRangeStartEndInclusive;
+const getSubheadings = require( "../../stringProcessing/getSubheadings" ).getSubheadings;
 
 /**
  * Represents the assessment that checks if the keyword is present in one of the subheadings.
@@ -18,14 +19,16 @@ class SubHeadingsKeywordAssessment extends Assessment {
 		super();
 
 		const defaultConfig = {
+			parameters: {
+				lowerBoundary: 0.3,
+				upperBoundary: 0.75,
+			},
 			scores: {
 				noMatches: 3,
 				tooFewMatches: 3,
 				goodNumberOfMatches: 9,
 				tooManyMatches: 3,
 			},
-			lowerBoundary: 0.3,
-			upperBoundary: 0.75,
 		};
 
 		this.identifier = "subheadingsKeyword";
@@ -43,16 +46,28 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	 */
 	getResult( paper, researcher, i18n ) {
 		this._subHeadings = researcher.getResearch( "matchKeywordInSubheadings" );
-		this._minNumberOfSubheadings = Math.ceil( this._subHeadings.count * this._config.lowerBoundary );
-		this._maxNumberOfSubheadings = Math.floor( this._subHeadings.count * this._config.upperBoundary );
+		this._minNumberOfSubheadings = Math.ceil( this._subHeadings.count * this._config.parameters.lowerBoundary );
+		this._maxNumberOfSubheadings = Math.floor( this._subHeadings.count * this._config.parameters.upperBoundary );
 
 		let assessmentResult = new AssessmentResult();
-		const score = this.calculateScore();
 
-		assessmentResult.setScore( score );
-		assessmentResult.setText( this.translateScore( this._subHeadings, i18n ) );
+		const calculatedResult = this.calculateResult( i18n );
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
+	}
+
+	/**
+	 * Checks whether the paper has a subheadings.
+	 *
+	 * @param {Paper} paper The paper to use for the check.
+	 *
+	 * @returns {boolean} True when there is at least one subheading.
+	 */
+	hasSubheadings( paper ) {
+		const subheadings = getSubheadings( paper.getText() );
+		return subheadings.length > 0;
 	}
 
 	/**
@@ -63,16 +78,7 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	 * @returns {boolean} True when there is text and a keyword.
 	 */
 	isApplicable( paper ) {
-		return paper.hasText() && paper.hasKeyword();
-	}
-
-	/**
-	 * Checks whether there are no subheadings with the keyword.
-	 *
-	 * @returns {boolean} Returns true if there are no subheadings with the keyword.
-	 */
-	hasNoMatches() {
-		return this._subHeadings.matches === 0;
+		return paper.hasText() && paper.hasKeyword() && this.hasSubheadings( paper );
 	}
 
 	/**
@@ -107,86 +113,76 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	 * the keyword is included in less subheadings than the recommended maximum.
 	 */
 	hasTooManyMatches() {
-		return this._subHeadings.count > 1  && this._subHeadings.matches > this._maxNumberOfSubheadings;
+		return this._subHeadings.count > 1 && this._subHeadings.matches > this._maxNumberOfSubheadings;
 	}
 
 	/**
-	 * Calculates the score for the subheadings.
+	 * Determines the score and the Result text for the subheadings.
 	 *
-	 * @returns {number} The calculated score.
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} The object with the calculated score and the result text.
 	 */
-	calculateScore() {
-		if ( this.hasNoMatches() ) {
-			return this._config.scores.noMatches;
-		}
-
+	calculateResult( i18n ) {
 		if ( this.hasTooFewMatches() ) {
-			return this._config.scores.tooFewMatches;
+			return {
+				score: this._config.scores.tooFewMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the total number of subheadings.
+					%2$d expands to the number of subheadings containing the keyword. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword appears only in %2$d out of %1$d subheadings. " +
+						"Try to use it in more subheadings."
+					),
+					this._subHeadings.count,
+					this._subHeadings.matches
+				),
+			};
 		}
 
 		if ( this.hasGoodNumberOfMatches() ) {
-			return this._config.scores.goodNumberOfMatches;
+			return {
+				score: this._config.scores.goodNumberOfMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the total number of subheadings.
+					%2$d expands to the number of subheadings containing the keyword. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The focus keyword appears in %2$d out of %1$d subheading. That's great.",
+						"The focus keyword appears in %2$d out of %1$d subheadings. That's great.",
+						this._subHeadings.count
+					),
+					this._subHeadings.count,
+					this._subHeadings.matches
+				),
+			};
 		}
 
 		if ( this.hasTooManyMatches() ) {
-			return this._config.scores.tooManyMatches;
+			return {
+				score: this._config.scores.tooManyMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the total number of subheadings.
+					%2$d expands to the number of subheadings containing the keyword. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword appears in %2$d out of %1$d subheadings. That might sound a bit repetitive. " +
+						"Try to change some of those subheadings to make the flow of your text sound more natural."
+					),
+					this._subHeadings.count,
+					this._subHeadings.matches
+				),
+			};
 		}
 
-		return null;
-	}
-
-	/**
-	 * Translates the score to a message the user can understand.
-	 *
-	 * @param {Object} subHeadings  The object with all subHeadings matches.
-	 * @param {Object} i18n         The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( subHeadings, i18n ) {
-		if ( this.hasNoMatches() ) {
-			return i18n.dgettext(
+		return {
+			score: this._config.scores.noMatches,
+			resultText: i18n.dgettext(
 				"js-text-analysis",
 				"You have not used the focus keyword in any subheading (such as an H2)."
-			);
-		}
-
-		if ( this.hasTooFewMatches() ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis",
-					/* Translators: %1$d expands to the total number of subheadings. %2$d expands to the
-					 number of subheadings containing the keyword. */
-					"The focus keyword appears only in %2$d out of %1$d subheadings. " +
-					"Try to use it in more subheadings." ),
-					subHeadings.count, subHeadings.matches
-			);
-		}
-
-		if ( this.hasGoodNumberOfMatches() ) {
-			return i18n.sprintf(
-				i18n.dngettext( "js-text-analysis",
-					/* Translators: %1$d expands to the total number of subheadings. %2$d expands to the
-					 number of subheadings containing the keyword. */
-					"The focus keyword appears in %2$d out of %1$d subheading. " +
-					"That's great.", "The focus keyword appears in %2$d out of %1$d subheadings. " +
-					"That's great.", subHeadings.count ),
-				subHeadings.count, subHeadings.matches
-			);
-		}
-
-		if ( this.hasTooManyMatches() ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis",
-					/* Translators: %1$d expands to the total number of subheadings. %2$d expands to the
-					 number of subheadings containing the keyword. */
-					"The focus keyword appears in %2$d out of %1$d subheadings. " +
-					"That might sound a bit repetitive. " +
-					"Try to change some of those subheadings to make the flow of your text sound more natural." ),
-				subHeadings.count, subHeadings.matches
-			);
-		}
-
-		return "";
+			),
+		};
 	}
 }
 

--- a/src/assessments/seo/textCompetingLinksAssessment.js
+++ b/src/assessments/seo/textCompetingLinksAssessment.js
@@ -26,10 +26,8 @@ class TextCompetingLinksAssessment extends Assessment {
 			parameters: {
 				recommendedMaximum: 0,
 			},
-			bad: {
-				score: 2,
-				resultText: "You're linking to another page with the focus keyword you want this page to rank for. " +
-				"Consider changing that if you truly want this page to rank.",
+			scores: {
+				bad: 2,
 			},
 		};
 
@@ -51,13 +49,14 @@ class TextCompetingLinksAssessment extends Assessment {
 
 		this.linkCount = researcher.getResearch( "getLinkStatistics" );
 
-		const calculatedResult = this.calculateResult();
+		const calculatedResult = this.calculateResult( i18n );
+
 		if ( isUndefined( calculatedResult ) ) {
 			return assessmentResult;
 		}
 
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText( this.translateScore( calculatedResult.resultText, i18n ) );
+		assessmentResult.setText( calculatedResult.resultText );
 		assessmentResult.setHasMarks( true );
 		assessmentResult.setMarker( this.getMarks() );
 
@@ -78,24 +77,23 @@ class TextCompetingLinksAssessment extends Assessment {
 	/**
 	 * Returns a result based on the number of links.
 	 *
-	 * @returns {Object} ResultObject with score and text
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} ResultObject with score and text.
 	 */
-	calculateResult() {
+	calculateResult( i18n ) {
 		if ( this.linkCount.keyword.totalKeyword > this._config.parameters.recommendedMaximum ) {
-			return this._config.bad;
+			return {
+				score: this._config.scores.bad,
+				resultText: i18n.sprintf(
+					i18n.dgettext(
+						"js-text-analysis",
+						"You're linking to another page with the focus keyword you want this page to rank for. " +
+						"Consider changing that if you truly want this page to rank."
+					)
+				),
+			};
 		}
-	}
-
-	/**
-	 * Translates the score into a specific feedback to the user.
-	 *
-	 * @param {string} resultText The feedback string.
-	 * @param {Object} i18n The i18n-object used for parsing translations.
-	 *
-	 * @returns {string} Text feedback.
-	 */
-	translateScore( resultText, i18n ) {
-		return i18n.sprintf( i18n.dgettext( "js-text-analysis", resultText ) );
 	}
 
 	/**

--- a/src/assessments/seo/textCompetingLinksAssessment.js
+++ b/src/assessments/seo/textCompetingLinksAssessment.js
@@ -48,10 +48,6 @@ class TextCompetingLinksAssessment extends Assessment {
 	getResult( paper, researcher, i18n ) {
 		let assessmentResult = new AssessmentResult();
 
-		if ( ! this.isApplicable( paper ) ) {
-			return assessmentResult;
-		}
-
 		this.linkCount = researcher.getResearch( "getLinkStatistics" );
 
 		const calculatedResult = this.calculateResult();

--- a/src/assessments/seo/textCompetingLinksAssessment.js
+++ b/src/assessments/seo/textCompetingLinksAssessment.js
@@ -1,73 +1,120 @@
-var AssessmentResult = require( "../../values/AssessmentResult.js" );
+const Assessment = require( "../../assessment.js" );
+const AssessmentResult = require( "../../values/AssessmentResult.js" );
 
-var Mark = require( "../../values/Mark.js" );
-var addMark = require( "../../markers/addMark.js" );
+const Mark = require( "../../values/Mark.js" );
+const addMark = require( "../../markers/addMark.js" );
 
-var map = require( "lodash/map" );
+const map = require( "lodash/map" );
+const merge = require( "lodash/merge" );
+const isUndefined = require( "lodash/isUndefined" );
 
 /**
- * Returns a score and text based on the number of links.
- *
- * @param {object} linkStatistics The object with all linkstatistics.
- * @param {object} i18n The object used for translations
- * @returns {object} resultObject with score and text
+ * Assessment to check whether the keyphrase is encountered in the first paragraph of the article.
  */
-var calculateLinkCountResult = function( linkStatistics, i18n ) {
-	if ( linkStatistics.keyword.totalKeyword > 0 ) {
-		return {
-			score: 2,
-			hasMarks: true,
-			text: i18n.dgettext( "js-text-analysis", "You're linking to another page with the focus keyword you want this page to rank for. " +
-				"Consider changing that if you truly want this page to rank." ),
+class TextCompetingLinksAssessment extends Assessment {
+	/**
+	 * Sets the identifier and the config.
+	 *
+	 * @param {Object} config The configuration to use.
+	 *
+	 * @returns {void}
+	 */
+	constructor( config = {} ) {
+		super();
+
+		let defaultConfig = {
+			parameters: {
+				recommendedMaximum: 0,
+			},
+			bad: {
+				score: 2,
+				resultText: "You're linking to another page with the focus keyword you want this page to rank for. " +
+				"Consider changing that if you truly want this page to rank.",
+			},
 		};
+
+		this.identifier = "textCompetingLinks";
+		this._config = merge( defaultConfig, config );
 	}
-	return {};
-};
 
-/**
- * Runs the linkCount module, based on this returns an assessment result with score.
- *
- * @param {object} paper The paper to use for the assessment.
- * @param {object} researcher The researcher used for calling research.
- * @param {object} i18n The object used for translations
- * @returns {object} the Assessmentresult
- */
-var textHasCompetingLinksAssessment = function( paper, researcher, i18n ) {
-	var linkCount = researcher.getResearch( "getLinkStatistics" );
+	/**
+	 * Runs the linkCount module, based on this returns an assessment result with score.
+	 *
+	 * @param {object} paper The paper to use for the assessment.
+	 * @param {object} researcher The researcher used for calling research.
+	 * @param {object} i18n The object used for translations
+	 * @returns {object} the AssessmentResult
+	 */
+	getResult( paper, researcher, i18n ) {
+		let assessmentResult = new AssessmentResult();
 
-	var linkCountResult = calculateLinkCountResult( linkCount, i18n );
-	var assessmentResult = new AssessmentResult();
+		if ( ! this.isApplicable( paper ) ) {
+			return assessmentResult;
+		}
 
-	assessmentResult.setScore( linkCountResult.score );
-	assessmentResult.setText( linkCountResult.text );
-	assessmentResult.setHasMarks( linkCountResult.hasMarks );
+		this.linkCount = researcher.getResearch( "getLinkStatistics" );
 
-	return assessmentResult;
-};
+		const calculatedResult = this.calculateResult();
+		if ( isUndefined( calculatedResult ) ) {
+			return assessmentResult;
+		}
 
-/**
- * Mark the anchors.
- *
- * @param {Paper} paper The paper to use for the marking.
- * @param {Researcher} researcher The researcher to use.
- * @returns {Array} Array with all the marked anchors.
- */
-var competingLinkMarker = function( paper, researcher ) {
-	var competingLinks = researcher.getResearch( "getLinkStatistics" );
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( this.translateScore( calculatedResult.resultText, i18n ) );
+		assessmentResult.setHasMarks( true );
+		assessmentResult.setMarker( this.getMarks() );
 
-	return map( competingLinks.keyword.matchedAnchors, function( matchedAnchor ) {
-		return new Mark( {
-			original: matchedAnchor,
-			marked: addMark( matchedAnchor ),
-		} );
-	} );
-};
+		return assessmentResult;
+	}
 
-module.exports = {
-	identifier: "textCompetingLinks",
-	getResult: textHasCompetingLinksAssessment,
-	isApplicable: function( paper ) {
+	/**
+	 * Determines if the assessment is applicable to the paper.
+	 *
+	 * @param {Paper} paper The paper to check
+	 *
+	 * @returns {boolean} Whether the paper has text and a keyword
+	 */
+	isApplicable( paper ) {
 		return paper.hasText() && paper.hasKeyword();
-	},
-	getMarks: competingLinkMarker,
-};
+	}
+
+	/**
+	 * Returns a result based on the number of links.
+	 *
+	 * @returns {object} resultObject with score and text
+	 */
+	calculateResult() {
+		if ( this.linkCount.keyword.totalKeyword > this._config.parameters.recommendedMaximum ) {
+			return this._config.bad;
+		}
+	}
+
+	/**
+	 * Translates the score into a specific feedback to the user.
+	 *
+	 * @param {string} resultText The text string from the config to be returned for this number of occurrences of keyphrase
+	 * in the first paragraph.
+	 * @param {Object} i18n The i18n-object used for parsing translations.
+	 *
+	 * @returns {string} Text feedback.
+	 */
+	translateScore( resultText, i18n ) {
+		return i18n.sprintf( i18n.dgettext( "js-text-analysis", resultText ) );
+	}
+
+	/**
+	 * Mark the anchors.
+	 *
+	 * @returns {Array} Array with all the marked anchors.
+	 */
+	getMarks() {
+		return map( this.linkCount.keyword.matchedAnchors, function( matchedAnchor ) {
+			return new Mark( {
+				original: matchedAnchor,
+				marked: addMark( matchedAnchor ),
+			} );
+		} );
+	}
+}
+
+module.exports = TextCompetingLinksAssessment;

--- a/src/assessments/seo/textCompetingLinksAssessment.js
+++ b/src/assessments/seo/textCompetingLinksAssessment.js
@@ -9,7 +9,7 @@ const merge = require( "lodash/merge" );
 const isUndefined = require( "lodash/isUndefined" );
 
 /**
- * Assessment to check whether the keyphrase is encountered in the first paragraph of the article.
+ * Assessment to check whether you're linking to a different page with the focus keyword from this page.
  */
 class TextCompetingLinksAssessment extends Assessment {
 	/**
@@ -40,10 +40,11 @@ class TextCompetingLinksAssessment extends Assessment {
 	/**
 	 * Runs the linkCount module, based on this returns an assessment result with score.
 	 *
-	 * @param {object} paper The paper to use for the assessment.
-	 * @param {object} researcher The researcher used for calling research.
-	 * @param {object} i18n The object used for translations
-	 * @returns {object} the AssessmentResult
+	 * @param {Object} paper The paper to use for the assessment.
+	 * @param {Object} researcher The researcher used for calling research.
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} The AssessmentResult.
 	 */
 	getResult( paper, researcher, i18n ) {
 		let assessmentResult = new AssessmentResult();
@@ -77,7 +78,7 @@ class TextCompetingLinksAssessment extends Assessment {
 	/**
 	 * Returns a result based on the number of links.
 	 *
-	 * @returns {object} resultObject with score and text
+	 * @returns {Object} ResultObject with score and text
 	 */
 	calculateResult() {
 		if ( this.linkCount.keyword.totalKeyword > this._config.parameters.recommendedMaximum ) {
@@ -88,8 +89,7 @@ class TextCompetingLinksAssessment extends Assessment {
 	/**
 	 * Translates the score into a specific feedback to the user.
 	 *
-	 * @param {string} resultText The text string from the config to be returned for this number of occurrences of keyphrase
-	 * in the first paragraph.
+	 * @param {string} resultText The feedback string.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
 	 *
 	 * @returns {string} Text feedback.

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -9,7 +9,7 @@ class TextImagesAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
@@ -55,7 +55,7 @@ class TextImagesAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The Paper object to assess.
 	 * @param {Researcher} researcher The Researcher object containing all available researches.
-	 * @param {object} i18n The locale object.
+	 * @param {Object} i18n The locale object.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -24,26 +24,6 @@ class TextImagesAssessment extends Assessment {
 				withAlt: 6,
 				noAlt: 6,
 			},
-			noImages: {
-				score: 3,
-				resultText: "No images appear in this page, consider adding some as appropriate.",
-			},
-			withAltKeyword: {
-				score: 9,
-				resultText: "The images on this page contain alt attributes with the focus keyword.",
-			},
-			withAltNonKeyword: {
-				score: 6,
-				resultText: "The images on this page do not have alt attributes containing the focus keyword.",
-			},
-			withAlt: {
-				score: 6,
-				resultText: "The images on this page contain alt attributes.",
-			},
-			noAlt: {
-				score: 6,
-				resultText: "The images on this page are missing alt attributes.",
-			},
 		};
 
 		this.identifier = "textImages";
@@ -55,7 +35,7 @@ class TextImagesAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The Paper object to assess.
 	 * @param {Researcher} researcher The Researcher object containing all available researches.
-	 * @param {Object} i18n The locale object.
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
@@ -64,9 +44,9 @@ class TextImagesAssessment extends Assessment {
 		this.imageCount = researcher.getResearch( "imageCount" );
 		this.altProperties = researcher.getResearch( "altTagCount" );
 
-		const calculatedResult = this.calculateResult();
+		const calculatedResult = this.calculateResult( i18n );
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText( this.translateScore( calculatedResult.resultText, i18n ) );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
@@ -85,41 +65,60 @@ class TextImagesAssessment extends Assessment {
 	/**
 	 * Calculate the result based on the current image count and current image alt-tag count.
 	 *
+	 * @param {Object} i18n The object used for translations.
+	 *
 	 * @returns {Object} The calculated result.
 	 */
-	calculateResult() {
+	calculateResult( i18n ) {
 		if ( this.imageCount === 0 ) {
-			return this._config.noImages;
+			return {
+				score: this._config.scores.noImages,
+				resultText: i18n.dgettext(
+					"js-text-analysis",
+					"No images appear in this page, consider adding some as appropriate."
+				),
+			};
 		}
 
 		// Has alt-tag and keywords
 		if ( this.altProperties.withAltKeyword > 0 ) {
-			return this._config.withAltKeyword;
+			return {
+				score: this._config.scores.withAltKeyword,
+				resultText: i18n.dgettext(
+					"js-text-analysis",
+					"The images on this page contain alt attributes with the focus keyword."
+				),
+			};
 		}
 
 		// Has alt-tag, but no keywords and it's not okay
 		if ( this.altProperties.withAltNonKeyword > 0 ) {
-			return this._config.withAltNonKeyword;
+			return {
+				score: this._config.scores.withAltNonKeyword,
+				resultText: i18n.dgettext(
+					"js-text-analysis",
+					"The images on this page do not have alt attributes containing the focus keyword."
+				),
+			};
 		}
 
 		// Has alt-tag, but no keyword is set
 		if ( this.altProperties.withAlt > 0 ) {
-			return this._config.withAlt;
+			return {
+				score: this._config.scores.withAlt,
+				resultText: i18n.dgettext(
+					"js-text-analysis",
+					"The images on this page contain alt attributes."
+				),
+			};
 		}
-
-		return this._config.noAlt;
-	}
-
-	/**
-	 * Translates the score to a message the user can understand.
-	 *
-	 * @param {string} resultText The feedback to give to the user.
-	 * @param {Object} i18n The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( resultText, i18n ) {
-		return i18n.dgettext( "js-text-analysis", resultText );
+		return {
+			score: this._config.scores.noAlt,
+			resultText: i18n.dgettext(
+				"js-text-analysis",
+				"The images on this page are missing alt attributes."
+			),
+		};
 	}
 }
 

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -24,6 +24,26 @@ class TextImagesAssessment extends Assessment {
 				withAlt: 6,
 				noAlt: 6,
 			},
+			noImages: {
+				score: 3,
+				resultText: "No images appear in this page, consider adding some as appropriate.",
+			},
+			withAltKeyword: {
+				score: 9,
+				resultText: "The images on this page contain alt attributes with the focus keyword.",
+			},
+			withAltNonKeyword: {
+				score: 6,
+				resultText: "The images on this page do not have alt attributes containing the focus keyword.",
+			},
+			withAlt: {
+				score: 6,
+				resultText: "The images on this page contain alt attributes.",
+			},
+			noAlt: {
+				score: 6,
+				resultText: "The images on this page are missing alt attributes.",
+			},
 		};
 
 		this.identifier = "textImages";
@@ -41,11 +61,12 @@ class TextImagesAssessment extends Assessment {
 	 */
 	getResult( paper, researcher, i18n ) {
 		let assessmentResult = new AssessmentResult();
-		let imageCount = researcher.getResearch( "imageCount" );
-		let altProperties = researcher.getResearch( "altTagCount" );
+		this.imageCount = researcher.getResearch( "imageCount" );
+		this.altProperties = researcher.getResearch( "altTagCount" );
 
-		assessmentResult.setScore( this.calculateScore( imageCount, altProperties ) );
-		assessmentResult.setText( this.translateScore( imageCount, altProperties, i18n ) );
+		const calculatedResult = this.calculateResult();
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( this.translateScore( calculatedResult.resultText, i18n ) );
 
 		return assessmentResult;
 	}
@@ -62,76 +83,43 @@ class TextImagesAssessment extends Assessment {
 	}
 
 	/**
-	 * Calculate the score based on the current image count and current image alt-tag count.
+	 * Calculate the result based on the current image count and current image alt-tag count.
 	 *
-	 * @param {number} imageCount The amount of images to be checked against.
-	 * @param {object} altProperties An object containing the various alt-tags.
-	 *
-	 * @returns {number} The calculated score.
+	 * @returns {Object} The calculated result.
 	 */
-	calculateScore( imageCount, altProperties ) {
-		if ( imageCount === 0 ) {
-			return this._config.scores.noImages;
+	calculateResult() {
+		if ( this.imageCount === 0 ) {
+			return this._config.noImages;
 		}
 
 		// Has alt-tag and keywords
-		if ( altProperties.withAltKeyword > 0 ) {
-			return this._config.scores.withAltKeyword;
+		if ( this.altProperties.withAltKeyword > 0 ) {
+			return this._config.withAltKeyword;
 		}
 
 		// Has alt-tag, but no keywords and it's not okay
-		if ( altProperties.withAltNonKeyword > 0 ) {
-			return this._config.scores.withAltNonKeyword;
+		if ( this.altProperties.withAltNonKeyword > 0 ) {
+			return this._config.withAltNonKeyword;
 		}
 
 		// Has alt-tag, but no keyword is set
-		if ( altProperties.withAlt > 0 ) {
-			return this._config.scores.withAlt;
+		if ( this.altProperties.withAlt > 0 ) {
+			return this._config.withAlt;
 		}
 
-		// Has no alt-tag
-		if ( altProperties.noAlt > 0 ) {
-			return this._config.scores.noAlt;
-		}
-
-		return null;
+		return this._config.noAlt;
 	}
 
 	/**
 	 * Translates the score to a message the user can understand.
 	 *
-	 * @param {number} imageCount The amount of images to be checked against.
-	 * @param {object} altProperties An object containing the various alt-tags.
-	 * @param {object} i18n The object used for translations.
+	 * @param {string} resultText The feedback to give to the user.
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( imageCount, altProperties, i18n ) {
-		if ( imageCount === 0 ) {
-			return i18n.dgettext( "js-text-analysis", "No images appear in this page, consider adding some as appropriate." );
-		}
-
-		// Has alt-tag and keywords
-		if ( altProperties.withAltKeyword > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes with the focus keyword." );
-		}
-
-		// Has alt-tag, but no keywords and it's not okay
-		if ( altProperties.withAltNonKeyword > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page do not have alt attributes containing the focus keyword." );
-		}
-
-		// Has alt-tag, but no keyword is set
-		if ( altProperties.withAlt > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes." );
-		}
-
-		// Has no alt-tag
-		if ( altProperties.noAlt > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page are missing alt attributes." );
-		}
-
-		return "";
+	translateScore( resultText, i18n ) {
+		return i18n.dgettext( "js-text-analysis", resultText );
 	}
 }
 

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -79,7 +79,12 @@ class TextLengthAssessment extends Assessment {
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText(
-			this.translateScore( calculatedResult.resultText, calculatedResult.resultTextPlural, i18n ) );
+			this.translateScore(
+				calculatedResult.resultText,
+				calculatedResult.resultTextPlural,
+				i18n
+			)
+		);
 
 		return assessmentResult;
 	}

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -10,7 +10,7 @@ class TextLengthAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
@@ -68,7 +68,7 @@ class TextLengthAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The Paper object to assess.
 	 * @param {Researcher} researcher The Researcher object containing all available researches.
-	 * @param {object} i18n The locale object.
+	 * @param {Object} i18n The locale object.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
@@ -112,9 +112,9 @@ class TextLengthAssessment extends Assessment {
 	/**
 	 * Translates the score to a message the user can understand.
 	 *
-	 * @param {string} resultText The text of the feedback from the configuration
-	 * @param {string} resultTextPlural The text of the feedback from the configuration (for the plural)
-	 * @param {object} i18n The object used for translations.
+	 * @param {string} resultText The text of the feedback from the configuration.
+	 * @param {string} resultTextPlural The text of the feedback from the configuration (for the plural).
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -24,38 +24,12 @@ class TextLengthAssessment extends Assessment {
 				belowMinimum: 200,
 				veryFarBelowMinimum: 100,
 			},
-			good: {
-				score: 9,
-				resultText: "The text contains %1$d word. This is more than or equal to the recommended minimum of %2$d words.",
-				resultTextPlural: "The text contains %1$d words. This is more than or equal to the recommended minimum of %2$d words.",
-			},
-			okay: {
-				score: 6,
-				resultText: "The text contains %1$d word. This is slightly below the recommended minimum of %2$d words. " +
-				"Add a bit more copy.",
-				resultTextPlural: "The text contains %1$d words. This is slightly below the recommended minimum of %2$d words. " +
-				"Add a bit more copy.",
-			},
-			bad: {
-				score: 3,
-				resultText: "The text contains %1$d word. This is below the recommended minimum of %2$d words. " +
-				"Add more content that is relevant for the topic.",
-				resultTextPlural: "The text contains %1$d words. This is below the recommended minimum of %2$d words. " +
-				"Add more content that is relevant for the topic.",
-			},
-			veryBad: {
-				score: -10,
-				resultText: "The text contains %1$d word. This is far below the recommended minimum of %2$d words. " +
-				"Add more content that is relevant for the topic.",
-				resultTextPlural: "The text contains %1$d words. This is far below the recommended minimum of %2$d words. " +
-				"Add more content that is relevant for the topic.",
-			},
-			veryVeryBad: {
-				score: -20,
-				resultText: "The text contains %1$d word. This is far below the recommended minimum of %2$d words. " +
-				"Add more content that is relevant for the topic.",
-				resultTextPlural: "The text contains %1$d words. This is far below the recommended minimum of %2$d words. " +
-				"Add more content that is relevant for the topic.",
+			scores: {
+				good: 9,
+				okay: 6,
+				bad: 3,
+				veryBad: -10,
+				veryVeryBad: -20,
 			},
 		};
 
@@ -68,23 +42,17 @@ class TextLengthAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The Paper object to assess.
 	 * @param {Researcher} researcher The Researcher object containing all available researches.
-	 * @param {Object} i18n The locale object.
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher, i18n ) {
 		this.wordCount = researcher.getResearch( "wordCountInText" );
 		let assessmentResult = new AssessmentResult();
-		const calculatedResult = this.calculateResult();
 
+		const calculatedResult = this.calculateResult( i18n );
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText(
-			this.translateScore(
-				calculatedResult.resultText,
-				calculatedResult.resultTextPlural,
-				i18n
-			)
-		);
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
@@ -92,49 +60,99 @@ class TextLengthAssessment extends Assessment {
 	/**
 	 * Calculates the result based on the current word count.
 	 *
-	 * @returns {Object} The result.
+	 * 	@param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} The result object with score and resultText.
 	 */
-	calculateResult() {
+	calculateResult( i18n ) {
 		if ( this.wordCount >= this._config.parameters.recommendedMinimum ) {
-			return this._config.good;
+			return {
+				score: this._config.scores.good,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of words in the text, %2$s expands to the recommended minimum of words. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The text contains %1$d word. This is more than or equal to the recommended minimum of %2$d words.",
+						"The text contains %1$d words. This is more than or equal to the recommended minimum of %2$d words.",
+						this.wordCount
+					),
+					this.wordCount,
+					this._config.parameters.recommendedMinimum
+				),
+			};
 		}
 
 		if ( inRange( this.wordCount, this._config.parameters.slightlyBelowMinimum, this._config.parameters.recommendedMinimum ) ) {
-			return this._config.okay;
+			return {
+				score: this._config.scores.okay,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of words in the text, %2$s expands to the recommended minimum of words. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The text contains %1$d word. This is slightly below the recommended minimum of %2$d words. Add a bit more copy.",
+						"The text contains %1$d words. This is slightly below the recommended minimum of %2$d words. Add a bit more copy.",
+						this.wordCount
+					),
+					this.wordCount,
+					this._config.parameters.recommendedMinimum
+				),
+			};
 		}
 
 		if ( inRange( this.wordCount, this._config.parameters.belowMinimum, this._config.parameters.slightlyBelowMinimum ) ) {
-			return this._config.bad;
+			return {
+				score: this._config.scores.bad,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of words in the text, %2$s expands to the recommended minimum of words. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The text contains %1$d word. This is below the recommended minimum of %2$d words. " +
+							"Add more content that is relevant for the topic.",
+						"The text contains %1$d words. This is below the recommended minimum of %2$d words. " +
+							"Add more content that is relevant for the topic.",
+						this.wordCount
+					),
+					this.wordCount,
+					this._config.parameters.recommendedMinimum
+				),
+			};
 		}
 
 		if ( inRange( this.wordCount, this._config.parameters.veryFarBelowMinimum, this._config.parameters.belowMinimum ) ) {
-			return this._config.veryBad;
+			return {
+				score: this._config.scores.veryBad,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of words in the text, %2$s expands to the recommended minimum of words. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The text contains %1$d word. This is far below the recommended minimum of %2$d words. " +
+							"Add more content that is relevant for the topic.",
+						"The text contains %1$d words. This is far below the recommended minimum of %2$d words. " +
+							"Add more content that is relevant for the topic.",
+						this.wordCount
+					),
+					this.wordCount,
+					this._config.parameters.recommendedMinimum
+				),
+			};
 		}
 
-		return this._config.veryVeryBad;
-	}
-
-	/**
-	 * Translates the score to a message the user can understand.
-	 *
-	 * @param {string} resultText The text of the feedback from the configuration.
-	 * @param {string} resultTextPlural The text of the feedback from the configuration (for the plural).
-	 * @param {Object} i18n The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( resultText, resultTextPlural, i18n ) {
-		return i18n.sprintf(
-			i18n.dngettext(
-				"js-text-analysis",
+		return {
+			score: this._config.scores.veryVeryBad,
+			resultText: i18n.sprintf(
 				/* Translators: %1$d expands to the number of words in the text, %2$s expands to the recommended minimum of words. */
-				resultText,
-				resultTextPlural,
-				this.wordCount
+				i18n.dngettext(
+					"js-text-analysis",
+					"The text contains %1$d word. This is far below the recommended minimum of %2$d words. " +
+						"Add more content that is relevant for the topic.",
+					"The text contains %1$d words. This is far below the recommended minimum of %2$d words. " +
+						"Add more content that is relevant for the topic.",
+					this.wordCount
+				),
+				this.wordCount,
+				this._config.parameters.recommendedMinimum
 			),
-			this.wordCount,
-			this._config.parameters.recommendedMinimum
-		);
+		};
 	}
 }
 

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -18,17 +18,44 @@ class TextLengthAssessment extends Assessment {
 		super();
 
 		let defaultConfig = {
-			recommendedMinimum: 300,
-			slightlyBelowMinimum: 250,
-			belowMinimum: 200,
-			veryFarBelowMinimum: 100,
-
-			scores: {
-				recommendedMinimum: 9,
-				slightlyBelowMinimum: 6,
-				belowMinimum: 3,
-				farBelowMinimum: -10,
-				veryFarBelowMinimum: -20,
+			parameters: {
+				recommendedMinimum: 300,
+				slightlyBelowMinimum: 250,
+				belowMinimum: 200,
+				veryFarBelowMinimum: 100,
+			},
+			good: {
+				score: 9,
+				resultText: "The text contains %1$d word. This is more than or equal to the recommended minimum of %2$d words.",
+				resultTextPlural: "The text contains %1$d words. This is more than or equal to the recommended minimum of %2$d words.",
+			},
+			okay: {
+				score: 6,
+				resultText: "The text contains %1$d word. This is slightly below the recommended minimum of %2$d words. " +
+				"Add a bit more copy.",
+				resultTextPlural: "The text contains %1$d words. This is slightly below the recommended minimum of %2$d words. " +
+				"Add a bit more copy.",
+			},
+			bad: {
+				score: 3,
+				resultText: "The text contains %1$d word. This is below the recommended minimum of %2$d words. " +
+				"Add more content that is relevant for the topic.",
+				resultTextPlural: "The text contains %1$d words. This is below the recommended minimum of %2$d words. " +
+				"Add more content that is relevant for the topic.",
+			},
+			veryBad: {
+				score: -10,
+				resultText: "The text contains %1$d word. This is far below the recommended minimum of %2$d words. " +
+				"Add more content that is relevant for the topic.",
+				resultTextPlural: "The text contains %1$d words. This is far below the recommended minimum of %2$d words. " +
+				"Add more content that is relevant for the topic.",
+			},
+			veryVeryBad: {
+				score: -20,
+				resultText: "The text contains %1$d word. This is far below the recommended minimum of %2$d words. " +
+				"Add more content that is relevant for the topic.",
+				resultTextPlural: "The text contains %1$d words. This is far below the recommended minimum of %2$d words. " +
+				"Add more content that is relevant for the topic.",
 			},
 		};
 
@@ -46,122 +73,63 @@ class TextLengthAssessment extends Assessment {
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher, i18n ) {
-		let wordCount = researcher.getResearch( "wordCountInText" );
+		this.wordCount = researcher.getResearch( "wordCountInText" );
 		let assessmentResult = new AssessmentResult();
+		const calculatedResult = this.calculateResult();
 
-		assessmentResult.setScore( this.calculateScore( wordCount ) );
+		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText(
-			i18n.sprintf( this.translateScore( assessmentResult.getScore(), wordCount, i18n ), wordCount, this._config.recommendedMinimum ) );
+			this.translateScore( calculatedResult.resultText, calculatedResult.resultTextPlural, i18n ) );
 
 		return assessmentResult;
 	}
 
 	/**
-	 * Calculates the score based on the current word count.
+	 * Calculates the result based on the current word count.
 	 *
-	 * @param {number} wordCount The amount of words to be checked against.
-
-	 * @returns {number|null} The score.
+	 * @returns {Object} The result.
 	 */
-	calculateScore( wordCount ) {
-		if ( wordCount >= this._config.recommendedMinimum ) {
-			return this._config.scores.recommendedMinimum;
+	calculateResult() {
+		if ( this.wordCount >= this._config.parameters.recommendedMinimum ) {
+			return this._config.good;
 		}
 
-		if ( inRange( wordCount, this._config.slightlyBelowMinimum, this._config.recommendedMinimum ) ) {
-			return this._config.scores.slightlyBelowMinimum;
+		if ( inRange( this.wordCount, this._config.parameters.slightlyBelowMinimum, this._config.parameters.recommendedMinimum ) ) {
+			return this._config.okay;
 		}
 
-		if ( inRange( wordCount, this._config.belowMinimum, this._config.slightlyBelowMinimum ) ) {
-			return this._config.scores.belowMinimum;
+		if ( inRange( this.wordCount, this._config.parameters.belowMinimum, this._config.parameters.slightlyBelowMinimum ) ) {
+			return this._config.bad;
 		}
 
-		if ( inRange( wordCount, this._config.veryFarBelowMinimum, this._config.belowMinimum ) ) {
-			return this._config.scores.farBelowMinimum;
+		if ( inRange( this.wordCount, this._config.parameters.veryFarBelowMinimum, this._config.parameters.belowMinimum ) ) {
+			return this._config.veryBad;
 		}
 
-		if ( inRange( wordCount, 0, this._config.veryFarBelowMinimum ) ) {
-			return this._config.scores.veryFarBelowMinimum;
-		}
-
-		return null;
+		return this._config.veryVeryBad;
 	}
 
 	/**
 	 * Translates the score to a message the user can understand.
 	 *
-	 * @param {number} score The amount of words to be checked against.
-	 * @param {number} wordCount The amount of words.
+	 * @param {string} resultText The text of the feedback from the configuration
+	 * @param {string} resultTextPlural The text of the feedback from the configuration (for the plural)
 	 * @param {object} i18n The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( score, wordCount, i18n ) {
-		if ( score === this._config.scores.recommendedMinimum ) {
-			return i18n.dngettext(
+	translateScore( resultText, resultTextPlural, i18n ) {
+		return i18n.sprintf(
+			i18n.dngettext(
 				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is more than or equal to the recommended minimum of %2$d word.",
-				"This is more than or equal to the recommended minimum of %2$d words.",
-				this._config.recommendedMinimum
-			);
-		}
-
-		if ( score === this._config.scores.slightlyBelowMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is slightly below the recommended minimum of %2$d word. Add a bit more copy.",
-				"This is slightly below the recommended minimum of %2$d words. Add a bit more copy.",
-				this._config.recommendedMinimum
-			);
-		}
-
-		if ( score === this._config.scores.belowMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
-				this._config.recommendedMinimum
-			);
-		}
-
-		if ( score === this._config.scores.farBelowMinimum || score === this._config.scores.veryFarBelowMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
-				this._config.recommendedMinimum
-			);
-		}
-
-		return "";
+				/* Translators: %1$d expands to the number of words in the text, %2$s expands to the recommended minimum of words. */
+				resultText,
+				resultTextPlural,
+				this.wordCount
+			),
+			this.wordCount,
+			this._config.parameters.recommendedMinimum
+		);
 	}
 }
 

--- a/src/assessments/seo/titleKeywordAssessment.js
+++ b/src/assessments/seo/titleKeywordAssessment.js
@@ -101,7 +101,7 @@ class TitleKeywordAssessment extends Assessment {
 	 *
 	 * @param {text} resultText The text of feedback for a given value of the assessment result.
 	 * @param {boolean} requiresKeyword Whether feedback text needs to include keyword.
-	 * @param {string} keyword The keyword of the paper
+	 * @param {string} keyword The keyword of the paper.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
 	 *
 	 * @returns {string} Text feedback.

--- a/src/assessments/seo/titleKeywordAssessment.js
+++ b/src/assessments/seo/titleKeywordAssessment.js
@@ -59,14 +59,23 @@ class TitleKeywordAssessment extends Assessment {
 
 		let assessmentResult = new AssessmentResult();
 
-		if ( paper.hasKeyword() && paper.hasTitle() ) {
-			const calculatedScore = this.calculateResult();
-			assessmentResult.setScore( calculatedScore.score );
-			assessmentResult.setText( this.translateScore( calculatedScore.resultText, calculatedScore.requiresKeyword,
-				escape( paper.getKeyword() ), i18n ) );
-		}
+		const calculatedScore = this.calculateResult();
+		assessmentResult.setScore( calculatedScore.score );
+		assessmentResult.setText( this.translateScore( calculatedScore.resultText, calculatedScore.requiresKeyword,
+			escape( paper.getKeyword() ), i18n ) );
 
 		return assessmentResult;
+	}
+
+	/**
+	 * Checks whether the assessment is applicable to the paper
+	 *
+	 * @param {Paper} paper The Paper object to assess.
+	 *
+	 * @returns {boolean} Whether the paper has a keyword and a title
+	 */
+	isApplicable( paper ) {
+		return paper.hasKeyword() && paper.hasTitle();
 	}
 
 	/**

--- a/src/assessments/seo/urlKeywordAssessment.js
+++ b/src/assessments/seo/urlKeywordAssessment.js
@@ -9,7 +9,7 @@ class UrlKeywordAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {object} config The configuration to use.
+	 * @param {Object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
@@ -19,6 +19,7 @@ class UrlKeywordAssessment extends Assessment {
 		let defaultConfig = {
 			scores: {
 				noKeywordInUrl: 6,
+				good: 9,
 			},
 		};
 
@@ -31,16 +32,18 @@ class UrlKeywordAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The Paper object to assess.
 	 * @param {Researcher} researcher The Researcher object containing all available researches.
-	 * @param {object} i18n The locale object.
+	 * @param {Object} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher, i18n ) {
-		let totalKeywords = researcher.getResearch( "keywordCountInUrl" );
+		this._totalKeywords = researcher.getResearch( "keywordCountInUrl" );
 
 		let assessmentResult = new AssessmentResult();
-		assessmentResult.setScore( this.calculateScore( totalKeywords ) );
-		assessmentResult.setText( this.translateScore( totalKeywords, i18n ) );
+
+		const calculatedResult = this.calculateResult( i18n );
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
@@ -57,35 +60,31 @@ class UrlKeywordAssessment extends Assessment {
 	}
 
 	/**
-	 * Calculates the score based on whether or not there's a keyword in the url.
+	 * Determines the score  and the result text based on whether or not there's a keyword in the url.
 	 *
-	 * @param {number} totalKeywords The amount of keywords to be checked against.
+	 * @param {Object} i18n The object used for translations.
 	 *
-	 * @returns {number} The calculated score.
+	 * @returns {Object} The object with calculated score and resultText.
 	 */
-	calculateScore( totalKeywords ) {
-		if ( totalKeywords === 0 ) {
-			return this._config.scores.noKeywordInUrl;
+	calculateResult( i18n ) {
+		if ( this._totalKeywords === 0 ) {
+			return {
+				score: this._config.scores.noKeywordInUrl,
+				resultText: i18n.dgettext(
+					"js-text-analysis",
+					"The focus keyword does not appear in the URL for this page. " +
+					"If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!"
+				),
+			};
 		}
 
-		return 9;
-	}
-
-	/**
-	 * Translates the score to a message the user can understand.
-	 *
-	 * @param {number} totalKeywords The amount of keywords to be checked against.
-	 * @param {object} i18n The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( totalKeywords, i18n ) {
-		if ( totalKeywords === 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The focus keyword does not appear in the URL for this page. " +
-				"If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!" );
-		}
-
-		return i18n.dgettext( "js-text-analysis", "The focus keyword appears in the URL for this page." );
+		return {
+			score: this._config.scores.good,
+			resultText: i18n.dgettext(
+				"js-text-analysis",
+				"The focus keyword appears in the URL for this page."
+			),
+		};
 	}
 }
 

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -1,21 +1,21 @@
-let Assessor = require( "../assessor.js" );
-let SEOAssessor = require( "../seoAssessor" );
+const Assessor = require( "../assessor.js" );
+const SEOAssessor = require( "../seoAssessor" );
 
-let IntroductionKeyword = require( "../assessments/seo/introductionKeywordAssessment.js" );
-let KeyphraseLength = require( "../assessments/seo/keyphraseLengthAssessment.js" );
-let KeywordDensity = require( "../assessments/seo/keywordDensityAssessment.js" );
-let MetaDescriptionKeyword = require( "../assessments/seo/metaDescriptionKeywordAssessment.js" );
-let MetaDescriptionLength = require( "../assessments/seo/metaDescriptionLengthAssessment.js" );
-let SubheadingsKeyword = require( "../assessments/seo/subheadingsKeywordAssessment.js" );
-let textCompetingLinks = require( "../assessments/seo/textCompetingLinksAssessment.js" );
-let TextImages = require( "../assessments/seo/textImagesAssessment.js" );
-let TextLength = require( "../assessments/seo/textLengthAssessment.js" );
-let OutboundLinks = require( "../assessments/seo/outboundLinksAssessment.js" );
-let internalLinks = require( "../assessments/seo/internalLinksAssessment" );
-let TitleKeyword = require( "../assessments/seo/titleKeywordAssessment.js" );
-let TitleWidth = require( "../assessments/seo/pageTitleWidthAssessment.js" );
-let UrlKeyword = require( "../assessments/seo/urlKeywordAssessment.js" );
-let SingleH1Assessment = require( "../assessments/seo/singleH1Assessment.js" );
+const IntroductionKeyword = require( "../assessments/seo/introductionKeywordAssessment.js" );
+const KeyphraseLength = require( "../assessments/seo/keyphraseLengthAssessment.js" );
+const KeywordDensity = require( "../assessments/seo/keywordDensityAssessment.js" );
+const MetaDescriptionKeyword = require( "../assessments/seo/metaDescriptionKeywordAssessment.js" );
+const MetaDescriptionLength = require( "../assessments/seo/metaDescriptionLengthAssessment.js" );
+const SubheadingsKeyword = require( "../assessments/seo/subheadingsKeywordAssessment.js" );
+const TextCompetingLinks = require( "../assessments/seo/textCompetingLinksAssessment.js" );
+const TextImages = require( "../assessments/seo/textImagesAssessment.js" );
+const TextLength = require( "../assessments/seo/textLengthAssessment.js" );
+const OutboundLinks = require( "../assessments/seo/outboundLinksAssessment.js" );
+const internalLinks = require( "../assessments/seo/internalLinksAssessment" );
+const TitleKeyword = require( "../assessments/seo/titleKeywordAssessment.js" );
+const TitleWidth = require( "../assessments/seo/pageTitleWidthAssessment.js" );
+const UrlKeyword = require( "../assessments/seo/urlKeywordAssessment.js" );
+const SingleH1Assessment = require( "../assessments/seo/singleH1Assessment.js" );
 
 /**
  * Creates the Assessor
@@ -49,7 +49,7 @@ let CornerstoneSEOAssessor = function( i18n, options ) {
 				},
 			}
 		),
-		textCompetingLinks,
+		new TextCompetingLinks(),
 		new TextImages( {
 			scores: {
 				noImages: 3,

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -11,7 +11,7 @@ const TextCompetingLinks = require( "../assessments/seo/textCompetingLinksAssess
 const TextImages = require( "../assessments/seo/textImagesAssessment.js" );
 const TextLength = require( "../assessments/seo/textLengthAssessment.js" );
 const OutboundLinks = require( "../assessments/seo/outboundLinksAssessment.js" );
-const internalLinks = require( "../assessments/seo/internalLinksAssessment" );
+const InternalLinks = require( "../assessments/seo/internalLinksAssessment" );
 const TitleKeyword = require( "../assessments/seo/titleKeywordAssessment.js" );
 const TitleWidth = require( "../assessments/seo/pageTitleWidthAssessment.js" );
 const UrlKeyword = require( "../assessments/seo/urlKeywordAssessment.js" );
@@ -74,7 +74,7 @@ let CornerstoneSEOAssessor = function( i18n, options ) {
 				noLinks: 3,
 			},
 		} ),
-		internalLinks,
+		new InternalLinks(),
 		new TitleKeyword(),
 		new TitleWidth(
 			{

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -1,7 +1,7 @@
 let Assessor = require( "../assessor.js" );
 let SEOAssessor = require( "../seoAssessor" );
 
-let introductionKeyword = require( "../assessments/seo/introductionKeywordAssessment.js" );
+let IntroductionKeyword = require( "../assessments/seo/introductionKeywordAssessment.js" );
 let KeyphraseLength = require( "../assessments/seo/keyphraseLengthAssessment.js" );
 let KeywordDensity = require( "../assessments/seo/keywordDensityAssessment.js" );
 let MetaDescriptionKeyword = require( "../assessments/seo/metaDescriptionKeywordAssessment.js" );
@@ -30,7 +30,7 @@ let CornerstoneSEOAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 
 	this._assessments = [
-		introductionKeyword,
+		new IntroductionKeyword(),
 		new KeyphraseLength(),
 		new KeywordDensity(),
 		new MetaDescriptionKeyword(),

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -10,7 +10,7 @@ const TextCompetingLinks = require( "./assessments/seo/textCompetingLinksAssessm
 const TextImages = require( "./assessments/seo/textImagesAssessment.js" );
 const TextLength = require( "./assessments/seo/textLengthAssessment.js" );
 const OutboundLinks = require( "./assessments/seo/outboundLinksAssessment.js" );
-const internalLinks = require( "./assessments/seo/internalLinksAssessment" );
+const InternalLinks = require( "./assessments/seo/internalLinksAssessment" );
 const TitleKeyword = require( "./assessments/seo/titleKeywordAssessment.js" );
 const TitleWidth = require( "./assessments/seo/pageTitleWidthAssessment.js" );
 const UrlKeyword = require( "./assessments/seo/urlKeywordAssessment.js" );
@@ -39,7 +39,7 @@ let SEOAssessor = function( i18n, options ) {
 		new TextImages(),
 		new TextLength(),
 		new OutboundLinks(),
-		internalLinks,
+		new InternalLinks(),
 		new TitleKeyword(),
 		new TitleWidth(),
 		new UrlKeyword(),

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -1,20 +1,20 @@
-var Assessor = require( "./assessor.js" );
+const Assessor = require( "./assessor.js" );
 
-var introductionKeyword = require( "./assessments/seo/introductionKeywordAssessment.js" );
-var KeyphraseLength = require( "./assessments/seo/keyphraseLengthAssessment.js" );
-var KeywordDensity = require( "./assessments/seo/keywordDensityAssessment.js" );
-var MetaDescriptionKeyword = require( "./assessments/seo/metaDescriptionKeywordAssessment.js" );
-var MetaDescriptionLength = require( "./assessments/seo/metaDescriptionLengthAssessment.js" );
-var SubheadingsKeyword = require( "./assessments/seo/subheadingsKeywordAssessment.js" );
-var textCompetingLinks = require( "./assessments/seo/textCompetingLinksAssessment.js" );
-var TextImages = require( "./assessments/seo/textImagesAssessment.js" );
-var TextLength = require( "./assessments/seo/textLengthAssessment.js" );
-var OutboundLinks = require( "./assessments/seo/outboundLinksAssessment.js" );
-var internalLinks = require( "./assessments/seo/internalLinksAssessment" );
-var TitleKeyword = require( "./assessments/seo/titleKeywordAssessment.js" );
-var TitleWidth = require( "./assessments/seo/pageTitleWidthAssessment.js" );
-var UrlKeyword = require( "./assessments/seo/urlKeywordAssessment.js" );
-var SingleH1Assessment = require( "./assessments/seo/singleH1Assessment.js" );
+const IntroductionKeyword = require( "./assessments/seo/introductionKeywordAssessment.js" );
+const KeyphraseLength = require( "./assessments/seo/keyphraseLengthAssessment.js" );
+const KeywordDensity = require( "./assessments/seo/keywordDensityAssessment.js" );
+const MetaDescriptionKeyword = require( "./assessments/seo/metaDescriptionKeywordAssessment.js" );
+const MetaDescriptionLength = require( "./assessments/seo/metaDescriptionLengthAssessment.js" );
+const SubheadingsKeyword = require( "./assessments/seo/subheadingsKeywordAssessment.js" );
+const textCompetingLinks = require( "./assessments/seo/textCompetingLinksAssessment.js" );
+const TextImages = require( "./assessments/seo/textImagesAssessment.js" );
+const TextLength = require( "./assessments/seo/textLengthAssessment.js" );
+const OutboundLinks = require( "./assessments/seo/outboundLinksAssessment.js" );
+const internalLinks = require( "./assessments/seo/internalLinksAssessment" );
+const TitleKeyword = require( "./assessments/seo/titleKeywordAssessment.js" );
+const TitleWidth = require( "./assessments/seo/pageTitleWidthAssessment.js" );
+const UrlKeyword = require( "./assessments/seo/urlKeywordAssessment.js" );
+const SingleH1Assessment = require( "./assessments/seo/singleH1Assessment.js" );
 
 /**
  * Creates the Assessor
@@ -25,11 +25,11 @@ var SingleH1Assessment = require( "./assessments/seo/singleH1Assessment.js" );
  *
  * @constructor
  */
-var SEOAssessor = function( i18n, options ) {
+let SEOAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 
 	this._assessments = [
-		introductionKeyword,
+		new IntroductionKeyword(),
 		new KeyphraseLength(),
 		new KeywordDensity(),
 		new MetaDescriptionKeyword(),

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -6,7 +6,7 @@ const KeywordDensity = require( "./assessments/seo/keywordDensityAssessment.js" 
 const MetaDescriptionKeyword = require( "./assessments/seo/metaDescriptionKeywordAssessment.js" );
 const MetaDescriptionLength = require( "./assessments/seo/metaDescriptionLengthAssessment.js" );
 const SubheadingsKeyword = require( "./assessments/seo/subheadingsKeywordAssessment.js" );
-const textCompetingLinks = require( "./assessments/seo/textCompetingLinksAssessment.js" );
+const TextCompetingLinks = require( "./assessments/seo/textCompetingLinksAssessment.js" );
 const TextImages = require( "./assessments/seo/textImagesAssessment.js" );
 const TextLength = require( "./assessments/seo/textLengthAssessment.js" );
 const OutboundLinks = require( "./assessments/seo/outboundLinksAssessment.js" );
@@ -35,7 +35,7 @@ let SEOAssessor = function( i18n, options ) {
 		new MetaDescriptionKeyword(),
 		new MetaDescriptionLength(),
 		new SubheadingsKeyword(),
-		textCompetingLinks,
+		new TextCompetingLinks(),
 		new TextImages(),
 		new TextLength(),
 		new OutboundLinks(),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug when introductionKeywordAssessment was triggered for papers without text or keyword.
* Fixes a bug when subheadingsKeywordAssessment was triggered for papers without subheadings.

## Relevant technical choices:

* introductionKeywordAssessment, textCompetingLinksAssessment, and internalLinksAssessment are converted in a class. SEOAssessorSpec and cornerstone/SEOAssessorSpec were adjusted accordingly.
* metaDescriptionLengthAssessment, titleKeywordAssessment, outboundLinksAssessment, subheadingsKeywordAssessment, textImagesAssessment, and textLenghtAssessment were slightly edited to improve consistency with other SEO assessments and test coverage.

## Test instructions

Since many of the assessments that were involved in this PR are difficult to test within the Browserified, use local Wordpress instead.

- Use the beta script to create an RC of the branch (use "feature/recalibration" as plugin branch and "stories/1439-convert-assessments-to-classes" as YoastSEO.js branch)

### introductionKeywordAssessment
- add a keyword and some text that does not contain that keyword - the assessment should return: "The focus keyword doesn't appear in the first paragraph of the copy. Make sure the topic is clear immediately."
- add your keyword to the second paragraph of your text - the feedback should remain the same.
- add your keyword to the first paragraph of your text - the feedback should change to "The focus keyword appears in the first paragraph of the copy."
- add more instances of your keyword in the first paragraph of our text - the feedback should remain the same.

### textCompetingLinksAssessment
- Add a post and fill in a certain keyword.
- Add a link with the keyword as the link text (the URL doesn't matter)
- The assessment should return a bad score and feedback: "You're linking to another page with the focus keyword you want this page to rank for. Consider changing that if you truly want this page to rank."
- Change the link so that the link text doesn't use the keyword anymore and make sure that the feedback disappears.

- Note that marking of conflicting links does not work, there is an issue about it #1350

### internalLinksAssessment
- Add two posts without any links to each other or to any other posts.
- The assessment should return "No internal links appear in this page, consider adding some as appropriate." for both posts.
- Refer from post 1 to the post 2 using a follow-link.
- The assessment for post 1 should return "This page has 1 internal link(s)."
- Change the follow-link in post 1 into a no-follow-link.
- The assessment  for post 1 should return "This page has 1 internal link(s), all nofollowed."
- Add another link in post 1 (can be to the same post 2) and make it follow.
- The assessment for post 1 should return "This page has 1 nofollowed internal link(s) and 1 normal internal link(s)."

### outboundLinksAssessment
- Add a post without any links to any external websites.
- The assessment should return "No outbound links appear in this page, consider adding some as appropriate."
- Refer from your post to an external website using a follow-link.
- The assessment should return "This page has 1 outbound link(s)."
- Change the follow-link into a no-follow-link.
- The assessment  should return "This page has 1 outbound link(s), all nofollowed."
- Add another link (can be to the same external website) and make it follow.
- The assessment for should return "This page has 1 nofollowed internal link(s) and 1 normal outbound link(s)."

### metaDescriptionLengthAssessment
- Add a post without any metadescription. The assessment should return a red bullet and "No meta description has been specified. Search engines will display copy from the page instead."
- Add a very short metadescription (under 120 characters). The assessment should return an orange bullet and "The meta description is under 120 characters long. However, up to 156 characters are available."
- Add more words to metadescription (between 120 and 156). The assessment should return a green bullet and "The meta description has a nice length."
- Add even more words to metadescription (above 156). The assessment should return an orange bullet and "The meta description is over 156 characters. Reducing the length will ensure the entire description will be visible."

### titleKeywordAssessment
- Add a keyword and a title that starts directly with that keyword - the assessment should return a green bullet "The SEO title contains the focus keyword, at the beginning which is considered to improve rankings."
- Add an article in the beginning of your title (e.g., "a", "an", "the" for English) - the assessment result should remain the same
- Add a different non-article word in the beginning of your title - the assessment should return an orange bullet "The SEO title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning."
- Remove the keyword from the title - the assessment should return a red bullet "The focus keyword 'your keyword here' does not appear in the SEO title."

### subheadinsKeywordAssessment
- Add a keyword and a text without any subheadings. The assessment should return nothing.
- Add a subheading that does not contain your keyword. The assessment should return a red bullet and "You have not used the focus keyword in any subheading (such as an H2) in your copy."
- Add a subheading that does contain your keyword. The assessment should return a green bullet and "The focus keyword appears in 1 (out of 2) subheadings in your copy."

### textImagesAssessment
- Add a text without images. The assessment should return a red bullet and "No images appear in this page, consider adding some as appropriate."
- Add an image without alt tags. The assessment should return an orange bullet and "The images on this page are missing alt attributes."
- Add an alt tag. The assessment should return an orange bullet and "The images on this page contain alt attributes."
- Add a keyword (in the keyword box). The assessment should return an orange bullet and "The images on this page do not have alt attributes containing the focus keyword."
- Add your keyword to the alt tag. The assessment should return a green bullet and "The images on this page contain alt attributes with the focus keyword."

### textLengthAssessment
- Add a very short text (5 words). The assessment should return a red bullet and "The text contains 5 words. This is far below the recommended minimum of 300 words. Add more content that is relevant for the topic."
- Add a little more copy (150 words). The assessment should return a red bullet and "The text contains 150 words. This is far below the recommended minimum of 300 words. Add more content that is relevant for the topic."
- Add a little more copy (230 words). The assessment should return a red bullet and "The text contains 230 word. This is below the recommended minimum of 300 words. Add more content that is relevant for the topic."
- Add a little more copy (270 words). The assessment should return an orange bullet and "The text contains 270 word. This is slightly below the recommended minimum of 300 words. Add a bit more copy."
- Add a little more copy (310 words). The assessment should return a green bullet and "The text contains 310 word. This is more than or equal to the recommended minimum of 300 words."

### keyphraseLenghAssessment
- write a little text or paste if from somewhere
- keep the focus keyword box blank - the assessment should return a red bullet "No focus keyword was set for this page. If you do not set a focus keyword, no score can be calculated."
- enter a short focus keyword (1 to 4 words) - the assessment should return a green bullet "Your keyphrase has a nice length."
- enter a longer focus keyword (5 to 8 words) - the assessment should return an orange bullet "Your keyphrase is %1$d words long. That's more than the recommended maximum of %2$d words. You might want to make the keyphrase a bit shorter."
- enter an even longer focus keyword (9 words or longer) - the assessment should return a red bullet "Your keyphrase is %1$d words long. That's way more than the recommended maximum of %2$d words. Make the keyphrase shorter. "

### keywordDensityAssessment
- write a text and fill in the keyword that does not occur in the text - the assessment should return a red bullet "The focus keyword was found 0 times. That's less than the recommended minimum of %1$d times for a text of this length."
- paste your keyword once in the text - the assessment should return a red bullet "The focus keyword was found %1$d time(s). That's less than the recommended minimum of %2$d times for a text of this length."
- paste more keyword in your text - notice if the assessment returns meaningful feedback. 
- for more precise testing see #1411 

### metaDescriptionKeywordAssessment
- write a metadescripion and fill in the keyword that does not occur in the text - the assessment should return a red bullet "A meta description has been specified, but it does not contain the focus keyword."
- paste your keyword in the metadescripion once or twice - the assessment should return a green bullet "The meta description contains the focus keyword. That's great." or "The meta description contains the focus keyword %1$d times. That's great."
- past your keyword in the metadescripion a few more times - the assessment should return a red bullet "The meta description contains the focus keyword %1$d times, which is over the advised maximum of %2$d times."

### pageTitleWidthAssessment
- add no SEO title at all - the assessment should return a red bullet "Please create an SEO title."
- fill in a short SEO title (<400 pixels) - the assessment should return an orange bullet "The SEO title is too short. Use the space to add keyword variations or create compelling call-to-action copy."
- add a few words to the SEO title (between 400 and 600 pixels) - the assessment should return a green bullet "The SEO title has a nice length."
- add a few more words to the SEO title (>600 pixels) - the assessment should return a red bullet "The SEO title is wider than the viewable limit."


Fixes #1439 
