### PR TITLE
Make SnippetPreview optional

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -83,6 +83,7 @@ var defaults = {
 	marker: function() {},
 	keywordAnalysisActive: true,
 	contentAnalysisActive: true,
+	hasSnippetPreview: true,
 };
 
 /**
@@ -132,7 +133,10 @@ function verifyArguments( args ) {
 	}
 
 	// The args.targets.snippet argument is only required if not SnippetPreview object has been passed.
-	if ( ! isValidSnippetPreview( args.snippetPreview ) && ! isString( args.targets.snippet ) ) {
+	if (
+		args.hasSnippetPreview &&
+		! isValidSnippetPreview( args.snippetPreview ) &&
+		! isString( args.targets.snippet ) ) {
 		throw new MissingArgument( "A snippet preview is required. When no SnippetPreview object isn't passed to " +
 			"the App, the `targets.snippet` is a required App argument. `targets.snippet` is not a string." );
 	}
@@ -276,9 +280,10 @@ var App = function( args ) {
 			this.snippetPreview.refObj = this;
 			this.snippetPreview.i18n = this.i18n;
 		}
-	} else {
+	} else if ( args.hasSnippetPreview ) {
 		this.snippetPreview = createDefaultSnippetPreview.call( this );
 	}
+
 	this.initSnippetPreview();
 	this.initAssessorPresenters();
 };
@@ -467,7 +472,7 @@ App.prototype.constructI18n = function( translations ) {
 App.prototype.getData = function() {
 	this.rawData = this.callbacks.getData();
 
-	if ( ! isUndefined( this.snippetPreview ) ) {
+	if ( this.hasSnippetPreview() ) {
 		// Gets the data FOR the analyzer
 		var data = this.snippetPreview.getAnalyzerData();
 
@@ -511,15 +516,26 @@ App.prototype._pureRefresh = function() {
 };
 
 /**
+ * Determines whether or not this app has a snippet preview.
+ *
+ * @returns {boolean} Whether or not this app has a snippet preview.
+ */
+App.prototype.hasSnippetPreview = function() {
+	return this.snippetPreview !== null && ! isUndefined( this.snippetPreview );
+};
+
+/**
  * Initializes the snippet preview for this App.
  *
  * @returns {void}
  */
 App.prototype.initSnippetPreview = function() {
-	this.snippetPreview.renderTemplate();
-	this.snippetPreview.callRegisteredEventBinder();
-	this.snippetPreview.bindEvents();
-	this.snippetPreview.init();
+	if ( this.hasSnippetPreview() ) {
+		this.snippetPreview.renderTemplate();
+		this.snippetPreview.callRegisteredEventBinder();
+		this.snippetPreview.bindEvents();
+		this.snippetPreview.init();
+	}
 };
 
 /**
@@ -569,7 +585,7 @@ App.prototype.bindInputEvent = function() {
  * @returns {void}
  */
 App.prototype.reloadSnippetText = function() {
-	if ( isUndefined( this.snippetPreview ) ) {
+	if ( this.hasSnippetPreview() ) {
 		this.snippetPreview.reRender();
 	}
 };
@@ -614,12 +630,19 @@ App.prototype.runAnalyzer = function() {
 
 	this.analyzerData = this.modifyData( this.rawData );
 
-	this.snippetPreview.refresh();
+	if ( this.hasSnippetPreview() ) {
+		this.snippetPreview.refresh();
+	}
 
 	let text = this.analyzerData.text;
 
 	// Insert HTML stripping code
 	text = removeHtmlBlocks( text );
+
+	let titleWidth = this.analyzerData.titleWidth;
+	if ( this.hasSnippetPreview() ) {
+		titleWidth = this.snippetPreview.getTitleWidth();
+	}
 
 	// Create a paper object for the Researcher
 	this.paper = new Paper( text, {
@@ -627,7 +650,7 @@ App.prototype.runAnalyzer = function() {
 		description: this.analyzerData.meta,
 		url: this.analyzerData.url,
 		title: this.analyzerData.metaTitle,
-		titleWidth: this.snippetPreview.getTitleWidth(),
+		titleWidth: titleWidth,
 		locale: this.config.locale,
 		permalink: this.analyzerData.permalink,
 	} );
@@ -649,7 +672,9 @@ App.prototype.runAnalyzer = function() {
 		this.endTime();
 	}
 
-	this.snippetPreview.reRender();
+	if ( this.hasSnippetPreview() ) {
+		this.snippetPreview.reRender();
+	}
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Makes the snippetPreview optional in the App. This can be enabled by
putting the `hasSnippetPreview` argument to `false`.

## Relevant technical choices:

* Created a new method hasSnippetPreview to detect if there is a
snippet preview.

## Test instructions

This PR can be tested by following these steps:

* In combination with the PR in Yoast SEO.
