### PR TITLE
Add synonyms to Paper.js

### DIFF
--- a/spec/values/paperSpec.js
+++ b/spec/values/paperSpec.js
@@ -41,6 +41,19 @@ describe( "Paper", function() {
 			var paper = new Paper( "text", attributes );
 			expect( paper.hasUrl() ).toBe( true );
 			expect( paper.getUrl() ).toBe( "http://yoast.com/post" );
+			expect( paper.hasSynonyms() ).toBe( false );
+			expect( paper.getSynonyms() ).toBe( "" );
+		} );
+
+		it( "returns synonyms", function() {
+			var attributes = {
+				keyword: "website",
+				synonyms: "site",
+			};
+
+			var paper = new Paper( "text", attributes );
+			expect( paper.hasSynonyms() ).toBe( true );
+			expect( paper.getSynonyms() ).toBe( "site" );
 		} );
 
 		it( "returns title", function() {

--- a/src/values/Paper.js
+++ b/src/values/Paper.js
@@ -3,10 +3,11 @@ const isEmpty = require( "lodash/isEmpty" );
 
 /**
  * Default attributes to be used by the Paper if they are left undefined.
- * @type {{keyword: string, description: string, title: string, url: string}}
+ * @type {{keyword: string, synonyms: string, description: string, title: string, url: string}}
  */
 var defaultAttributes = {
 	keyword: "",
+	synonyms: "",
 	description: "",
 	title: "",
 	titleWidth: 0,
@@ -54,6 +55,22 @@ Paper.prototype.hasKeyword = function() {
  */
 Paper.prototype.getKeyword = function() {
 	return this._attributes.keyword;
+};
+
+/**
+ * Check whether synonyms is available.
+ * @returns {boolean} Returns true if the Paper has synonyms.
+ */
+Paper.prototype.hasSynonyms = function() {
+	return this._attributes.synonyms !== "";
+};
+
+/**
+ * Return the associated synonyms or an empty string if no synonyms is available.
+ * @returns {string} Returns ynonyms
+ */
+Paper.prototype.getSynonyms = function() {
+	return this._attributes.synonyms;
 };
 
 /**

--- a/src/values/Paper.js
+++ b/src/values/Paper.js
@@ -67,7 +67,7 @@ Paper.prototype.hasSynonyms = function() {
 
 /**
  * Return the associated synonyms or an empty string if no synonyms is available.
- * @returns {string} Returns ynonyms
+ * @returns {string} Returns synonyms.
  */
 Paper.prototype.getSynonyms = function() {
 	return this._attributes.synonyms;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* no user-facing changes

## Relevant technical choices:

* Adds basic functionality to store and pass synonyms to the Paper object.

## Test instructions

This PR can be tested by following these steps:

* Try adding more specs to the paperSpec.js

Fixes #1541 
