### PR TITLE
Fix translations bug

### DIFF
--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -1,4 +1,4 @@
-const FleschReadingAssessment = require ( "../../js/assessments/readability/fleschReadingEaseAssessment.js" );
+const FleschReadingAssessment = require( "../../js/assessments/readability/fleschReadingEaseAssessment.js" );
 let Paper = require( "../../js/values/Paper.js" );
 
 const factory = require( "../helpers/factory.js" );

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -1,7 +1,6 @@
 let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let Assessment = require( "../../assessment.js" );
 const inRange = require( "lodash/inRange" );
-const isEmpty = require( "lodash/isEmpty" );
 
 const getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 
@@ -27,15 +26,16 @@ class FleschReadingEaseAssessment extends Assessment {
 	 * @param {Object} paper The paper to run this assessment on.
 	 * @param {Object} researcher The researcher used for the assessment.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
+	 *
 	 * @returns {Object} An assessmentResult with the score and formatted text.
 	 */
 	getResult( paper, researcher, i18n ) {
 		this.fleschReadingResult = researcher.getResearch( "calculateFleschReading" );
 		if ( this.isApplicable( paper ) ) {
-			let assessmentResult =  new AssessmentResult();
-			const calculatedResult = this.calculateResult();
+			let assessmentResult =  new AssessmentResult( i18n );
+			const calculatedResult = this.calculateResult( i18n );
 			assessmentResult.setScore( calculatedResult.score );
-			assessmentResult.setText( this.translateScore( calculatedResult.resultText, calculatedResult.note, i18n ) );
+			assessmentResult.setText( calculatedResult.resultText );
 
 			return assessmentResult;
 		}
@@ -44,67 +44,88 @@ class FleschReadingEaseAssessment extends Assessment {
 
 	/**
 	 * Calculates the assessment result based on the fleschReadingScore.
-	 * @returns {Object} Object with score, resultText and note.
-	 */
-	calculateResult() {
-		if ( this.fleschReadingResult > this._config.borders.veryEasy ) {
-			return this._config.veryEasy;
-		}
-
-		if ( inRange( this.fleschReadingResult, this._config.borders.easy, this._config.borders.veryEasy ) ) {
-			return this._config.easy;
-		}
-
-		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyEasy, this._config.borders.easy ) ) {
-			return this._config.fairlyEasy;
-		}
-
-		if ( inRange( this.fleschReadingResult, this._config.borders.okay, this._config.borders.fairlyEasy ) ) {
-			return this._config.okay;
-		}
-
-		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyDifficult, this._config.borders.okay ) ) {
-			return this._config.fairlyDifficult;
-		}
-
-		if ( inRange( this.fleschReadingResult, this._config.borders.difficult, this._config.borders.fairlyDifficult ) ) {
-			return this._config.difficult;
-		}
-
-		return this._config.veryDifficult;
-	}
-
-	/**
-	 * Translates the FleschReading score into a specific feedback text.
 	 *
-	 * @param {string} resultText The feedback for a range of Flesch reading results from the config.
-	 * @param {string} noteText The note for a range of Flesch reading results from the config.
 	 * @param {Object} i18n The i18n-object used for parsing translations.
-	 * @returns {string} text Feedback text.
+	 *
+	 * @returns {Object} Object with score and resultText.
 	 */
