### PR TITLE
Add titleWidth to rawData in app.js to be used by the title width assessment

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ var Researcher = require( "./researcher.js" );
 var AssessorPresenter = require( "./renderers/AssessorPresenter.js" );
 var Pluggable = require( "./pluggable.js" );
 var Paper = require( "./values/Paper.js" );
+import { measureTextWidth } from "./helpers/createMeasurementElement.js";
 
 var removeHtmlBlocks = require( "./stringProcessing/htmlParser.js" );
 
@@ -485,6 +486,8 @@ App.prototype.getData = function() {
 		this.rawData.metaTitle = this.pluggable._applyModifications( "data_page_title", this.rawData.metaTitle );
 		this.rawData.meta = this.pluggable._applyModifications( "data_meta_desc", this.rawData.meta );
 	}
+
+	this.rawData.titleWidth = measureTextWidth( this.rawData.metaTitle );
 
 	this.rawData.locale = this.config.locale;
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added the title width to rawData in app.js to be used by the title width assessment.

## Relevant technical choices:

## Test instructions

This PR can be tested by following these steps:

* Link this branch to `release/7.6` of `wordpress-seo`.

For https://github.com/Yoast/wordpress-seo/issues/9768: 
* Set some template variables for the title in your settings (you most likely already have them set).
* Create a new post. The SEO analysis should not show "Please create an SEO title" but something that is based on the length of your SEO title.
* The borders of the progress bar color (green, orange, red) should exactly be the same as the borders between the green, orange and red bullets. 
* When you manually remove the entire snippet title, "Please create an SEO title" should be shown. 

For https://github.com/Yoast/wordpress-seo/issues/9770:
* Put some replacevars in your title, including %%title%%.
* Change the length of the WordPress title (the one above your post, not the one in the snippet editor). Both the progress bar in the snippet editor, as well as the feedback in the analysis should change when you reach a specific title width. In short: the replace vars should be parsed before the title width is calculated for the progress bar and analysis.

Fixes https://github.com/Yoast/wordpress-seo/issues/9770
Fixes https://github.com/Yoast/wordpress-seo/issues/9768