### PR TITLE
Check keyword in meta description only when there is a meta description

### DIFF
--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -25,7 +25,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textLength",
 			"titleWidth",
@@ -39,7 +38,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textLength",
 			"titleKeyword",
@@ -69,7 +67,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textImages",
 			"textLength",
@@ -86,7 +83,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textImages",
 			"textLength",
@@ -94,6 +90,23 @@ describe( "running assessments in the assessor", function() {
 			"internalLinks",
 			"titleWidth",
 			"urlKeyword",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a meta description and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "meta description" } ) );
+		let assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
 		] );
 	} );
 
@@ -112,7 +125,6 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textImages",
 			"textLength",

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -25,7 +25,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textLength",
 			"titleWidth",
@@ -39,7 +38,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textLength",
 			"titleKeyword",
@@ -69,7 +67,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textImages",
 			"textLength",
@@ -86,7 +83,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textImages",
 			"textLength",
@@ -94,6 +90,23 @@ describe( "running assessments in the assessor", function() {
 			"internalLinks",
 			"titleWidth",
 			"urlKeyword",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a meta description and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "meta description" } ) );
+		let assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
 		] );
 	} );
 
@@ -112,7 +125,6 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"textImages",
 			"textLength",

--- a/src/assessments/seo/metaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/metaDescriptionKeywordAssessment.js
@@ -1,6 +1,6 @@
-var AssessmentResult = require( "../../values/AssessmentResult.js" );
-let Assessment = require( "../../assessment.js" );
-let merge = require( "lodash/merge" );
+const AssessmentResult = require( "../../values/AssessmentResult.js" );
+const Assessment = require( "../../assessment.js" );
+const merge = require( "lodash/merge" );
 
 /**
  * Assessment for calculating the length of the meta description.
@@ -16,7 +16,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	constructor( config = {} ) {
 		super();
 
-		let defaultConfig = {
+		const defaultConfig = {
 			recommendedMinimumMatches: 1,
 			recommendedMaximumMatches: 2,
 			scores: {
@@ -41,7 +41,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 */
 	getResult( paper, researcher, i18n ) {
 		this._keywordMatches = researcher.getResearch( "metaDescriptionKeyword" );
-		var assessmentResult = new AssessmentResult();
+		let assessmentResult = new AssessmentResult();
 
 		assessmentResult.setScore( this.calculateScore() );
 		assessmentResult.setText( this.translateScore( i18n ) );
@@ -116,7 +116,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {boolean} True when the paper has a keyword.
 	 */
 	isApplicable( paper ) {
-		return paper.hasKeyword();
+		return paper.hasKeyword() && paper.hasDescription();
 	}
 }
 