-	translateScore( resultText, noteText, i18n ) {
-		/* Translators: %1$s expands to the numeric flesch reading ease score, %2$s to a link to a Yoast.com article about Flesch ease reading score,
-		 %3$s to the easyness of reading, %4$s expands to a note about the flesch reading score. */
-		let text = i18n.dgettext( "js-text-analysis", "The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s" );
-		const feedback = i18n.dgettext( "js-text-analysis", resultText );
-		const url = "<a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a>";
-
-		let note = "";
-		if ( ! isEmpty( noteText ) ) {
-			note = i18n.dgettext( "js-text-analysis", noteText );
-		}
-
+	calculateResult( i18n ) {
 		// Results must be between 0 and 100;
 		if ( this.fleschReadingResult < 0 ) {
 			this.fleschReadingResult = 0;
 		}
+
 		if ( this.fleschReadingResult > 100 ) {
 			this.fleschReadingResult = 100;
 		}
 
-		text = i18n.sprintf( text, this.fleschReadingResult, url, feedback, note );
+		/* Translators: %1$s expands to the numeric Flesch reading ease score,
+		%2$s to a link to a Yoast.com article about Flesch reading ease score,
+		%3$s to the easyness of reading,
+		%4$s expands to a note about the flesch reading score. */
+		let text = i18n.dgettext(
+			"js-text-analysis",
+			"The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s"
+		);
 
-		return text;
+		const url = "<a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a>";
+
+		if ( this.fleschReadingResult > this._config.borders.veryEasy ) {
+			const feedback = i18n.dgettext( "js-text-analysis", "very easy" );
+			return {
+				score: this._config.scores.veryEasy,
+				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.easy, this._config.borders.veryEasy ) ) {
+			const feedback = i18n.dgettext( "js-text-analysis", "easy" );
+			return {
+				score: this._config.scores.easy,
+				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyEasy, this._config.borders.easy ) ) {
+			const feedback = i18n.dgettext( "js-text-analysis", "fairly easy" );
+			return {
+				score: this._config.scores.fairlyEasy,
+				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.okay, this._config.borders.fairlyEasy ) ) {
+			const feedback = i18n.dgettext( "js-text-analysis", "ok" );
+			return {
+				score: this._config.scores.okay,
+				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyDifficult, this._config.borders.okay ) ) {
+			const feedback = i18n.dgettext( "js-text-analysis", "fairly difficult" );
+			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences to improve readability." );
+			return {
+				score: this._config.scores.fairlyDifficult,
+				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, note ),
+			};
+		}
+
+		if ( inRange( this.fleschReadingResult, this._config.borders.difficult, this._config.borders.fairlyDifficult ) ) {
+			const feedback = i18n.dgettext( "js-text-analysis", "difficult" );
+			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." );
+			return {
+				score: this._config.scores.difficult,
+				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, note ),
+			};
+		}
+
+		const feedback = i18n.dgettext( "js-text-analysis", "very difficult" );
+		const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." );
+		return {
+			score: this._config.scores.veryDifficult,
+			resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, note ),
+		};
 	}
 
 	/**
@@ -117,7 +138,6 @@ class FleschReadingEaseAssessment extends Assessment {
 		const isLanguageAvailable = getLanguageAvailability( paper.getLocale(), availableLanguages );
 		return ( isLanguageAvailable && paper.hasText() );
 	}
-
 }
 
 module.exports = FleschReadingEaseAssessment;

--- a/src/config/content/default.js
+++ b/src/config/content/default.js
@@ -1,3 +1,4 @@
+
 module.exports = {
 	sentenceLength: {
 		recommendedWordCount: 20,
@@ -14,40 +15,14 @@ module.exports = {
 			difficult: 30,
 			veryDifficult: 0,
 		},
-		veryEasy: {
-			score: 9,
-			resultText: "very easy",
-			note: "",
-		},
-		easy: {
-			score: 9,
-			resultText: "easy",
-			note: "",
-		},
-		fairlyEasy: {
-			score: 9,
-			resultText: "fairly easy",
-			note: "",
-		},
-		okay: {
-			score: 9,
-			resultText: "ok",
-			note: "",
-		},
-		fairlyDifficult: {
-			score: 6,
-			resultText: "fairly difficult",
-			note: "Try to make shorter sentences to improve readability.",
-		},
-		difficult: {
-			score: 3,
-			resultText: "difficult",
-			note: "Try to make shorter sentences, using less difficult words to improve readability.",
-		},
-		veryDifficult: {
-			score: 3,
-			resultText: "very difficult",
-			note: "Try to make shorter sentences, using less difficult words to improve readability.",
+		scores:{
+			veryEasy: 9,
+			easy: 9,
+			fairlyEasy: 9,
+			okay: 9,
+			fairlyDifficult: 6,
+			difficult: 3,
+			veryDifficult: 3,
 		},
 	},
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where translation strings with feedback were not translated by 100%.

## Relevant technical choices:

* n/a

## Test instructions

This PR can be tested by following these steps:

* Use the beta script to create an RC of the branch (use "trunk" as plugin branch and "stories/1507-fix-flesch-translations" as YoastSEO.js branch)
* Write a very simple text in any language but Russian.
* Make sure the Flesch Reading score appears and makes sense.
* Check if translation strings are correct for various text complexity and various languages.
* Switch to Russian.
* Try getting a text that scores between 50 and 60 in Flesch Reading assessment. It should get an orange bullet and an "ok" feedback.

Fixes #1507
