### PR TITLE
Improve image assessment by checking how often the keyword is included in alt-tags

### DIFF
--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -1,24 +1,24 @@
-var ImageCountAssessment = require( "../../js/assessments/seo/textImagesAssessment" );
-var Paper = require( "../../js/values/Paper.js" );
-var Factory = require( "../helpers/factory.js" );
-var i18n = Factory.buildJed();
+const ImageCountAssessment = require( "../../js/assessments/seo/textImagesAssessment" );
+const Paper = require( "../../js/values/Paper.js" );
+const Factory = require( "../helpers/factory.js" );
+const i18n = Factory.buildJed();
 
 let imageCountAssessment = new ImageCountAssessment();
 
 describe( "An image count assessment", function() {
 	it( "assesses no images", function() {
-		var mockPaper = new Paper( "sample" );
+		const mockPaper = new Paper( "sample" );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "No images appear in this page, consider adding some as appropriate." );
 	} );
 
 	it( "assesses a single image, without a keyword and alt-tag set", function() {
-		var mockPaper = new Paper( "These are just five words <img src='image.jpg' />" );
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' />" );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
 			noAlt: 1,
 			withAlt: 0,
 			withAltKeyword: 0,
@@ -30,9 +30,9 @@ describe( "An image count assessment", function() {
 	} );
 
 	it( "assesses a single image, without a keyword, but with an alt-tag set", function() {
-		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' />" );
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' />" );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
 			noAlt: 0,
 			withAlt: 1,
 			withAltKeyword: 0,
@@ -40,66 +40,78 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The images on this page contain alt attributes." );
+		expect( assessment.getText() ).toEqual( "The images on this page contain alt attributes. Once you've set a focus keyword, also include the keyword where appropriate." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
-		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='keyword' />", {
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='keyword' />", {
 			keyword: "Sample",
 		} );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 0,
-			withAltKeyword: 0,
-			withAltNonKeyword: 1,
-		} ), i18n );
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 1,
+			},
+			imageCount: 1,
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "The images on this page do not have alt attributes containing the focus keyword." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword", function() {
-		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
 			keyword: "Sample",
 		} );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 0,
-			withAltKeyword: 1,
-			withAltNonKeyword: 0,
-		} ), i18n );
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 0,
+			},
+			imageCount: 1,
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
-		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
 			keyword: "Sample",
-		} );
+		}, true );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 0,
-			withAltKeyword: 1,
-			withAltNonKeyword: 1,
-		} ), i18n );
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 1,
+			},
+			imageCount: 1,
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
-		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
 			keyword: "Sample",
 		} );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 4,
-			withAlt: 0,
-			withAltKeyword: 1,
-			withAltNonKeyword: 1,
-		} ), i18n );
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			altTagCount: {
+				noAlt: 4,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 1,
+			},
+			imageCount: 1,
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 	} );

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -19,11 +19,32 @@ describe( "An image count assessment", function() {
 		const mockPaper = new Paper( "These are just five words <img src='image.jpg' />" );
 
 		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 1,
-			withAlt: 0,
-			withAltKeyword: 0,
-			withAltNonKeyword: 0,
-		} ), i18n );
+			altTagCount: {
+				noAlt: 1,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+		},
+			imageCount: 1,
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "The images on this page are missing alt attributes." );
+	} );
+
+	it( "assesses 5 images without a keyword and alt-tag set", function() {
+		const mockPaper = new Paper( "<img src='image.jpg' /><img src='image.jpg' /><img src='image.jpg' /><img src='image.jpg' />" +
+			"<img src='image.jpg' />" );
+
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			altTagCount: {
+				noAlt: 5,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			},
+			imageCount: 5,
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "The images on this page are missing alt attributes." );
@@ -33,11 +54,14 @@ describe( "An image count assessment", function() {
 		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' />" );
 
 		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 1,
-			withAltKeyword: 0,
-			withAltNonKeyword: 0,
-		} ), i18n );
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 1,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			},
+			imageCount: 1,
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "The images on this page contain alt attributes. Once you've set a focus keyword, don't forget to include it in alt attributes, where appropriate." );
@@ -57,12 +81,12 @@ describe( "An image count assessment", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "Only in 1 out of 6 images on this page contain alt attributes with the focus keyword. " +
+		expect( assessment.getText() ).toEqual( "Only 1 out of 6 images on this page contain alt attributes with the focus keyword. " +
 			"Where appropriate, try to include the focus keyword in more alt attributes." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
-		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='keyword' />", {
+		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='abc' />", {
 			keyword: "Sample",
 		} );
 
@@ -80,6 +104,26 @@ describe( "An image count assessment", function() {
 		expect( assessment.getText() ).toEqual( "The images on this page do not have alt attributes containing the focus keyword." );
 	} );
 