--- a/src/assessments/seo/metaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/metaDescriptionKeywordAssessment.js
@@ -3,7 +3,7 @@ const Assessment = require( "../../assessment.js" );
 const merge = require( "lodash/merge" );
 
 /**
- * Assessment for calculating the length of the meta description.
+ * Assessment for checking the keyword matches in the meta description.
  */
 class MetaDescriptionKeywordAssessment extends Assessment {
 	/**
@@ -17,12 +17,29 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 		super();
 
 		const defaultConfig = {
-			recommendedMinimumMatches: 1,
-			recommendedMaximumMatches: 2,
-			scores: {
-				tooFewMatches: 3,
-				tooManyMatches: 3,
-				correctNumberOfMatches: 9,
+			parameters: {
+				recommendedMinimumMatches: 1,
+				recommendedMaximumMatches: 2,
+			},
+			tooFewMatches: {
+				score: 3,
+				resultText: "A meta description has been specified, but it does not contain the focus keyword.",
+				requiresMatches: false,
+				requiresMax: false,
+			},
+			tooManyMatches: {
+				score: 3,
+				resultText: "The meta description contains the focus keyword %1$d times, " +
+				"which is over the advised maximum of %2$d times.",
+				requiresMatches: true,
+				requiresMax: true,
+			},
+			correctNumberOfMatches: {
+				score: 9,
+				resultText: "The meta description contains the focus keyword. That's great.",
+				resultTextPlural: "The meta description contains the focus keyword %1$d times. That's great.",
+				requiresMatches: true,
+				requiresMax: false,
 			},
 		};
 
@@ -33,87 +50,84 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	/**
 	 * Runs the metaDescriptionKeyword researcher and based on this, returns an assessment result with score.
 	 *
-	 * @param {Paper} paper The paper to use for the assessment.
-	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Object} i18n The object used for translations.
+	 * @param {Paper} paper             The paper to use for the assessment.
+	 * @param {Researcher} researcher   The researcher used for calling research.
+	 * @param {Object} i18n             The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
 	getResult( paper, researcher, i18n ) {
 		this._keywordMatches = researcher.getResearch( "metaDescriptionKeyword" );
 		let assessmentResult = new AssessmentResult();
+		const calculatedResult = this.calculateResult();
 
-		assessmentResult.setScore( this.calculateScore() );
-		assessmentResult.setText( this.translateScore( i18n ) );
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( this.translateScore(
+			calculatedResult.resultText, calculatedResult.resultTextPlural, calculatedResult.requiresMatches, calculatedResult.requiresMax, i18n )
+		);
 
 		return assessmentResult;
 	}
 
 	/**
-	 * Checks whether there are too few keyword matches in the meta description.
+	 * Returns the result object based on the number of keyword matches in the meta description.
 	 *
-	 * @returns {boolean} Returns true if there is less than 1 keyword match in the meta description.
+	 * @returns {Object} Result object with score and text.
 	 */
-	hasTooFewMatches() {
-		return this._keywordMatches < this._config.recommendedMinimumMatches;
-	}
-
-	/**
-	 * Checks whether there is a good number of keyword matches in the meta description.
-	 *
-	 * @returns {boolean} Returns true if the number of keyword matches is within the recommended range.
-	 */
-	hasGoodNumberOfMatches() {
-		return ( this._keywordMatches >= this._config.recommendedMinimumMatches &&
-		this._keywordMatches <= this._config.recommendedMaximumMatches );
-	}
-
-	/**
-	 * Returns the score for the descriptionLength.
-	 *
-	 * @returns {number} The calculated score.
-	 */
-	calculateScore() {
-		if ( this.hasTooFewMatches() ) {
-			return this._config.scores.tooFewMatches;
+	calculateResult() {
+		if ( this._keywordMatches < this._config.parameters.recommendedMinimumMatches ) {
+			return this._config.tooFewMatches;
 		}
 
-		if ( this.hasGoodNumberOfMatches() ) {
-			return this._config.scores.correctNumberOfMatches;
+		if ( this._keywordMatches >= this._config.parameters.recommendedMinimumMatches &&
+			this._keywordMatches <= this._config.parameters.recommendedMaximumMatches ) {
+			return this._config.correctNumberOfMatches;
 		}
 
 		// Implicitly return this if the number of matches is more than the recommended maximum.
-		return this._config.scores.tooManyMatches;
+		return this._config.tooManyMatches;
 	}
 
 	/**
 	 * Translates the score to a message the user can understand.
 	 *
-	 * @param {Object} i18n The object used for translations.
+	 * @param {string} resultText        The feedback string.
+	 * @param {string} resultTextPlural  The feedback string for the plural.
+	 * @param {boolean} requiresMatches  Whether the feedback string contains keyword matches.
+	 * @param {boolean} requiresMax      Whether the feedback string contains the recommended maximum of feedback matches.
+	 * @param {Object} i18n              The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( i18n ) {
-		if ( this.hasTooFewMatches() ) {
-			return i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it does not contain the focus keyword." );
+	translateScore( resultText, resultTextPlural, requiresMatches, requiresMax, i18n ) {
+		if ( requiresMatches === true && requiresMax === false ) {
+			return i18n.sprintf( i18n.dngettext(
+				"js-text-analysis",
+				/* Translators: %1$s expands to the number of keyword matches in the meta description */
+				resultText,
+				resultTextPlural,
+				this._keywordMatches
+			), this._keywordMatches );
 		}
 
-		if ( this.hasGoodNumberOfMatches() ) {
-			return i18n.sprintf( i18n.dngettext( "js-text-analysis", "The meta description contains the focus keyword. That's great.",
-				"The meta description contains the focus keyword %1$d times. That's great.", this._keywordMatches ), this._keywordMatches );
+		if ( requiresMatches === true && requiresMax === true ) {
+			return i18n.sprintf( i18n.dngettext(
+				"js-text-analysis",
+				/* Translators: %1$s expands to the number of keyword matches in the meta description,
+				 * 2$s expands to the maximum recommended number of matches. */
+				resultText
+				), this._keywordMatches, this._config.parameters.recommendedMaximumMatches );
 		}
 
-		// Implicitly returns this if the number of matches is more than the recommended maximum.
-		return i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description contains the focus keyword %1$d times, " +
-			"which is over the advised maximum of %2$d times." ), this._keywordMatches, this._config.recommendedMaximumMatches );
+		return i18n.sprintf( i18n.dgettext( "js-text-analysis", resultText ) );
 	}
 
 	/**
-	 * Checks whether the paper has a keyword.
+	 * Checks whether the paper has a keyword and a meta description.
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 *
-	 * @returns {boolean} True when the paper has a keyword.
+	 * @returns {boolean} True if the paper has a keyword and a meta description.
 	 */
 	isApplicable( paper ) {
 		return paper.hasKeyword() && paper.hasDescription();

--- a/src/assessments/seo/metaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/metaDescriptionKeywordAssessment.js
@@ -21,25 +21,9 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 				recommendedMinimumMatches: 1,
 				recommendedMaximumMatches: 2,
 			},
