### PR TITLE
Implement keyword distribution assessment

### DIFF
--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -31,4 +31,22 @@ describe( "running assessments in the assessor", function() {
 		assessor.assess( new Paper( "text", { url: "sample url" } ) );
 		expect( assessor.getValidResults().length ).toBe( 7 );
 	} );
+
+	// These specifications will additionally trigger the largest keyword distance assessment.
+	it( "additionally runs assessments that require an url", function() {
+		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 10 );
+	} );
 } );

--- a/spec/assessments/largestKeywordDistanceAssessmentSpec.js
+++ b/spec/assessments/largestKeywordDistanceAssessmentSpec.js
@@ -9,7 +9,7 @@ let keywordDistanceAssessment = new largestKeyWordDistanceAssessment();
 describe( "An assessment to check the largest percentage of text in which no keyword occurs", function() {
 	it( "returns a bad score when the largest keyword distance is between more than 40%", function() {
 		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
-		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 45 ), i18n );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 55 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
 		expect( assessment.getText() ).toEqual( "Large parts of your text do not contain the keyword. Try to distribute the keyword more evenly." );
@@ -17,7 +17,7 @@ describe( "An assessment to check the largest percentage of text in which no key
 
 	it( "returns an okay score when the largest keyword distance is between 30 and 40%", function() {
 		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
-		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 35 ), i18n );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 45 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "Some parts of your text do not contain the keyword. Try to distribute the keyword more evenly." );

--- a/spec/assessments/largestKeywordDistanceAssessmentSpec.js
+++ b/spec/assessments/largestKeywordDistanceAssessmentSpec.js
@@ -1,0 +1,94 @@
+const largestKeyWordDistanceAssessment = require( "../../js/assessments/seo/largestKeywordDistanceAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
+const Factory = require( "../helpers/factory.js" );
+const i18n = Factory.buildJed();
+const Mark = require( "../../js/values/Mark.js" );
+
+let keywordDistanceAssessment = new largestKeyWordDistanceAssessment();
+
+describe( "An assessment to check the largest percentage of text in which no keyword occurs", function() {
+	it( "returns a bad score when the largest keyword distance is between more than 40%", function() {
+		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 45 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 1 );
+		expect( assessment.getText() ).toEqual( "Large parts of your text do not contain the keyword. Try to distribute the keyword more evenly." );
+	} );
+
+	it( "returns an okay score when the largest keyword distance is between 30 and 40%", function() {
+		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 35 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "Some parts of your text do not contain the keyword. Try to distribute the keyword more evenly." );
+	} );
+
+	it( "returns an okay score when the largest keyword distance is less than 30%", function() {
+		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "Your keyword is distributed evenly throughout the text. That's great." );
+	} );
+} );
+
+describe( "Checks if the assessment is applicable", function() {
+	it( "is applicable papers with more than 200 words and 2 keywords", function() {
+		let mockPaper = new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.isApplicable( mockPaper );
+
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable papers with more than 200 words and only 1 keyword", function() {
+		let mockPaper = new Paper( "This is the keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.isApplicable( mockPaper );
+
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is not applicable papers with less than 100 words that contain the keyword more than once", function() {
+		let mockPaper = new Paper( "Keyword and keyword. ", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.isApplicable( mockPaper );
+
+		expect( assessment ).toBe( false );
+	} );
+} );
+
+describe( "A test for marking keywords in the text", function() {
+	it( "returns markers for keywords in the text", function() {
+		let mockPaper = new Paper( "Text.", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment;
+
+		let expected = [
+			new Mark( { original: "keyword",
+				marked: "<yoastmark class='yoast-text-mark'>keyword</yoastmark>" } ),
+		];
+
+		expect( assessment.getMarks( mockPaper ) ).toEqual( expected );
+	} );
+} );

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -29,4 +29,22 @@ describe( "running assessments in the assessor", function() {
 		assessor.assess( new Paper( "text", { url: "sample url" } ) );
 		expect( assessor.getValidResults().length ).toBe( 7 );
 	} );
+
+	// These specifications will additionally trigger the largest keyword distance assessment.
+	it( "additionally runs assessments that require an url", function() {
+		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 10 );
+	} );
 } );

