### PR TITLE
Add Spanish Flesch reading ease assessment 

### DIFF
--- a/spec/researches/calculateFleschReadingSpec.js
+++ b/spec/researches/calculateFleschReadingSpec.js
@@ -59,6 +59,13 @@ describe( "A test that uses the Russian Flesch Reading", function() {
 	} );
 } );
 
+describe( "A test that uses the Spanish Flesch Reading", function() {
+	it( "returns a score", function() {
+		var mockPaper = new Paper( "Existen seis subespecies de tigre, de las cuales la de Bengala es la más numerosa.", { locale: "es_ES" } );
+		expect( fleschFunction( mockPaper ) ).toBe( 83.5 );
+	} );
+} );
+
 describe( "A test that returns 0 after sentence formatting", function() {
 	it( "returns a score of 0", function() {
 		var mockPaper = new Paper( "()" );

--- a/spec/stringProcessing/syllables/countSpanishSpec.js
+++ b/spec/stringProcessing/syllables/countSpanishSpec.js
@@ -1,0 +1,142 @@
+let countSyllableFunction = require( "../../../js/stringProcessing/syllables/count.js" );
+
+describe( "a syllable counter for Spanish text strings", function() {
+	it( "returns the number of syllables of words containing the add syllable i[ií]", function() {
+		expect( countSyllableFunction( "chiita", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "chií", "es_ES" ) ).toBe( 2 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable [íú][aeo]", function() {
+		expect( countSyllableFunction( "astrología", "es_ES" ) ).toBe( 5 );
+		expect( countSyllableFunction( "hematíe", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "avío", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "búa", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "lúe", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "avalúo", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable o[aáeéíóú]", function() {
+		expect( countSyllableFunction( "anoa", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "coágulo", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "aloe", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "poética", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "egoísmo", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "oósfera", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "noúmeno", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable uu", function() {
+		expect( countSyllableFunction( "duunvir", "es_ES" ) ).toBe( 3 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable flu[iea]", function() {
+		expect( countSyllableFunction( "fluir", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "afluente", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable ru[ie]", function() {
+		expect( countSyllableFunction( "ruido", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "prueba", "es_ES" ) ).toBe( 3 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable eio", function() {
+		expect( countSyllableFunction( "meiosis", "es_ES" ) ).toBe( 3 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable eu[aá]", function() {
+		expect( countSyllableFunction( "cleuasmo", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "fideuá", "es_ES" ) ).toBe( 3 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable oi[aó]", function() {
+		expect( countSyllableFunction( "paranoia", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "termoiónico", "es_ES" ) ).toBe( 5 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable [iu]ei", function() {
+		expect( countSyllableFunction( "vieira", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "queimada", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable ui[éu]", function() {
+		expect( countSyllableFunction( "quién", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "braquiuro", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable ui[éu]", function() {
+		expect( countSyllableFunction( "quién", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "braquiuro", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable ^anti[aeoá]", function() {
+		expect( countSyllableFunction( "antiaéreo", "es_ES" ) ).toBe( 6 );
+		expect( countSyllableFunction( "antieconómico", "es_ES" ) ).toBe( 7 );
+		expect( countSyllableFunction( "antioquia", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "antiácido", "es_ES" ) ).toBe( 5 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable ^zoo", function() {
+		expect( countSyllableFunction( "zoológico", "es_ES" ) ).toBe( 5 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable coo", function() {
+		expect( countSyllableFunction( "cooperación", "es_ES" ) ).toBe( 5 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable microo", function() {
+		expect( countSyllableFunction( "microondas", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable [eéó][aáeéíoóú]", function() {
+		expect( countSyllableFunction( "agrear", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "teátrico", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "creer", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "feérico", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "proteína", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "aseo", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "anteón", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "feúra", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "océano", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "nucléolo", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "bóer", "es_ES" ) ).toBe( 2 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable [aáü][aáeéiíoóú]", function() {
+		expect( countSyllableFunction( "contraataque", "es_ES" ) ).toBe( 5 );
+		expect( countSyllableFunction( "abaá", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "caer", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "aéreo", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "aire", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "maíz", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "cacao", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "faraón", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "baúl", "es_ES" ) ).toBe( 2 );
+		expect( countSyllableFunction( "afrikáans", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "arráez", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "bonsái", "es_ES" ) ).toBe( 3 );
+		expect( countSyllableFunction( "agüela", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "aconcagüino", "es_ES" ) ).toBe( 6 );
+		expect( countSyllableFunction( "güérmeces", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable eoi", function() {
+		expect( countSyllableFunction( "geoide", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable oeu", function() {
+		expect( countSyllableFunction( "indoeuropeo", "es_ES" ) ).toBe( 7 );
+	} );
+
+	it( "returns the number of syllables of words containing the add syllable [eu]au", function() {
+		expect( countSyllableFunction( "meauca", "es_ES" ) ).toBe( 4 );
+		expect( countSyllableFunction( "aguaucle", "es_ES" ) ).toBe( 4 );
+	} );
+
+	it( "returns the number of syllables of words from the exclusion full words list", function() {
+		expect( countSyllableFunction( "y, scooter, via, beat, ok", "es_ES" ) ).toBe( 8 );
+	} );
+
+	it( "returns the number of syllables of words containing words from the global fragments", function() {
+		expect( countSyllableFunction( "business, free, nouveau, training", "es_ES" ) ).toBe( 7 );
+	} );
+} );

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -5,7 +5,7 @@ const isEmpty = require( "lodash/isEmpty" );
 
 const getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 
-const availableLanguages = [ "en", "nl", "de", "it", "ru" ];
+const availableLanguages = [ "en", "nl", "de", "it", "ru", "es" ];
 
 class FleschReadingEaseAssessment extends Assessment {
 	/**

--- a/src/config/syllables.js
+++ b/src/config/syllables.js
@@ -8,8 +8,9 @@ let en = require( './syllables/en.json' );
 let nl = require( './syllables/nl.json' );
 let it = require( './syllables/it.json' );
 let ru = require( './syllables/ru.json' );
+let es = require( './syllables/es.json' );
 
-let languages = { de, nl, en, it, ru };
+let languages = { de, nl, en, it, ru, es };
 
 module.exports = function( locale = "en_US" ) {
 	let language = getLanguage( locale );

--- a/src/config/syllables/es.json
+++ b/src/config/syllables/es.json
@@ -1,0 +1,176 @@
+{
+  "vowels": "aeiouáéíóúü",
+  "deviations": {
+    "vowels": [
+      {
+        "fragments": [
+          "i[ií]",
+          "[íú][aeo]",
+          "o[aáeéíóú]",
+          "uu",
+          "flu[iea]",
+          "ru[ie]",
+          "eio",
+          "eu[aá]",
+          "oi[aó]",
+          "[iu]ei",
+          "ui[éu]",
+          "^anti[aeoá]",
+          "^zoo",
+          "coo",
+          "microo"
+        ],
+        "countModifier": 1
+      },
+      {
+        "fragments": [
+          "[eéó][aáeéíoóú]"
+        ],
+        "countModifier": 1
+      },
+      {
+        "fragments": [
+          "[aáü][aáeéiíoóú]",
+          "eoi",
+          "oeu",
+          "[eu]au"
+        ],
+        "countModifier": 1
+      }
+    ],
+    "words": {
+      "full": [
+        {
+          "word": "scooter",
+          "syllables": 2
+        },
+        {
+          "word": "y",
+          "syllables": 1
+        },
+        {
+          "word": "beat",
+          "syllables": 1
+        },
+        {
+          "word": "via",
+          "syllables": 2
+        },
+        {
+          "word": "ok",
+          "syllables": 2
+        }
+      ],
+      "fragments": {
+        "global": [
+          {
+            "word": "business",
+            "syllables": 2
+          },
+          {
+            "word": "coach",
+            "syllables": 1
+          },
+          {
+            "word": "reggae",
+            "syllables": 2
+          },
+          {
+            "word": "mail",
+            "syllables": 1
+          },
+          {
+            "word": "airbag",
+            "syllables": 2
+          },
+          {
+            "word": "affaire",
+            "syllables": 2
+          },
+          {
+            "word": "training",
+            "syllables": 2
+          },
+          {
+            "word": "hawaian",
+            "syllables": 3
+          },
+          {
+            "word": "saharaui",
+            "syllables": 3
+          },
+          {
+            "word": "nouveau",
+            "syllables": 2
+          },
+          {
+            "word": "chapeau",
+            "syllables": 2
+          },
+          {
+            "word": "free",
+            "syllables": 1
+          },
+          {
+            "word": "green",
+            "syllables": 1
+          },
+          {
+            "word": "jeep",
+            "syllables": 1
+          },
+          {
+            "word": "toffee",
+            "syllables": 2
+          },
+          {
+            "word": "tweet",
+            "syllables": 1
+          },
+          {
+            "word": "tweed",
+            "syllables": 1
+          },
+          {
+            "word": "semiautomátic",
+            "syllables": 6
+          },
+          {
+            "word": "estadou",
+            "syllables": 4
+          },
+          {
+            "word": "broadway",
+            "syllables": 2
+          },
+          {
+            "word": "board",
+            "syllables": 1
+          },
+          {
+            "word": "load",
+            "syllables": 1
+          },
+          {
+            "word": "roaming",
+            "syllables": 2
+          },
+          {
+            "word": "heavy",
+            "syllables": 2
+          },
+          {
+            "word": "break",
+            "syllables": 1
+          }
+        ]
+      }
+    }
+  }
+}
+
+
+
+
+
+

--- a/src/researches/calculateFleschReading.js
+++ b/src/researches/calculateFleschReading.js
@@ -62,6 +62,9 @@ module.exports = function( paper ) {
 		case "ru":
 			score = 206.835 - ( 1.3 * numberOfWords / numberOfSentences ) - ( 60.1 * numberOfSyllables / numberOfWords );
 			break;
+		case "es":
+			score = 206.84 - ( 1.02 * numberOfWords / numberOfSentences ) - ( 0.6 * syllablesPer100Words );
+			break;
 		case "en":
 		default:
 			score = 206.835 - ( 1.015 * ( averageWordsPerSentence ) ) - ( 84.6 * ( numberOfSyllables / numberOfWords ) );

--- a/src/stringProcessing/syllables/count.js
+++ b/src/stringProcessing/syllables/count.js
@@ -172,8 +172,7 @@ var countSyllablesInText = function( text, locale ) {
 	var syllableCounts = map( words,  function( word ) {
 		return countSyllablesInWord( word, locale );
 	} );
-
-	console.log( sum(syllableCounts) );
+	
 	return sum( syllableCounts );
 };
 

--- a/src/stringProcessing/syllables/count.js
+++ b/src/stringProcessing/syllables/count.js
@@ -173,6 +173,7 @@ var countSyllablesInText = function( text, locale ) {
 		return countSyllablesInWord( word, locale );
 	} );
 
+	console.log( sum(syllableCounts) );
 	return sum( syllableCounts );
 };
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Adds Flesch reading ease assessment for Spanish.

## Test instructions
This PR can be tested by following these steps:

**Browserified**

* Checkout the branch
* Run yarn install followed by grunt build:js.
* Open the browserified example in examples/browserified/index.html.
* Set locale to Spanish (es_ES).
* Write a Spanish text.
* Determine whether the Flesch Reading score appears or not (it should).

**WordPress**

* In your WordPress SEO testing environment, ensure you've already run yarn install once in the plugin's directory.
* Run yarn add "git+https://github.com/Yoast/yoastseo.js#stories/1508-add-Spanish-Flesch-reading-ease" in the plugin's directory.
* Navigate to node_modules/yoastseo and run yarn install and grunt build:js.
* Navigate back to the plugin's directory and run grunt build:js.
* In your testing environment, set the language to Spanish.
* Write a Spanish text.
* Determine whether the Flesch Reading score appears or not (it should).

Fixes #1508