-			tooFewMatches: {
-				score: 3,
-				resultText: "A meta description has been specified, but it does not contain the focus keyword.",
-				requiresMatches: false,
-				requiresMax: false,
-			},
-			tooManyMatches: {
-				score: 3,
-				resultText: "The meta description contains the focus keyword %1$d times, " +
-				"which is over the advised maximum of %2$d times.",
-				requiresMatches: true,
-				requiresMax: true,
-			},
-			correctNumberOfMatches: {
-				score: 9,
-				resultText: "The meta description contains the focus keyword. That's great.",
-				resultTextPlural: "The meta description contains the focus keyword %1$d times. That's great.",
-				requiresMatches: true,
-				requiresMax: false,
+			scores: {
+				good: 9,
+				bad: 3,
 			},
 		};
 
@@ -59,12 +43,10 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	getResult( paper, researcher, i18n ) {
 		this._keywordMatches = researcher.getResearch( "metaDescriptionKeyword" );
 		let assessmentResult = new AssessmentResult();
-		const calculatedResult = this.calculateResult();
+		const calculatedResult = this.calculateResult( i18n );
 
 		assessmentResult.setScore( calculatedResult.score );
-		assessmentResult.setText( this.translateScore(
-			calculatedResult.resultText, calculatedResult.resultTextPlural, calculatedResult.requiresMatches, calculatedResult.requiresMax, i18n )
-		);
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
@@ -72,54 +54,47 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	/**
 	 * Returns the result object based on the number of keyword matches in the meta description.
 	 *
+	 * @param {Object} i18n The object used for translations.
+	 *
 	 * @returns {Object} Result object with score and text.
 	 */
-	calculateResult() {
+	calculateResult( i18n ) {
 		if ( this._keywordMatches < this._config.parameters.recommendedMinimumMatches ) {
-			return this._config.tooFewMatches;
+			return {
+				score: this._config.scores.bad,
+				resultText: i18n.sprintf( i18n.dgettext(
+					"js-text-analysis",
+					"A meta description has been specified, but it does not contain the focus keyword." ) ),
+			};
 		}
 
 		if ( this._keywordMatches >= this._config.parameters.recommendedMinimumMatches &&
 			this._keywordMatches <= this._config.parameters.recommendedMaximumMatches ) {
-			return this._config.correctNumberOfMatches;
+			return {
+				score: this._config.scores.good,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s expands to the number of keyword matches in the meta description */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The meta description contains the focus keyword. That's great.",
+						"The meta description contains the focus keyword %1$d times. That's great.",
+					this._keywordMatches
+				), this._keywordMatches ),
+			};
 		}
 
 		// Implicitly return this if the number of matches is more than the recommended maximum.
-		return this._config.tooManyMatches;
-	}
-
-	/**
-	 * Translates the score to a message the user can understand.
-	 *
-	 * @param {string} resultText        The feedback string.
-	 * @param {string} resultTextPlural  The feedback string for the plural.
-	 * @param {boolean} requiresMatches  Whether the feedback string contains keyword matches.
-	 * @param {boolean} requiresMax      Whether the feedback string contains the recommended maximum of feedback matches.
-	 * @param {Object} i18n              The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( resultText, resultTextPlural, requiresMatches, requiresMax, i18n ) {
-		if ( requiresMatches === true && requiresMax === false ) {
-			return i18n.sprintf( i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$s expands to the number of keyword matches in the meta description */
-				resultText,
-				resultTextPlural,
-				this._keywordMatches
-			), this._keywordMatches );
-		}
-
-		if ( requiresMatches === true && requiresMax === true ) {
-			return i18n.sprintf( i18n.dngettext(
-				"js-text-analysis",
+		return {
+			score: this._config.scores.bad,
+			resultText: i18n.sprintf(
 				/* Translators: %1$s expands to the number of keyword matches in the meta description,
-				 * 2$s expands to the maximum recommended number of matches. */
-				resultText
-				), this._keywordMatches, this._config.parameters.recommendedMaximumMatches );
-		}
-
-		return i18n.sprintf( i18n.dgettext( "js-text-analysis", resultText ) );
+				2$s expands to the maximum recommended number of matches. */
+				i18n.dngettext(
+					"js-text-analysis",
+					"The meta description contains the focus keyword %1$d times, " +
+					"which is over the advised maximum of %2$d times."
+			), this._keywordMatches, this._config.parameters.recommendedMaximumMatches ),
+		};
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

n/a

## Relevant technical choices:

* Changes the assessment so that it checks whether there's a keyword in the meta description only when a meta description has been set.

## Test instructions

This PR can be tested by following these steps:

### Browserified
* Check out this branch.
* Use the browserified example. Don't forget to run a `grunt build:js`.
* Add a keyword and add a meta description that does not contain the keyword. There should be no feedback that says that you haven't used the keyword in the meta description. This feedback should only appear once you add text to the meta description.

### WordPress
* Use the beta script to combine this branch with `stories/9718-change-meta-description-keyword-taxonomy-assessor-specs `on `wordpress-seo` (or, if that has already been merged, use `feature/recalibration`). 
* Test the same functionality as specified above. Check also whether this works for category pages.

Fixes #1478 
