### PR TITLE
Use normalized quotes for most keyword assessments

### DIFF
--- a/spec/researches/findKeywordInPageitleSpec.js
+++ b/spec/researches/findKeywordInPageitleSpec.js
@@ -31,6 +31,10 @@ describe( "Match keywords in string", function() {
 		result = pageTitleKeyword( mockPaper );
 		expect( result.matches ).toBe( 0 );
 
+		var mockPaper = new Paper( "", { keyword: "Focus Keyword", title: "focus keyword" } );
+		result = pageTitleKeyword( mockPaper );
+		expect( result.matches ).toBe( 1 );
+
 		var mockPaper = new Paper( "", { keyword: "$keyword", title: "A title with a $keyword" } );
 		result = pageTitleKeyword( mockPaper );
 		expect( result.matches ).toBe( 1 );

--- a/spec/stringProcessing/matchTextWithWordSpec.js
+++ b/spec/stringProcessing/matchTextWithWordSpec.js
@@ -17,6 +17,8 @@ describe( "Counts the occurences of a word in a string", function() {
 	it( "should match quotes", function() {
 		expect( wordMatch( "Yoast's analyzer", "Yoast's" ) ).toBe( 1 );
 		expect( wordMatch( "Yoast\"s analyzer", "Yoast\"s analyzer" ) ).toBe( 1 );
+		expect( wordMatch( "Yoast’s analyzer", "Yoast’s" ) ).toBe( 1 );
+		expect( wordMatch( "Yoast's analyzer", "Yoast's" ) ).toBe( 1 );
 	} );
 
 	it( "should match normalized regardless of the type of quotes/apostrophes used", function() {

--- a/spec/stringProcessing/matchTextWithWordSpec.js
+++ b/spec/stringProcessing/matchTextWithWordSpec.js
@@ -19,6 +19,11 @@ describe( "Counts the occurences of a word in a string", function() {
 		expect( wordMatch( "Yoast\"s analyzer", "Yoast\"s analyzer" ) ).toBe( 1 );
 	} );
 
+	it( "should match normalized regardless of the type of quotes/apostrophes used", function() {
+		expect( wordMatch( "Yoast’s analyzer", "Yoast's" ) ).toBe( 1 );
+		expect( wordMatch( "Yoast's analyzer", "Yoast’s" ) ).toBe( 1 );
+	} );
+
 	it( "should match special characters", function() {
 		expect( wordMatch( "a string with diacritics äöüß oompaloomp", "äöüß oompaloomp" ) ).toBe( 1 );
 		expect( wordMatch( "", "äbc" ) ).toBe( 0 );

--- a/src/researches/findKeywordInFirstParagraph.js
+++ b/src/researches/findKeywordInFirstParagraph.js
@@ -1,11 +1,11 @@
 /** @module analyses/findKeywordInFirstParagraph */
 
-var matchParagraphs = require( "../stringProcessing/matchParagraphs.js" );
-var wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
+const matchParagraphs = require( "../stringProcessing/matchParagraphs.js" );
+const wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
-var reject = require( "lodash/reject" );
-var isEmpty = require( "lodash/isEmpty" );
+const escapeRegExp = require( "lodash/escapeRegExp" );
+const reject = require( "lodash/reject" );
+const isEmpty = require( "lodash/isEmpty" );
 
 /**
  * Counts the occurrences of the keyword in the first paragraph, returns 0 if it is not found,
@@ -16,8 +16,8 @@ var isEmpty = require( "lodash/isEmpty" );
  * @returns {number} The number of occurrences of the keyword in the first paragraph.
  */
 module.exports = function( paper ) {
-	var paragraphs = matchParagraphs( paper.getText() );
-	var keyword = escapeRegExp( paper.getKeyword().toLocaleLowerCase() );
-	var paragraph = reject( paragraphs, isEmpty )[ 0 ] || "";
+	const paragraphs = matchParagraphs( paper.getText() );
+	const keyword = escapeRegExp( paper.getKeyword().toLocaleLowerCase() );
+	const paragraph = reject( paragraphs, isEmpty )[ 0 ] || "";
 	return wordMatch( paragraph, keyword, paper.getLocale() );
 };

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -19,11 +19,10 @@ module.exports = function( paper ) {
 	 * necessary to repeat it here.
 	 */
 	const title = normalizeQuotes( paper.getTitle() );
-	const keyword = escapeRegExp( normalizeQuotes( paper.getKeyword() ) );
+	const keyword = escapeRegExp( normalizeQuotes( paper.getKeyword() ).toLocaleLowerCase() );
 	const locale = paper.getLocale();
 	const result = { matches: 0, position: -1 };
 	result.matches = wordMatch( title, keyword, locale );
 	result.position = title.toLocaleLowerCase().indexOf( keyword );
-
 	return result;
 };

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -1,8 +1,9 @@
 /** @module analyses/findKeywordInPageTitle */
 
-var wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
+const wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
+const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+const escapeRegExp = require( "lodash/escapeRegExp" );
 
 /**
  * Counts the occurrences of the keyword in the pagetitle. Returns the number of matches
@@ -13,10 +14,14 @@ var escapeRegExp = require( "lodash/escapeRegExp" );
  */
 
 module.exports = function( paper ) {
-	var title = paper.getTitle();
-	var keyword = escapeRegExp( paper.getKeyword() );
-	var locale = paper.getLocale();
-	var result = { matches: 0, position: -1 };
+	/*
+	 * NormalizeQuotes also is used in wordMatch, but in order to find the index of the keyword, it's
+	 * necessary to repeat it here.
+	 */
+	const title = normalizeQuotes( paper.getTitle() );
+	const keyword = escapeRegExp( normalizeQuotes( paper.getKeyword() ) );
+	const locale = paper.getLocale();
+	const result = { matches: 0, position: -1 };
 	result.matches = wordMatch( title, keyword, locale );
 	result.position = title.toLocaleLowerCase().indexOf( keyword );
 

--- a/src/researches/keywordCount.js
+++ b/src/researches/keywordCount.js
@@ -12,8 +12,8 @@ const escapeRegExp = require( "lodash/escapeRegExp" );
  * @returns {number} The keyword count.
  */
 module.exports = function( paper ) {
-	const keyword = escapeRegExp( normalizeQuotes( paper.getKeyword() ) );
-	const text = normalizeQuotes( paper.getText() );
+	const keyword = escapeRegExp( paper.getKeyword() );
+	const text = paper.getText();
 	const locale = paper.getLocale();
 	return matchWords( text, keyword, locale );
 };

--- a/src/researches/keywordCount.js
+++ b/src/researches/keywordCount.js
@@ -1,7 +1,6 @@
 /** @module analyses/getKeywordCount */
 
 const matchWords = require( "../stringProcessing/matchTextWithWord.js" );
-const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 
 const escapeRegExp = require( "lodash/escapeRegExp" );
 

--- a/src/stringProcessing/matchTextWithWord.js
+++ b/src/stringProcessing/matchTextWithWord.js
@@ -1,8 +1,9 @@
 /** @module stringProcessing/matchTextWithWord */
 
-var stripSomeTags = require( "../stringProcessing/stripNonTextTags.js" );
-var unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyAllSpaces;
-var matchStringWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
+const stripSomeTags = require( "../stringProcessing/stripNonTextTags.js" );
+const unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyAllSpaces;
+const matchStringWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
+const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 
 /**
  * Returns the number of matches in a given string
@@ -16,6 +17,8 @@ var matchStringWithTransliteration = require( "../stringProcessing/matchTextWith
 module.exports = function( text, wordToMatch, locale, extraBoundary ) {
 	text = stripSomeTags( text );
 	text = unifyWhitespace( text );
-	var matches = matchStringWithTransliteration( text, wordToMatch, locale, extraBoundary );
+	text = normalizeQuotes( text );
+	wordToMatch = normalizeQuotes( wordToMatch );
+	const matches = matchStringWithTransliteration( text, wordToMatch, locale, extraBoundary );
 	return matches.length;
 };

--- a/src/stringProcessing/subheadingsMatch.js
+++ b/src/stringProcessing/subheadingsMatch.js
@@ -11,10 +11,9 @@ const matchTextWithWord = require( "../stringProcessing/matchTextWithWord.js" );
  * @returns {number} The number of occurrences of the keyword in the headings.
  */
 module.exports = function( matches, keyword, locale ) {
-	let foundInHeader;
-	if ( matches === null ) {
-		foundInHeader = -1;
-	} else {
+	let foundInHeader = -1;
+
+	if ( matches !== null ) {
 		foundInHeader = 0;
 		for ( let i = 0; i < matches.length; i++ ) {
 			// TODO: This replaceString call seemingly doesn't work, as no replacement value is being sent to the .replace method in replaceString

--- a/src/stringProcessing/subheadingsMatch.js
+++ b/src/stringProcessing/subheadingsMatch.js
@@ -1,6 +1,6 @@
-var replaceString = require( "../stringProcessing/replaceString.js" );
-var removalWords = require( "../config/removalWords.js" )();
-var matchTextWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
+const replaceString = require( "../stringProcessing/replaceString.js" );
+const removalWords = require( "../config/removalWords.js" )();
+const matchTextWithWord = require( "../stringProcessing/matchTextWithWord.js" );
 
 /**
  * Matches the keyword in an array of strings
@@ -11,19 +11,19 @@ var matchTextWithTransliteration = require( "../stringProcessing/matchTextWithTr
  * @returns {number} The number of occurrences of the keyword in the headings.
  */
 module.exports = function( matches, keyword, locale ) {
-	var foundInHeader;
+	let foundInHeader;
 	if ( matches === null ) {
 		foundInHeader = -1;
 	} else {
 		foundInHeader = 0;
-		for ( var i = 0; i < matches.length; i++ ) {
+		for ( let i = 0; i < matches.length; i++ ) {
 			// TODO: This replaceString call seemingly doesn't work, as no replacement value is being sent to the .replace method in replaceString
-			var formattedHeaders = replaceString(
+			const formattedHeaders = replaceString(
 				matches[ i ], removalWords
 			);
 			if (
-				matchTextWithTransliteration( formattedHeaders, keyword, locale ).length > 0 ||
-				matchTextWithTransliteration( matches[ i ], keyword, locale ).length > 0
+				matchTextWithWord( formattedHeaders, keyword, locale ) > 0 ||
+				matchTextWithWord( matches[ i ], keyword, locale ) > 0
 			) {
 				foundInHeader++;
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Instances of the same keyword with different kinds of apostrophes (e.g., `brain’s` and `brain's`) are now recognized as the same in the following assessments: keyword in meta description, keyword in subheading, keyword in first paragraph, keyword in title, keyword in URL.

## Relevant technical choices:

* Different kinds of apostrophes are still not recognized as the same in the following assessments:
  * Image alt tags: see issue https://github.com/Yoast/YoastSEO.js/issues/1209 (currently alt tags are cut off at the first apostrophe/quotation mark).
  * Previously used keywords: see issue https://github.com/Yoast/YoastSEO.js/issues/1538. (the current architecture of this assessment doesn't allow for a simple fix with regards to the normalized quotes issue; since the architecture will need to be overhauled in the course of the morphology project, this issue should be addressed there.)
* I removed `normalizeQuotes` in `keywordCount.js`, as this is now handled more cenrally in `matchTextWithWords.js`.


## Test instructions

This PR can be tested by following these steps:

* Create a beta version, using `trunk` for YoastSEO, and this branch for YoastSEO.js.
* Set the keyword to e.g. `brain’s` and include a version with a different apostrophe (e.g., `brain's`) the in the following places:
  * the meta description,
  * a subheading,
  * the first paragraph of the text,
  * the title,
  * the slug.
  * and the text (and add at least 150 words of copy to make sure the keyword density assessment is triggered).
* Make sure that the feedback for all of these assessments indicates that the keyword has been recognized.

Fixes #1399 
