### PR TITLE
Changed maximum meta description length

### DIFF
--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -19,7 +19,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The meta description is under 120 characters long. However, up to 155 characters are available." );
+		expect( assessment.getText() ).toEqual( "The meta description is under 120 characters long. However, up to 156 characters are available." );
 	} );
 
 	it( "assesses a too long description", function() {
@@ -27,7 +27,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The meta description is over 155 characters. Reducing the length will ensure the entire description will be visible." );
+		expect( assessment.getText() ).toEqual( "The meta description is over 156 characters. Reducing the length will ensure the entire description will be visible." );
 	} );
 
 	it( "assesses a good description", function() {

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -19,7 +19,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The meta description is under 120 characters long. However, up to 320 characters are available." );
+		expect( assessment.getText() ).toEqual( "The meta description is under 120 characters long. However, up to 155 characters are available." );
 	} );
 
 	it( "assesses a too long description", function() {
@@ -27,7 +27,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The meta description is over 320 characters. Reducing the length will ensure the entire description will be visible." );
+		expect( assessment.getText() ).toEqual( "The meta description is over 155 characters. Reducing the length will ensure the entire description will be visible." );
 	} );
 
 	it( "assesses a good description", function() {

--- a/spec/snippetPreviewSpec.js
+++ b/spec/snippetPreviewSpec.js
@@ -52,7 +52,7 @@ describe( "The SnippetPreview format functions", function() {
 		} );
 
 		expect( snippetPreview.formatTitle() ).toBe( "snippetTitle keyword" );
-		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et d" );
+		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et da" );
 		expect( snippetPreview.formatCite() ).toBe( "homeurl/" );
 		expect( snippetPreview.formatKeyword( "a string with keyword" ) ).toBe( "a string with<strong> keyword</strong>" );
 

--- a/spec/snippetPreviewSpec.js
+++ b/spec/snippetPreviewSpec.js
@@ -52,7 +52,7 @@ describe( "The SnippetPreview format functions", function() {
 		} );
 
 		expect( snippetPreview.formatTitle() ).toBe( "snippetTitle keyword" );
-		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et dapibus dictum. Duis imperdiet nisl id orci hendrerit imperdiet. Praesent commodo ornare ante vitae placerat. Aliquam leo justo, imperdiet ut purus at, pharetra sempe" );
+		expect( snippetPreview.formatMeta() ).toBe( "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia eget neque ut porttitor. Quisque semper ligula leo. Nullam convallis ligula et d" );
 		expect( snippetPreview.formatCite() ).toBe( "homeurl/" );
 		expect( snippetPreview.formatKeyword( "a string with keyword" ) ).toBe( "a string with<strong> keyword</strong>" );
 

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -2,7 +2,9 @@ let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let Assessment = require( "../../assessment.js" );
 let merge = require( "lodash/merge" );
 
-const maximumLength = 320;
+import Config from "../../config/config";
+
+const MAXIMUM_META_DESCRIPTION_LENGTH = Config.maxMeta;
 
 /**
  * Assessment for calculating the length of the meta description.
@@ -20,7 +22,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 
 		let defaultConfig = {
 			recommendedMaximumLength: 120,
-			maximumLength: maximumLength,
+			maximumLength: MAXIMUM_META_DESCRIPTION_LENGTH,
 			scores: {
 				noMetaDescription: 1,
 				tooLong: 6,
@@ -39,7 +41,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	 * @returns {number} The maximum length.
 	 */
 	getMaximumLength() {
-		return maximumLength;
+		return this._config.maximumLength;
 	}
 
 	/**

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -4,7 +4,7 @@ let merge = require( "lodash/merge" );
 
 import Config from "../../config/config";
 
-const MAXIMUM_META_DESCRIPTION_LENGTH = Config.maxMeta;
+const maximumMetaDescriptionLength = Config.maxMeta;
 
 /**
  * Assessment for calculating the length of the meta description.
@@ -22,7 +22,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 
 		let defaultConfig = {
 			recommendedMaximumLength: 120,
-			maximumLength: MAXIMUM_META_DESCRIPTION_LENGTH,
+			maximumLength: maximumMetaDescriptionLength,
 			scores: {
 				noMetaDescription: 1,
 				tooLong: 6,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,7 +4,7 @@ const analyzerConfig = {
 	wordsToRemove: [ " a", " in", " an", " on", " for", " the", " and" ],
 	maxSlugLength: 20,
 	maxUrlLength: 40,
-	maxMeta: 155,
+	maxMeta: 156,
 };
 
 export default analyzerConfig;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,10 +1,10 @@
-var analyzerConfig = {
+const analyzerConfig = {
 	queue: [ "wordCount", "keywordDensity", "subHeadings", "stopwords", "fleschReading", "linkCount", "imageCount", "urlKeyword", "urlLength", "metaDescriptionLength", "metaDescriptionKeyword", "pageTitleKeyword", "pageTitleLength", "firstParagraph", "urlStopwords", "keywordDoubles", "keyphraseSizeCheck" ],
 	stopWords: [ "a", "about", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "could", "did", "do", "does", "doing", "down", "during", "each", "few", "for", "from", "further", "had", "has", "have", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "it", "it's", "its", "itself", "let's", "me", "more", "most", "my", "myself", "nor", "of", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "she", "she'd", "she'll", "she's", "should", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "we", "we'd", "we'll", "we're", "we've", "were", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "would", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves" ],
 	wordsToRemove: [ " a", " in", " an", " on", " for", " the", " and" ],
 	maxSlugLength: 20,
 	maxUrlLength: 40,
-	maxMeta: 156
+	maxMeta: 155,
 };
 
-module.exports = analyzerConfig;
+export default analyzerConfig;

--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -185,11 +185,11 @@ function rateMetaDescLength( metaDescLength ) {
 
 	switch ( true ) {
 		case metaDescLength > 0 && metaDescLength < 120:
-		case metaDescLength > 320:
+		case metaDescLength > maximumMetaDescriptionLength:
 			rating = "ok";
 			break;
 
-		case metaDescLength >= 120 && metaDescLength <= 320:
+		case metaDescLength >= 120 && metaDescLength <= maximumMetaDescriptionLength:
 			rating = "good";
 			break;
 
@@ -692,8 +692,9 @@ SnippetPreview.prototype.formatMeta = function() {
 
 /**
  * Generates a meta description with an educated guess based on the passed text and excerpt.
- * It uses the keyword to select an appropriate part of the text. If the keyword isn't present it takes the first
- * 320 characters of the text. If both the keyword, text and excerpt are empty this function returns the sample text.
+ * It uses the keyword to select an appropriate part of the text. If the keyword isn't present it takes the maximum
+ * meta description length of the text. If both the keyword, text and excerpt are empty this function returns the
+ * sample text.
  *
  * @returns {string} A generated meta description.
  */

--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -20,6 +20,8 @@ var SnippetPreviewToggler = require( "./snippetPreviewToggler" );
 
 var domManipulation = require( "./helpers/domManipulation.js" );
 
+import Config from "./config/config";
+
 var defaults = {
 	data: {
 		title: "",
@@ -48,7 +50,7 @@ var defaults = {
 };
 
 var titleMaxLength = 600;
-var metadescriptionMaxLength = 320;
+const MAXIMUM_META_DESCRIPTION_LENGTH = Config.maxMeta;
 
 var inputPreviewBindings = [
 	{
@@ -435,7 +437,7 @@ SnippetPreview.prototype.renderTemplate = function() {
 
 	if ( this.hasProgressSupport ) {
 		this.element.progress.title.max = titleMaxLength;
-		this.element.progress.metaDesc.max = metadescriptionMaxLength;
+		this.element.progress.metaDesc.max = MAXIMUM_META_DESCRIPTION_LENGTH;
 	} else {
 		forEach( this.element.progress, function( progressElement ) {
 			domManipulation.addClass( progressElement, "snippet-editor__progress--fallback" );
@@ -674,7 +676,7 @@ SnippetPreview.prototype.formatMeta = function() {
 	meta = stripHTMLTags( meta );
 
 	// Cut-off the meta description according to the maximum length
-	meta = meta.substring( 0, metadescriptionMaxLength );
+	meta = meta.substring( 0, MAXIMUM_META_DESCRIPTION_LENGTH );
 
 	if ( this.hasApp() && ! isEmpty( this.refObj.rawData.keyword ) ) {
 		meta = this.formatKeyword( meta );
@@ -712,7 +714,7 @@ SnippetPreview.prototype.getMetaText = function() {
 
 	metaText = stripHTMLTags( metaText );
 
-	return metaText.substring( 0, metadescriptionMaxLength );
+	return metaText.substring( 0, MAXIMUM_META_DESCRIPTION_LENGTH );
 };
 
 /**
@@ -864,13 +866,13 @@ SnippetPreview.prototype.checkTextLength = function( event ) {
 	switch ( event.currentTarget.id ) {
 		case "snippet_meta":
 			event.currentTarget.className = "desc";
-			if ( text.length > metadescriptionMaxLength ) {
+			if ( text.length > MAXIMUM_META_DESCRIPTION_LENGTH ) {
 				/* eslint-disable */
 				YoastSEO.app.snippetPreview.unformattedText.snippet_meta = event.currentTarget.textContent;
 				/* eslint-enable */
 				event.currentTarget.textContent = text.substring(
 					0,
-					metadescriptionMaxLength
+					MAXIMUM_META_DESCRIPTION_LENGTH
 				);
 			}
 			break;
@@ -929,7 +931,7 @@ SnippetPreview.prototype.validateFields = function() {
 	var metaDescription = getAnalyzerMetaDesc.call( this );
 	var title = getAnalyzerTitle.call( this );
 
-	if ( metaDescription.length > metadescriptionMaxLength ) {
+	if ( metaDescription.length > MAXIMUM_META_DESCRIPTION_LENGTH ) {
 		domManipulation.addClass( this.element.input.metaDesc, "snippet-editor__field--invalid" );
 	} else {
 		domManipulation.removeClass( this.element.input.metaDesc, "snippet-editor__field--invalid" );
@@ -967,7 +969,7 @@ SnippetPreview.prototype.updateProgressBars = function() {
 		this,
 		this.element.progress.metaDesc,
 		metaDescription.length,
-		metadescriptionMaxLength,
+		MAXIMUM_META_DESCRIPTION_LENGTH,
 		metaDescriptionRating
 	);
 };

--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -50,7 +50,7 @@ var defaults = {
 };
 
 var titleMaxLength = 600;
-const MAXIMUM_META_DESCRIPTION_LENGTH = Config.maxMeta;
+const maximumMetaDescriptionLength = Config.maxMeta;
 
 var inputPreviewBindings = [
 	{
@@ -437,7 +437,7 @@ SnippetPreview.prototype.renderTemplate = function() {
 
 	if ( this.hasProgressSupport ) {
 		this.element.progress.title.max = titleMaxLength;
-		this.element.progress.metaDesc.max = MAXIMUM_META_DESCRIPTION_LENGTH;
+		this.element.progress.metaDesc.max = maximumMetaDescriptionLength;
 	} else {
 		forEach( this.element.progress, function( progressElement ) {
 			domManipulation.addClass( progressElement, "snippet-editor__progress--fallback" );
@@ -676,7 +676,7 @@ SnippetPreview.prototype.formatMeta = function() {
 	meta = stripHTMLTags( meta );
 
 	// Cut-off the meta description according to the maximum length
-	meta = meta.substring( 0, MAXIMUM_META_DESCRIPTION_LENGTH );
+	meta = meta.substring( 0, maximumMetaDescriptionLength );
 
 	if ( this.hasApp() && ! isEmpty( this.refObj.rawData.keyword ) ) {
 		meta = this.formatKeyword( meta );
@@ -714,7 +714,7 @@ SnippetPreview.prototype.getMetaText = function() {
 
 	metaText = stripHTMLTags( metaText );
 
-	return metaText.substring( 0, MAXIMUM_META_DESCRIPTION_LENGTH );
+	return metaText.substring( 0, maximumMetaDescriptionLength );
 };
 
 /**
@@ -866,13 +866,13 @@ SnippetPreview.prototype.checkTextLength = function( event ) {
 	switch ( event.currentTarget.id ) {
 		case "snippet_meta":
 			event.currentTarget.className = "desc";
-			if ( text.length > MAXIMUM_META_DESCRIPTION_LENGTH ) {
+			if ( text.length > maximumMetaDescriptionLength ) {
 				/* eslint-disable */
 				YoastSEO.app.snippetPreview.unformattedText.snippet_meta = event.currentTarget.textContent;
 				/* eslint-enable */
 				event.currentTarget.textContent = text.substring(
 					0,
-					MAXIMUM_META_DESCRIPTION_LENGTH
+					maximumMetaDescriptionLength
 				);
 			}
 			break;
@@ -931,7 +931,7 @@ SnippetPreview.prototype.validateFields = function() {
 	var metaDescription = getAnalyzerMetaDesc.call( this );
 	var title = getAnalyzerTitle.call( this );
 
-	if ( metaDescription.length > MAXIMUM_META_DESCRIPTION_LENGTH ) {
+	if ( metaDescription.length > maximumMetaDescriptionLength ) {
 		domManipulation.addClass( this.element.input.metaDesc, "snippet-editor__field--invalid" );
 	} else {
 		domManipulation.removeClass( this.element.input.metaDesc, "snippet-editor__field--invalid" );
@@ -969,7 +969,7 @@ SnippetPreview.prototype.updateProgressBars = function() {
 		this,
 		this.element.progress.metaDesc,
 		metaDescription.length,
-		MAXIMUM_META_DESCRIPTION_LENGTH,
+		maximumMetaDescriptionLength,
 		metaDescriptionRating
 	);
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Maximum meta description length has been changed from `320` to `156`.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Create a string of 156 characters.
Example:
`This is what the page might look like on a Google search result page. This is what the page might look like on a Google search result page. This is what the`
* Test if the length is still perceived as `good`.
* Add some characters. Check if the following SEO assessment is given: `The meta description is over 156 characters. Reducing the length will ensure the entire description will be visible.`

Fixes #1496 
