### PR TITLE
Filter prominent word combinations ending with 's

### DIFF
--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -11,7 +11,6 @@ let filterFunctionWordsAnywhere = relevantWords.filterFunctionWordsAnywhere;
 let filterOneCharacterWordCombinations = relevantWords.filterOneCharacterWordCombinations;
 let filterOnDensity = relevantWords.filterOnDensity;
 let filterEndingWith = relevantWords.filterEndingWith;
-let filterStartingWith = relevantWords.filterStartingWith;
 let englishFunctionWords = require( "../../js/researches/english/functionWords.js" )().all;
 
 describe( "getWordCombinations", function() {
@@ -283,24 +282,7 @@ describe( "filter one-letter words in word combinations", function() {
 	} );
 } );
 
-
-describe( "filter word combinations based on what string it starts with but with specified exceptions", function() {
-	it( "filters word combinations that start with you but not word combinations that start with you are", function() {
-		let input = [
-			new WordCombination( [ "you", "do", "you" ] ),
-			new WordCombination( [ "you", "are", "awesome" ] ),
-			new WordCombination( [ "who", "are", "you" ] ),
-		];
-		let expected = [
-			new WordCombination( [ "you", "are", "awesome" ] ),
-			new WordCombination( [ "who", "are", "you" ] ),
-		];
-		let combinations = filterStartingWith( input, "you", [ "you are" ] );
-		expect( combinations ).toEqual( expected );
-	} );
-} );
-
-describe( "filter word combinations based on what string it end with but with specified exceptions", function() {
+describe( "filter word combinations based on what string they end with but with specified exceptions", function() {
 	it( "filters word combinations that end with you but not word combinations that start with are you", function() {
 		let input = [
 			new WordCombination( [ "you", "do", "you" ] ),

--- a/spec/stringProcessing/relevantWordsSpec.js
+++ b/spec/stringProcessing/relevantWordsSpec.js
@@ -284,39 +284,37 @@ describe( "filter one-letter words in word combinations", function() {
 } );
 
 
-describe("filter word combinations based on what string it starts with but with specified exceptions", function(){
-	it ( "filters word combinations that start with you but not word combinations that start with you are" , function(){
+describe( "filter word combinations based on what string it starts with but with specified exceptions", function() {
+	it( "filters word combinations that start with you but not word combinations that start with you are", function() {
 		let input = [
-			new WordCombination (["you","do","you"]),
-			new WordCombination (["you","are","awesome"]),
-			new WordCombination (["who","are","you"]),
+			new WordCombination( [ "you", "do", "you" ] ),
+			new WordCombination( [ "you", "are", "awesome" ] ),
+			new WordCombination( [ "who", "are", "you" ] ),
 		];
 		let expected = [
-			new WordCombination (["you","are","awesome"]),
-			new WordCombination (["who","are","you"]),
+			new WordCombination( [ "you", "are", "awesome" ] ),
+			new WordCombination( [ "who", "are", "you" ] ),
 		];
-		let combinations = filterStartingWith(input, "you", ["you are"]);
+		let combinations = filterStartingWith( input, "you", [ "you are" ] );
 		expect( combinations ).toEqual( expected );
-	});
-	
-});
+	} );
+} );
 
-describe("filter word combinations based on what string it end with but with specified exceptions", function(){
-	it ( "filters word combinations that end with you but not word combinations that start with are you" , function(){
+describe( "filter word combinations based on what string it end with but with specified exceptions", function() {
+	it( "filters word combinations that end with you but not word combinations that start with are you", function() {
 		let input = [
-			new WordCombination (["you","do","you"]),
-			new WordCombination (["you","are","awesome"]),
-			new WordCombination (["who","are","you"]),
+			new WordCombination( [ "you", "do", "you" ] ),
+			new WordCombination( [ "you", "are", "awesome" ] ),
+			new WordCombination( [ "who", "are", "you" ] ),
 		];
 		let expected = [
-			new WordCombination (["you","are","awesome"]),
-			new WordCombination (["who","are","you"]),
+			new WordCombination( [ "you", "are", "awesome" ] ),
+			new WordCombination( [ "who", "are", "you" ] ),
 		];
-		let combinations = filterEndingWith(input, "you", ["are you"]);
+		let combinations = filterEndingWith( input, "you", [ "are you" ] );
 		expect( combinations ).toEqual( expected );
-	});
-	
-});
+	} );
+} );
 
 describe( "getRelevantWords", function() {
 	it( "uses the default (English) function words in case of a unknown locale", function() {

--- a/src/stringProcessing/relevantWords.js
+++ b/src/stringProcessing/relevantWords.js
@@ -263,12 +263,16 @@ function filterFunctionWords( combinations, functionWords ) {
  *
  * @param {Array} combinations The list of word combination objects.
  * @param {Function} functionWords The function containing the lists of function words.
+ * @param {string} language The language for which specific filters should be applied.
  * @returns {Array} The filtered list of word combination objects.
  */
-function filterCombinations( combinations, functionWords ) {
+function filterCombinations( combinations, functionWords, language ) {
 	combinations = filterFunctionWordsAnywhere( combinations, specialCharacters );
 	combinations = filterOneCharacterWordCombinations( combinations );
 	combinations = filterFunctionWords( combinations, functionWords );
+	if( language === "en" ) {
+		combinations = filterEndingWith( combinations, "'s", [] );
+	}
 	return combinations;
 }
 /**
@@ -314,13 +318,13 @@ function getRelevantWords( text, locale ) {
 		fiveWordCombinations
 	);
 
-	combinations = filterCombinations( combinations, functionWords );
+	combinations = filterCombinations( combinations, functionWords, language );
 
 	forEach( combinations, function( combination ) {
 		combination.setRelevantWords( oneWordRelevanceMap );
 	} );
 
-	combinations = getRelevantCombinations( combinations, wordCount );
+	combinations = getRelevantCombinations( combinations );
 	sortCombinations( combinations );
 
 	if ( wordCount >= wordCountLowerLimit ) {

--- a/src/stringProcessing/relevantWords.js
+++ b/src/stringProcessing/relevantWords.js
@@ -209,10 +209,7 @@ function filterEndingWith( wordCombinations, str, exceptions ) {
 				return true;
 			}
 		}
-		if ( combinationstr.endsWith( str ) ) {
-			return false;
-		}
-		return true;
+		return ! combinationstr.endsWith( str );
 	} );
 	return wordCombinations;
 }

--- a/src/stringProcessing/relevantWords.js
+++ b/src/stringProcessing/relevantWords.js
@@ -347,5 +347,5 @@ module.exports = {
 	filterOnDensity: filterOnDensity,
 	filterOneCharacterWordCombinations: filterOneCharacterWordCombinations,
 	filterStartingWith: filterStartingWith,
-	filterEndingWith: filterEndingWith
+	filterEndingWith: filterEndingWith,
 };

--- a/src/stringProcessing/relevantWords.js
+++ b/src/stringProcessing/relevantWords.js
@@ -194,30 +194,6 @@ function filterOnDensity( wordCombinations, wordCount, densityLowerLimit, densit
 }
 
 /**
- * Filters combinations based on whether they start with a specified string or not.
- *
- * @param {WordCombination[]} wordCombinations The array of WordCombinations to filter.
- * @param {string} str The string the WordCombinations that need to be filtered out start with.
- * @param {string[]} exceptions The array of strings containing exceptions to not filter.
- * @returns {WordCombination[]} The filtered array of WordCombinations.
- */
-function filterStartingWith( wordCombinations, str, exceptions ) {
-	wordCombinations = wordCombinations.filter( function( combination ) {
-		let combinationstr = combination.getCombination();
-		for ( let i = 0; i < exceptions.length; i++ ) {
-			if ( combinationstr.startsWith( exceptions[ i ] ) ) {
-				return true;
-			}
-		}
-		if ( combinationstr.startsWith( str ) ) {
-			return false;
-		}
-		return true;
-	} );
-	return wordCombinations;
-}
-
-/**
  * Filters combinations based on whether they end with a specified string or not.
  *
  * @param {WordCombination[]} wordCombinations The array of WordCombinations to filter.
@@ -346,6 +322,5 @@ module.exports = {
 	filterFunctionWordsAnywhere: filterFunctionWordsAnywhere,
 	filterOnDensity: filterOnDensity,
 	filterOneCharacterWordCombinations: filterOneCharacterWordCombinations,
-	filterStartingWith: filterStartingWith,
 	filterEndingWith: filterEndingWith,
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a filter to remove prominent word combinations ending in 's in English. Props to @swekkiekekkie

## Test instructions

This PR can be tested by following these steps:

### Browserified
* Check out this branch and run `grunt build:js`.
* Open the browserified relevant words example.
* Enter a text that contains a word combination ending in `'s`, e.g.:
```
Improve your site’s speed.
Improve your site’s design.
Improve your site’s functionality.
```
* Make sure no word combination ending in `'s` (e.g., `improve your site's`) shows up in the prominent words results.
* Switch the locale to another language and make sure combinations ending in `'s` show up again.

### WordPress
* Use the beta script to create a beta version of the plugin, combining `trunk` on WordPress SEO Premium and this branch on YoastSEO.js.
* Test the same functionality as described above.

Fixes #1103 