+	it( "assesses >5 images, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
+		const mockPaper = new Paper( "<img src='image.jpg' alt='abc' /><img src='image.jpg' alt='abc' />" +
+			"<img src='image.jpg' alt='abc' /><img src='image.jpg' alt='abc' /><img src='image.jpg' alt='abc' />" +
+			"<img src='image.jpg' alt='abc' />", {
+			keyword: "Sample",
+		} );
+
+		const assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 6,
+			},
+			imageCount: 6,
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "The images on this page do not have alt attributes containing the focus keyword." );
+	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
 		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -40,7 +40,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The images on this page contain alt attributes. Once you've set a focus keyword, also include the keyword where appropriate." );
+		expect( assessment.getText() ).toEqual( "The images on this page contain alt attributes. Once you've set a focus keyword, don't forget to include it in alt attributes, where appropriate." );
 	} );
 
 	it( "assesses images with too few keyword matches", function() {

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -1,3 +1,4 @@
+
 const ImageCountAssessment = require( "../../js/assessments/seo/textImagesAssessment" );
 const Paper = require( "../../js/values/Paper.js" );
 const Factory = require( "../helpers/factory.js" );
@@ -24,7 +25,7 @@ describe( "An image count assessment", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-		},
+			},
 			imageCount: 1,
 		}, true ), i18n );
 

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -68,7 +68,8 @@ class TextImagesAssessment extends Assessment {
 	 * with keywords is under the specified recommended minimum.
 	 */
 	hasTooFewMatches() {
-		return this.imageCount > 4 && this.altProperties.withAltKeyword < this._minNumberOfKeywordMatches;
+		return this.imageCount > 4 && this.altProperties.withAltKeyword > 0 &&
+			this.altProperties.withAltKeyword < this._minNumberOfKeywordMatches;
 	}
 
 	/**
@@ -137,8 +138,8 @@ class TextImagesAssessment extends Assessment {
 			};
 		}
 
-		// Image count < 5, has alt-tags, but no keywords while a keyword is set.
-		if ( this.imageCount < 5 && this.altProperties.withAltNonKeyword > 0 && this.altProperties.withAltKeyword === 0 ) {
+		// Has alt-tags, but no keywords while a keyword is set.
+		if ( this.altProperties.withAltNonKeyword > 0 && this.altProperties.withAltKeyword === 0 ) {
 			return {
 				score: this._config.scores.withAltNonKeyword,
 				resultText: i18n.dgettext(
@@ -157,7 +158,7 @@ class TextImagesAssessment extends Assessment {
 					 * %2$d expands to the total number of images. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"Only in %1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
+						"Only %1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
 						"Where appropriate, try to include the focus keyword in more alt attributes."
 					),
 					this.altProperties.withAltKeyword,

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -1,5 +1,6 @@
 let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let Assessment = require( "../../assessment.js" );
+const inRangeStartEndInclusive = require( "../../helpers/inRange.js" ).inRangeStartEndInclusive;
 let merge = require( "lodash/merge" );
 
 /**
@@ -17,9 +18,15 @@ class TextImagesAssessment extends Assessment {
 		super();
 
 		let defaultConfig = {
+			parameters: {
+				lowerBoundary: 0.3,
+				upperBoundary: 0.75,
+			},
 			scores: {
 				noImages: 3,
-				withAltKeyword: 9,
+				withAltGoodNumberOfKeywordMatches: 9,
+				withAltTooFewKeywordMatches: 6,
+				withAltTooManyKeywordMatches: 6,
 				withAltNonKeyword: 6,
 				withAlt: 6,
 				noAlt: 6,
@@ -43,12 +50,28 @@ class TextImagesAssessment extends Assessment {
 		let assessmentResult = new AssessmentResult();
 		this.imageCount = researcher.getResearch( "imageCount" );
 		this.altProperties = researcher.getResearch( "altTagCount" );
+		this._minNumberOfKeywordMatches = Math.ceil( this.imageCount * this._config.parameters.lowerBoundary );
+		this._maxNumberOfKeywordMatches = Math.floor( this.imageCount * this._config.parameters.upperBoundary );
 
 		const calculatedResult = this.calculateResult( i18n );
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
+	}
+
+	hasTooFewMatches() {
+		return this.imageCount > 4 && this.altProperties.withAltKeyword < this._minNumberOfKeywordMatches;
+	}
+
+	hasGoodNumberOfMatches() {
+		return ( ( this.imageCount < 5 && this.altProperties.withAltKeyword > 0 ) ||
+			( this.imageCount > 4 &&
+				inRangeStartEndInclusive( this.altProperties.withAltKeyword, this._minNumberOfKeywordMatches, this._maxNumberOfKeywordMatches ) ) );
+	}
+
+	hasTooManyMatches() {
+		return this.imageCount > 4 && this.altProperties.withAltKeyword > this._maxNumberOfKeywordMatches;
 	}
 
 	/**
@@ -80,19 +103,20 @@ class TextImagesAssessment extends Assessment {
 			};
 		}
 
-		// Has alt-tag and keywords
-		if ( this.altProperties.withAltKeyword > 0 ) {
+		// Has alt-tag, but no keyword is set.
+		if ( this.altProperties.withAlt > 0 ) {
 			return {
-				score: this._config.scores.withAltKeyword,
+				score: this._config.scores.withAlt,
 				resultText: i18n.dgettext(
 					"js-text-analysis",
-					"The images on this page contain alt attributes with the focus keyword."
+					"The images on this page contain alt attributes. " +
+					"Once you've set a focus keyword, also include the keyword where appropriate."
 				),
 			};
 		}
 
-		// Has alt-tag, but no keywords and it's not okay
-		if ( this.altProperties.withAltNonKeyword > 0 ) {
+		// Image count < 5, Has alt-tag, but no keywords and it's not okay.
+		if ( this.imageCount < 5 && this.altProperties.withAltNonKeyword > 0 && this.altProperties.withAltKeyword === 0 ) {
 			return {
 				score: this._config.scores.withAltNonKeyword,
 				resultText: i18n.dgettext(
@@ -102,16 +126,50 @@ class TextImagesAssessment extends Assessment {
 			};
 		}
 
-		// Has alt-tag, but no keyword is set
-		if ( this.altProperties.withAlt > 0 ) {
+		// Has alt-tag and keywords
+		if ( this.hasTooFewMatches() ) {
 			return {
-				score: this._config.scores.withAlt,
-				resultText: i18n.dgettext(
+				score: this._config.scores.withAltTooFewKeywordMatches,
+				resultText: i18n.sprintf( i18n.dgettext(
 					"js-text-analysis",
-					"The images on this page contain alt attributes."
+					"Only in %1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
+					"Where appropriate, try to include the focus keyword in more alt attributes."
+					),
+					this.altProperties.withAltKeyword,
+					this.imageCount
 				),
 			};
 		}
+
+		if ( this.hasGoodNumberOfMatches() ) {
+			return {
+				score: this._config.scores.withAltGoodNumberOfKeywordMatches,
+				resultText: i18n.sprintf( i18n.dngettext(
+					"js-text-analysis",
+					"The image on this page contains an alt attribute with the focus keyword.",
+					"%1$d out of %2$d images on this page contain alt attributes with the focus keyword.",
+					this.imageCount
+					),
+					this.altProperties.withAltKeyword,
+					this.imageCount
+				),
+			};
+		}
+
+		if ( this.hasTooManyMatches() ) {
+			return {
+				score: this._config.scores.withAltTooFewKeywordMatches,
+				resultText: i18n.sprintf( i18n.dgettext(
+					"js-text-analysis",
+					"%1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
+					"That's a bit much. Only include the focus keyword when it really fits the image."
+					),
+					this.altProperties.withAltKeyword,
+					this.imageCount
+				),
+			};
+		}
+
 		return {
 			score: this._config.scores.noAlt,
 			resultText: i18n.dgettext(

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -4,7 +4,7 @@ const inRangeStartEndInclusive = require( "../../helpers/inRange.js" ).inRangeSt
 let merge = require( "lodash/merge" );
 
 /**
- * Represents the assessment that checks whether images have alt-tags and and whether the alt tags contain the keyword.
+ * Represents the assessment that checks whether images have alt-tags and whether the alt tags contain the keyword.
  */
 class TextImagesAssessment extends Assessment {
 	/**
@@ -154,11 +154,11 @@ class TextImagesAssessment extends Assessment {
 				score: this._config.scores.withAltTooFewKeywordMatches,
 				resultText: i18n.sprintf(
 					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
-					 * %2$d expands to the number of images that don't contain an alt attribute with the keyword. */
+					 * %2$d expands to the total number of images. */
 					i18n.dgettext(
-					"js-text-analysis",
-					"Only in %1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
-					"Where appropriate, try to include the focus keyword in more alt attributes."
+						"js-text-analysis",
+						"Only in %1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
+						"Where appropriate, try to include the focus keyword in more alt attributes."
 					),
 					this.altProperties.withAltKeyword,
 					this.imageCount
@@ -175,12 +175,12 @@ class TextImagesAssessment extends Assessment {
 				score: this._config.scores.withAltGoodNumberOfKeywordMatches,
 				resultText: i18n.sprintf(
 					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
-                     * %2$d expands to the number of images that don't contain an alt attribute with the keyword. */
+                     * %2$d expands to the total number of images. */
 					i18n.dngettext(
-					"js-text-analysis",
-					"The image on this page contains an alt attribute with the focus keyword.",
-					"%1$d out of %2$d images on this page contain alt attributes with the focus keyword.",
-					this.imageCount
+						"js-text-analysis",
+						"The image on this page contains an alt attribute with the focus keyword.",
+						"%1$d out of %2$d images on this page contain alt attributes with the focus keyword.",
+						this.imageCount
 					),
 					this.altProperties.withAltKeyword,
 					this.imageCount
@@ -193,11 +193,11 @@ class TextImagesAssessment extends Assessment {
 				score: this._config.scores.withAltTooFewKeywordMatches,
 				resultText: i18n.sprintf(
 					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
-                     * %2$d expands to the number of images that don't contain an alt attribute with the keyword. */
+                     * %2$d expands to the total number of images. */
 					i18n.dgettext(
-					"js-text-analysis",
-					"%1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
-					"That's a bit much. Only include the focus keyword when it really fits the image."
+						"js-text-analysis",
+						"%1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
+						"That's a bit much. Only include the focus keyword when it really fits the image."
 					),
 					this.altProperties.withAltKeyword,
 					this.imageCount

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -132,7 +132,7 @@ class TextImagesAssessment extends Assessment {
 				resultText: i18n.dgettext(
 					"js-text-analysis",
 					"The images on this page contain alt attributes. " +
-					"Once you've set a focus keyword, also include the keyword where appropriate."
+					"Once you've set a focus keyword, don't forget to include it in alt attributes, where appropriate."
 				),
 			};
 		}
@@ -152,7 +152,10 @@ class TextImagesAssessment extends Assessment {
 		if ( this.hasTooFewMatches() ) {
 			return {
 				score: this._config.scores.withAltTooFewKeywordMatches,
-				resultText: i18n.sprintf( i18n.dgettext(
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
+					 * %2$d expands to the number of images that don't contain an alt attribute with the keyword. */
+					i18n.dgettext(
 					"js-text-analysis",
 					"Only in %1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
 					"Where appropriate, try to include the focus keyword in more alt attributes."
@@ -170,7 +173,10 @@ class TextImagesAssessment extends Assessment {
 		if ( this.hasGoodNumberOfMatches() ) {
 			return {
 				score: this._config.scores.withAltGoodNumberOfKeywordMatches,
-				resultText: i18n.sprintf( i18n.dngettext(
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
+                     * %2$d expands to the number of images that don't contain an alt attribute with the keyword. */
+					i18n.dngettext(
 					"js-text-analysis",
 					"The image on this page contains an alt attribute with the focus keyword.",
 					"%1$d out of %2$d images on this page contain alt attributes with the focus keyword.",
@@ -185,7 +191,10 @@ class TextImagesAssessment extends Assessment {
 		if ( this.hasTooManyMatches() ) {
 			return {
 				score: this._config.scores.withAltTooFewKeywordMatches,
-				resultText: i18n.sprintf( i18n.dgettext(
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
+                     * %2$d expands to the number of images that don't contain an alt attribute with the keyword. */
+					i18n.dgettext(
 					"js-text-analysis",
 					"%1$d out of %2$d images on this page contain alt attributes with the focus keyword. " +
 					"That's a bit much. Only include the focus keyword when it really fits the image."


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*  Adds a specific range for how often the keyword should be included in image alt tags.

## Relevant technical choices:

* When there less than 5 images, including an alt tag with the keyword at least once will always result in a green bullet. There is no upper limit. When there are exactly five images, 2-4 alt tags with keywords will result in a green bullet. This has been hard-coded since it's on the border between the less strict and the stricter condition. When there are 6 or more keywords, the number of alt tags with the keyword should be between 30% & 75% of all images.

## Test instructions

This PR can be tested by following these steps:

* Make a beta script with `feature/recalibration` as the branch for Yoast SEO Free, and this branch for YoastSEO.js.
* Follow the steps below and make sure you always get appropriate feedback after each step. When everything is alright, you should get a green bullet, whereas you'll get an orange bullet when something needs to be changed. The only condition where you'll get a red bullet is when there are no images at all.
* Add a new post.
* Add one image.
	* Add an alt tag with a description.
	* Remove the alt tag again.
* Add a keyword.
	* Add an alt tag that doesn't contain the keyword.
	* Add an alt tag that does contain the keyword.
* Add more images (up to 4).
	* Vary the number of images with alt tags that contain the keyword. As long as there is at least one image alt tag that contains the keyword, you should get a green bullet.
* Add exactly five images to your post. The bullet should be green as long as 2-4 of them contain the keyword.
* Add more than five images to the post. Make sure you get appropriate feedback when adding/removing alt tags with the keyword: between 30% & 75% should result in a green bullet, going higher or lower than that in an orange bullet.
	

Fixes #1388 
