### PR TITLE
Add font styling to hidden input

### DIFF
--- a/src/helpers/createMeasurementElement.js
+++ b/src/helpers/createMeasurementElement.js
@@ -16,6 +16,9 @@ const createMeasurementElement = function() {
 	hiddenElement.style.top = 0;
 	hiddenElement.style.height = 0;
 	hiddenElement.style.overflow = "hidden";
+	hiddenElement.style.fontFamily = "Arial";
+	hiddenElement.style.fontSize = "16px";
+	hiddenElement.style.fontWeight = "400";
 
 	document.body.appendChild( hiddenElement );
 	return hiddenElement;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds font styles to hidden input field to correctly measure the title width.

## Relevant technical choices:

* I've used the font size, weight and family from the snippet preview to hidden input field to correctly measure the title width.

## Test instructions

This PR can be tested by following these steps:

* Link `yoastseo.js` (stories/9770-get-correct-title-width) and `yoast-components` (the feature branch) to `wordpress-seo` (the feature branch).
* Add `console.log(titleLengthProgress.actual)` to the render method in `composites/Plugin/SnippetEditor/components/SnippetEditor.js` of `yoast-components` to log the title width in pixels.
* Look in the HTML whether the `yoast-measurement-element` has the following styling:
```
fontFamily = "Arial";
fontSize = "16px";
fontWeight = "400";
```
Fixes https://github.com/Yoast/wordpress-seo/issues/9854