--- a/spec/researches/largestKeywordDistanceSpec.js
+++ b/spec/researches/largestKeywordDistanceSpec.js
@@ -1,0 +1,33 @@
+const largestKeywordDistance = require( "../../js/researches/largestKeywordDistance.js" );
+const Paper = require( "../../js/values/Paper.js" );
+
+describe( "Test for checking the largest percentage of a text without keyword", function() {
+	it( "returns the largest distance when that is the distance between two keywords", function() {
+		let mockPaper = new Paper( "a text with the keyword in it and then there's some text and then the keyword appears again and the keyword appears one last time", { keyword: "keyword" } );
+
+		expect( largestKeywordDistance( mockPaper ) ).toBe( 41.86046511627907 );
+	} );
+
+	it( "returns the largest distance when that is the distance between the beginning of the text and the first keyword", function() {
+		let mockPaper = new Paper( "a lot of text before the first keyword and again the keyword", { keyword: "keyword" } );
+
+		expect( largestKeywordDistance( mockPaper ) ).toBe( 51.66666666666667 );
+	} );
+
+	it( "returns the largest distance when that is the distance between the last keyword and the end of the text", function() {
+		let mockPaper = new Paper( "a keyword and again the keyword and then there's a lot of text after that", { keyword: "keyword" } );
+
+		expect( largestKeywordDistance( mockPaper ) ).toBe( 67.12328767123287 );
+	} );
+
+	it( "returns the largest distance when there is only one keyword and the largest distance is between the keyword and the beginning of the text", function() {
+		let mockPaper = new Paper( "this text has only one keyword", { keyword: "keyword" } );
+		expect( largestKeywordDistance( mockPaper ) ).toBe( 76.66666666666667 );
+	} );
+
+	it( "returns the largest distance when there is only one keyword and the largest distance is between the keyword and the end of the text", function() {
+		let mockPaper = new Paper( "this is the only keyword in a very long text with lots of words", { keyword: "keyword" } );
+
+		expect( largestKeywordDistance( mockPaper ) ).toBe( 73.01587301587301 );
+	} );
+} );

