### PR TITLE
Parse synonyms list to array

### DIFF
--- a/spec/researches/getSynonymsSpec.js
+++ b/spec/researches/getSynonymsSpec.js
@@ -1,0 +1,39 @@
+const getSynonyms = require( "../../js/researches/getSynonyms" );
+const Paper = require( "../../js/values/Paper" );
+
+// todo: Change this spec as soon as the synonym interface is ready
+describe( "Gets synonyms from the paper keyword", function() {
+	it( "returns synonyms if they are provided by the user", function() {
+		let getSynonymsResult = getSynonyms(
+			new Paper( "text", { keyword: "keyword, synonym 1, synonym 2, synonym 3" } )
+		);
+
+		expect( getSynonymsResult.keyword ).toEqual( "keyword" );
+		expect( getSynonymsResult.synonyms ).toEqual( [ "synonym 1", "synonym 2", "synonym 3" ] );
+
+		getSynonymsResult = getSynonyms(
+			new Paper( "text", { keyword: "keyword!, Synonym 1?, synonym-2, synonym3" } )
+		);
+
+		expect( getSynonymsResult.keyword ).toEqual( "keyword" );
+		expect( getSynonymsResult.synonyms ).toEqual( [ "Synonym 1", "synonym-2", "synonym3" ] );
+	} );
+
+	it( "returns empty synonyms if only one keyword is provided by the user", function() {
+		const getSynonymsResult = getSynonyms(
+			new Paper( "text", { keyword: "keyword" } )
+		);
+
+		expect( getSynonymsResult.keyword ).toEqual( "keyword" );
+		expect( getSynonymsResult.synonyms ).toEqual( [] );
+	} );
+
+	it( "does not break if no keyword at all is provided by the user", function() {
+		const getSynonymsResult = getSynonyms(
+			new Paper( "text", { keyword: "" } )
+		);
+
+		expect( getSynonymsResult.keyword ).toEqual( "" );
+		expect( getSynonymsResult.synonyms ).toEqual( [] );
+	} );
+} );

--- a/spec/stringProcessing/parseSynonymsSpec.js
+++ b/spec/stringProcessing/parseSynonymsSpec.js
@@ -1,0 +1,13 @@
+var parseSynonyms = require( "../../js/stringProcessing/parseSynonyms" );
+
+describe( "A test for parsing a comma-separated list of synonyms into an array of words or phrases", function() {
+	it( "Should return an array from a comma-separated string", function() {
+		expect( parseSynonyms( "Item 1, item 2, item 3" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
+		expect( parseSynonyms( "Item 1,item 2, item 3" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
+		expect( parseSynonyms( "Item 1., !item 2, item 3?" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
+		expect( parseSynonyms( ", ," ) ).toEqual( [] );
+		expect( parseSynonyms( "!, ,?" ) ).toEqual( [] );
+		expect( parseSynonyms( "To be, or not to be, that is the question:" ) ).toEqual( [ "To be", "or not to be", "that is the question" ] );
+		expect( parseSynonyms( "To be,or not to be,that is the question:" ) ).toEqual( [ "To be", "or not to be", "that is the question" ] );
+	} );
+} );

--- a/src/researches/getSynonyms.js
+++ b/src/researches/getSynonyms.js
@@ -1,0 +1,24 @@
+const parseSynonyms = require( "../stringProcessing/parseSynonyms" );
+
+/**
+ * Gets the synonyms from the keyword field (provisionally) or from the synonym field, parses them into an array.
+ * @param {Paper} paper The Paper object to get the synonyms from.
+ *
+ * @returns {Object} The object with fields keyword and synonyms.
+ */
+module.exports = function( paper ) {
+	const keyphrase = paper.getKeyword();
+	let synonyms = parseSynonyms( keyphrase );
+
+	if ( synonyms.length < 2 ) {
+		return {
+			keyword: keyphrase,
+			synonyms: [],
+		};
+	}
+
+	return {
+		keyword: synonyms.shift(),
+		synonyms: synonyms,
+	};
+};

--- a/src/stringProcessing/parseSynonyms.js
+++ b/src/stringProcessing/parseSynonyms.js
@@ -1,0 +1,21 @@
+/** @module stringProcessing/parseSynonyms */
+
+const stripSpaces = require( "../stringProcessing/stripSpaces.js" );
+const removePunctuation = require( "../stringProcessing/removePunctuation.js" );
+
+/**
+ * Matches strings from an array against a given text.
+ *
+ * @param {String} synonyms The text to match
+ *
+ * @returns {Array} An array with all synonyms.
+ */
+module.exports = function( synonyms ) {
+	let synonymsSplit = synonyms.split( "," );
+
+	synonymsSplit = synonymsSplit.map( function( synonym ) {
+		return removePunctuation( stripSpaces( synonym ) ) ;
+	} ).filter( function( e ){ return e } );
+
+	return synonymsSplit;
+};

--- a/src/stringProcessing/parseSynonyms.js
+++ b/src/stringProcessing/parseSynonyms.js
@@ -14,8 +14,10 @@ module.exports = function( synonyms ) {
 	let synonymsSplit = synonyms.split( "," );
 
 	synonymsSplit = synonymsSplit.map( function( synonym ) {
-		return removePunctuation( stripSpaces( synonym ) ) ;
-	} ).filter( function( e ){ return e } );
+		return removePunctuation( stripSpaces( synonym ) );
+	} ).filter( function( synonym ) {
+		return synonym;
+	} );
 
 	return synonymsSplit;
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No user-facing changes

## Relevant technical choices:

* Adds a function that parses a list of synonyms into an array, trimming out all non-word characters at the beginning and at the end of the element string.
* Adds a research that receives a list of synonyms (for now, within the focus keyword string), parses it and returns an object that has fields `keyword` and `synonyms`.

## Test instructions

This PR can be tested by following these steps:

* Try enriching the spec for the parser function and the research and check if the new tests pass.

Fixes #1542