--- a/src/assessments/seo/largestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/largestKeywordDistanceAssessment.js
@@ -23,8 +23,8 @@ class largestKeywordDistanceAssessment extends Assessment {
 		super();
 
 		const defaultConfig = {
-			overRecommendedMaximumKeywordDistance: 40,
-			recommendedMaximumKeywordDistance: 30,
+			overRecommendedMaximumKeywordDistance: 50,
+			recommendedMaximumKeywordDistance: 40,
 			scores: {
 				good: 9,
 				okay: 6,
@@ -53,7 +53,7 @@ class largestKeywordDistanceAssessment extends Assessment {
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		assessmentResult.setHasMarks( calculatedResult.score < 2 );
+		assessmentResult.setHasMarks( calculatedResult.score < 9 );
 
 		return assessmentResult;
 	}

--- a/src/assessments/seo/largestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/largestKeywordDistanceAssessment.js
@@ -1,0 +1,133 @@
+const AssessmentResult = require( "../../values/AssessmentResult.js" );
+const Assessment = require( "../../assessment.js" );
+const merge = require( "lodash/merge" );
+const countWords = require( "../../stringProcessing/countWords.js" );
+const matchWords = require( "../../stringProcessing/matchTextWithWord.js" );
+const Mark = require( "../../values/Mark.js" );
+const marker = require( "../../markers/addMark.js" );
+const inRangeStartEndInclusive = require( "../../helpers/inRange.js" ).inRangeStartEndInclusive;
+
+/**
+ * Returns a score based on the largest percentage of text in
+ * which no keyword occurs.
+ */
+class largestKeywordDistanceAssessment extends Assessment {
+	/**
+	 * Sets the identifier and the config.
+	 *
+	 * @param {Object} config The configuration to use.
+	 *
+	 * @returns {void}
+	 */
+	constructor( config = {} ) {
+		super();
+
+		const defaultConfig = {
+			overRecommendedMaximumKeywordDistance: 40,
+			recommendedMaximumKeywordDistance: 30,
+			scores: {
+				good: 9,
+				okay: 6,
+				bad: 1,
+			},
+		};
+
+		this.identifier = "largestKeywordDistance";
+		this._config = merge( defaultConfig, config );
+	}
+
+	/**
+	 * Runs the largestKeywordDistance research and based on this returns an assessment result.
+	 *
+	 * @param {Paper}       paper       The paper to use for the assessment.
+	 * @param {Researcher}  researcher  The researcher used for calling research.
+	 * @param {Object}      i18n        The object used for translations.
+	 *
+	 * @returns {AssessmentResult} The assessment result.
+	 */
+	getResult( paper, researcher, i18n ) {
+		this._largestKeywordDistance = researcher.getResearch( "largestKeywordDistance" );
+		let assessmentResult = new AssessmentResult();
+
+		const calculatedResult = this.calculateResult( i18n );
+
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( calculatedResult.resultText );
+		assessmentResult.setHasMarks( calculatedResult.score < 2 );
+
+		return assessmentResult;
+	}
+
+	/**
+	 *  Calculates the result based on the largestKeywordDistance research.
+	 *
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} Object with score and feedback text.
+	 */
+	calculateResult( i18n ) {
+		if ( this._largestKeywordDistance > this._config.overRecommendedMaximumKeywordDistance ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: i18n.sprintf( i18n.dgettext(
+					"js-text-analysis",
+					"Large parts of your text do not contain the keyword. " +
+					"Try to distribute the keyword more evenly." ) ),
+			};
+		}
+
+		if ( inRangeStartEndInclusive(
+			this._largestKeywordDistance,
+			this._config.recommendedMaximumKeywordDistance,
+			this._config.overRecommendedMaximumKeywordDistance ) ) {
+			return {
+				score: this._config.scores.okay,
+				resultText: i18n.sprintf( i18n.dgettext(
+					"js-text-analysis",
+					"Some parts of your text do not contain the keyword. " +
+					"Try to distribute the keyword more evenly." ) ),
+			};
+		}
+
+		return {
+			score: this._config.scores.good,
+			resultText: i18n.sprintf( i18n.dgettext(
+				"js-text-analysis",
+				"Your keyword is distributed evenly throughout the text. " +
+				"That's great." ) ),
+		};
+	}
+
+	/**
+	 * Creates a marker for the keyword.
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 *
+	 * @returns {Array} All markers for the current text.
+	 */
+	getMarks( paper ) {
+		const keyword = paper.getKeyword();
+
+		return [ new Mark( {
+			original: keyword,
+			marked: marker( keyword ),
+		} ) ];
+	}
+
+	/**
+	 * Checks whether the paper has a text with at least 200 words, a keyword, and whether
+	 * the keyword appears more at least twice in the text (required to calculate a distribution).
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 *
+	 * @returns {boolean} True when there is a keyword and a text with 200 words or more,
+	 *                    with the keyword occurring more than one time.
+	 */
+	isApplicable( paper ) {
+		const keywordCount = matchWords( paper.getText(), paper.getKeyword(), paper.getLocale() );
+
+		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 200 && keywordCount > 1;
+	}
+}
+
+module.exports = largestKeywordDistanceAssessment;

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -18,6 +18,7 @@ let TitleWidth = require( "../assessments/seo/pageTitleWidthAssessment.js" );
 let UrlKeyword = require( "../assessments/seo/urlKeywordAssessment.js" );
 let UrlLength = require( "../assessments/seo/urlLengthAssessment.js" );
 let urlStopWords = require( "../assessments/seo/urlStopWordsAssessment.js" );
+const LargestKeywordDistance = require( "../assessments/seo/largestKeywordDistanceAssessment.js" );
 
 /**
  * Creates the Assessor
@@ -100,6 +101,7 @@ let CornerstoneSEOAssessor = function( i18n, options ) {
 			},
 		} ),
 		urlStopWords,
+		new LargestKeywordDistance(),
 	];
 };
 

--- a/src/researcher.js
+++ b/src/researcher.js
@@ -37,6 +37,7 @@ var passiveVoice = require( "./researches/getPassiveVoice.js" );
 var getSentenceBeginnings = require( "./researches/getSentenceBeginnings.js" );
 var relevantWords = require( "./researches/relevantWords" );
 var readingTime = require( "./researches/readingTime" );
+const largestKeywordDistance = require( "./researches/largestKeywordDistance" );
 
 /**
  * This contains all possible, default researches.
@@ -79,6 +80,7 @@ var Researcher = function( paper ) {
 		relevantWords: relevantWords,
 		readingTime: readingTime,
 		sentences,
+		largestKeywordDistance: largestKeywordDistance,
 	};
 
 	this.customResearches = {};

--- a/src/researches/largestKeywordDistance.js
+++ b/src/researches/largestKeywordDistance.js
@@ -1,0 +1,107 @@
+const getIndicesByWord = require( "../stringProcessing/indices" ).getIndicesByWord;
+const sortBy = require( "lodash/sortBy" );
+const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
+
+/**
+ * Gets the distance (in terms of characters) between two keywords, between the beginning
+ * of the text and the first keyword, or the last keyword and the end of the text.
+ *
+ * @param {number}  keywordIndex     The index of the keyword.
+ * @param {Array}   keywordIndices   All keyword indices.
+ * @param {number}  textLength       The length of the text in characters.
+ *
+ * @returns {Array} The distances for a given keyword in characters.
+ */
+const getKeywordDistances = function( keywordIndex, keywordIndices, textLength ) {
+	const currentIndexWithinArray = keywordIndices.indexOf( keywordIndex );
+	let indexOfPreviousKeyword;
+
+	let distances = [];
+
+	/*
+	 * If there's only one keyword, return the distance from the beginning
+	 * of the text to the keyword and from the keyword to the end of the text.
+	 */
+	if ( currentIndexWithinArray === 0 && keywordIndices.length === 1 ) {
+		distances.push( keywordIndex.index );
+		distances.push( textLength - keywordIndex.index );
+
+		return distances;
+	}
+
+	/*
+	 * For the first instance of the keyword calculate the distance between
+	 * the beginning of the text and that keyword.
+	 */
+	if ( currentIndexWithinArray === 0 ) {
+		distances.push( keywordIndex.index );
+
+		return distances;
+	}
+
+	/*
+	 * For the last instance of the keyword, calculate the distance between that keyword
+	 * and the previous keyword and also the distance between that keyword and the end
+	 * of the text.
+	 */
+	if ( currentIndexWithinArray === keywordIndices.length - 1 ) {
+		indexOfPreviousKeyword = keywordIndices[ currentIndexWithinArray - 1 ].index;
+		distances.push( keywordIndex.index - indexOfPreviousKeyword );
+		distances.push( textLength - keywordIndex.index );
+
+		return distances;
+	}
+
+	/*
+	 * For all instances in between first and last, calculate the distance between
+	 * that keyword and the preceding keyword.
+	 */
+	indexOfPreviousKeyword = keywordIndices[ currentIndexWithinArray - 1 ].index;
+	distances.push( keywordIndex.index - indexOfPreviousKeyword );
+
+	return distances;
+};
+
+/**
+ * Gets the largest keyword distance (in characters) from the array of all keyword distances.
+ *
+ * @param {Array} keywordDistances All keyword distances in characters.
+ *
+ * @returns {number} The largest keyword distance in characters.
+ */
+const getLargestDistanceInCharacters = function( keywordDistances ) {
+	keywordDistances = sortBy( keywordDistances );
+	keywordDistances = keywordDistances.reverse();
+
+	return keywordDistances[ 0 ];
+};
+
+/**
+ * Calculates the largest percentage of the text without a keyword.
+ *
+ * @param {Paper} paper The paper to check the keyword distance for.
+ *
+ * @returns {number} Returns the largest percentage of the text between two keyword occurrences
+ *                   or a keyword occurrence and the start/end of the text.
+ */
+module.exports = function( paper ) {
+	let text = paper.getText();
+	text = text.toLowerCase();
+	text = normalizeQuotes( text );
+
+	let keyword = paper.getKeyword();
+	keyword = keyword.toLowerCase();
+	keyword = normalizeQuotes( keyword );
+
+	const keywordIndices = getIndicesByWord( keyword, text );
+	let keywordDistances = [];
+
+	for ( let keywordIndex of keywordIndices ) {
+		let currentDistances = getKeywordDistances( keywordIndex, keywordIndices, text.length );
+		keywordDistances = keywordDistances.concat( currentDistances );
+	}
+
+	const largestKeywordDistanceInCharacters = getLargestDistanceInCharacters( keywordDistances );
+
+	return ( largestKeywordDistanceInCharacters / text.length ) * 100;
+};

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -17,6 +17,7 @@ var TitleWidth = require( "./assessments/seo/pageTitleWidthAssessment.js" );
 var UrlKeyword = require( "./assessments/seo/urlKeywordAssessment.js" );
 var UrlLength = require( "./assessments/seo/urlLengthAssessment.js" );
 var urlStopWords = require( "./assessments/seo/urlStopWordsAssessment.js" );
+const LargestKeywordDistance = require( "./assessments/seo/largestKeywordDistanceAssessment.js" );
 /**
  * Creates the Assessor
  *
@@ -47,6 +48,7 @@ var SEOAssessor = function( i18n, options ) {
 		new UrlKeyword(),
 		new UrlLength(),
 		urlStopWords,
+		new LargestKeywordDistance(),
 	];
 };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an assessment that checks whether there are any parts of the text (30% of the total or more) that don't include the keyword.


## Relevant technical choices:

* The keyword distance is based on the indices of the keywords, i.e. it is character-based (rather than word-based).
* The assessment gets triggered if the text contains 200 words or more and if there are at least 2 keyword occurrences in the text.


## Test instructions

This PR can be tested by following these steps:

See https://github.com/Yoast/YoastSEO.js/pull/1403

Fixes #1545 
