### PR TITLE
Implement topic density assessment

### DIFF
--- a/spec/assessments/keywordDensitySpec.js
+++ b/spec/assessments/keywordDensitySpec.js
@@ -17,11 +17,19 @@ describe( "An assessment for the keywordDensity", function() {
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+			getKeywordDensity: 0.1,
+			keywordCount: 1,
+		}, true ), i18n );
+		expect( result.getScore() ).toBe( 4 );
+		expect( result.getText() ).toBe( "The keyword density is 0.1%, which is too low; the focus keyword was found 1 time." );
+
+		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
 			getKeywordDensity: 10,
 			keywordCount: 1,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "The keyword density is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 times." );
+		expect( result.getText() ).toBe( "The keyword density is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 time." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -29,7 +37,7 @@ describe( "An assessment for the keywordDensity", function() {
 			keywordCount: 1,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The keyword density is 2%, which is great; the focus keyword was found 1 times." );
+		expect( result.getText() ).toBe( "The keyword density is 2%, which is great; the focus keyword was found 1 time." );
 
 		paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {

--- a/spec/assessments/topicDensitySpec.js
+++ b/spec/assessments/topicDensitySpec.js
@@ -1,0 +1,78 @@
+/* global describe it expect */
+const topicDensityAssessment = require( "../../js/assessments/seo/topicDensityAssessment.js" );
+const Paper = require( "../../js/values/Paper.js" );
+const Mark = require( "../../src/values/Mark.js" );
+const factory = require( "../helpers/factory.js" );
+const i18n = factory.buildJed();
+
+describe( "An assessment for the topicDensity", function() {
+	it( "runs the topicDensity on the paper with only keyword specified", function() {
+		let paper = new Paper( "string without the key", { keyword: "keyword" } );
+		let result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+			getTopicDensity: 0,
+			topicCount: {
+				count: 0,
+			},
+		}, true ), i18n );
+		expect( result.getScore() ).toBe( 4 );
+		expect( result.getText() ).toBe( "The topic density is 0%, which is too low; the focus keyword and its synonyms were found 0 times." );
+
+		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+			getTopicDensity: 10,
+			topicCount: {
+				count: 50,
+			},
+		}, true ), i18n );
+		expect( result.getScore() ).toBe( -50 );
+		expect( result.getText() ).toBe( "The topic density is 10%, which is way over the advised 3% maximum; the focus keyword and its synonyms were found 50 times." );
+
+		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+			getTopicDensity: 2,
+			topicCount: {
+				count: 1,
+			},
+		}, true ), i18n );
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The topic density is 2%, which is great; the focus keyword and its synonyms were found 1 times." );
+
+		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
+		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+			getTopicDensity: 3.5,
+			topicCount: {
+				count: 2,
+			},
+		}, true ), i18n );
+		expect( result.getScore() ).toBe( -10 );
+		expect( result.getText() ).toBe( "The topic density is 3.5%, which is over the advised 3% maximum; the focus keyword and its synonyms were found 2 times." );
+
+		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
+		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+			getTopicDensity: 0.5,
+			topicCount: {
+				count: 2,
+			},
+		}, true ), i18n );
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "The topic density is 0.5%, which is great; the focus keyword and its synonyms were found 2 times." );
+	} );
+} );
+
+describe( "A test for marking the keyword and its synonyms", function() {
+	it( "returns markers", function() {
+		const paper = new Paper( "This is a very interesting paper with a keyword and other keywords.", { keyword: "keyword, other keywords" }  );
+		const expected = [
+			new Mark( { original: "keyword", marked: "<yoastmark class='yoast-text-mark'>keyword</yoastmark>" } ),
+			new Mark( { original: "other keywords", marked: "<yoastmark class='yoast-text-mark'>other keywords</yoastmark>" } ),
+		];
+		expect( topicDensityAssessment.getMarks( paper ) ).toEqual( expected );
+	} );
+
+	it( "returns no markers", function() {
+		const paper = new Paper( "This is a very interesting paper with a keyword and other keywords.", { keyword: "seaside" }  );
+		const expected = [];
+		expect( topicDensityAssessment.getMarks( paper ) ).toEqual( expected );
+	} );
+} );
+

--- a/spec/assessments/topicDensitySpec.js
+++ b/spec/assessments/topicDensitySpec.js
@@ -35,7 +35,7 @@ describe( "An assessment for the topicDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The topic density is 2%, which is great; the focus keyword and its synonyms were found 1 times." );
+		expect( result.getText() ).toBe( "The topic density is 2%, which is great; the focus keyword and its synonyms were found 1 time." );
 
 		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
 		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
@@ -65,6 +65,15 @@ describe( "A test for marking the keyword and its synonyms", function() {
 		const expected = [
 			new Mark( { original: "other keywords", marked: "<yoastmark class='yoast-text-mark'>other keywords</yoastmark>" } ),
 			new Mark( { original: "keyword", marked: "<yoastmark class='yoast-text-mark'>keyword</yoastmark>" } ),
+		];
+		expect( new TopicDensityAssessment().getMarks( paper ) ).toEqual( expected );
+	} );
+
+	it( "returns markers when there is overlap", function() {
+		const paper = new Paper( "This is a very interesting paper with a key word and another key.", { keyword: "key, key word" }  );
+		const expected = [
+			new Mark( { original: "key word", marked: "<yoastmark class='yoast-text-mark'>key word</yoastmark>" } ),
+			new Mark( { original: "key", marked: "<yoastmark class='yoast-text-mark'>key</yoastmark>" } ),
 		];
 		expect( new TopicDensityAssessment().getMarks( paper ) ).toEqual( expected );
 	} );

--- a/spec/assessments/topicDensitySpec.js
+++ b/spec/assessments/topicDensitySpec.js
@@ -1,5 +1,5 @@
 /* global describe it expect */
-const topicDensityAssessment = require( "../../js/assessments/seo/topicDensityAssessment.js" );
+const TopicDensityAssessment = require( "../../js/assessments/seo/topicDensityAssessment.js" );
 const Paper = require( "../../js/values/Paper.js" );
 const Mark = require( "../../src/values/Mark.js" );
 const factory = require( "../helpers/factory.js" );
@@ -8,7 +8,7 @@ const i18n = factory.buildJed();
 describe( "An assessment for the topicDensity", function() {
 	it( "runs the topicDensity on the paper with only keyword specified", function() {
 		let paper = new Paper( "string without the key", { keyword: "keyword" } );
-		let result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+		let result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
 			getTopicDensity: 0,
 			topicCount: {
 				count: 0,
@@ -18,7 +18,7 @@ describe( "An assessment for the topicDensity", function() {
 		expect( result.getText() ).toBe( "The topic density is 0%, which is too low; the focus keyword and its synonyms were found 0 times." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
-		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
 			getTopicDensity: 10,
 			topicCount: {
 				count: 50,
@@ -28,7 +28,7 @@ describe( "An assessment for the topicDensity", function() {
 		expect( result.getText() ).toBe( "The topic density is 10%, which is way over the advised 3% maximum; the focus keyword and its synonyms were found 50 times." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
-		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
 			getTopicDensity: 2,
 			topicCount: {
 				count: 1,
@@ -38,7 +38,7 @@ describe( "An assessment for the topicDensity", function() {
 		expect( result.getText() ).toBe( "The topic density is 2%, which is great; the focus keyword and its synonyms were found 1 times." );
 
 		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
-		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
 			getTopicDensity: 3.5,
 			topicCount: {
 				count: 2,
@@ -48,7 +48,7 @@ describe( "An assessment for the topicDensity", function() {
 		expect( result.getText() ).toBe( "The topic density is 3.5%, which is over the advised 3% maximum; the focus keyword and its synonyms were found 2 times." );
 
 		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
-		result = topicDensityAssessment.getResult( paper, factory.buildMockResearcher( {
+		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
 			getTopicDensity: 0.5,
 			topicCount: {
 				count: 2,
@@ -63,16 +63,16 @@ describe( "A test for marking the keyword and its synonyms", function() {
 	it( "returns markers", function() {
 		const paper = new Paper( "This is a very interesting paper with a keyword and other keywords.", { keyword: "keyword, other keywords" }  );
 		const expected = [
-			new Mark( { original: "keyword", marked: "<yoastmark class='yoast-text-mark'>keyword</yoastmark>" } ),
 			new Mark( { original: "other keywords", marked: "<yoastmark class='yoast-text-mark'>other keywords</yoastmark>" } ),
+			new Mark( { original: "keyword", marked: "<yoastmark class='yoast-text-mark'>keyword</yoastmark>" } ),
 		];
-		expect( topicDensityAssessment.getMarks( paper ) ).toEqual( expected );
+		expect( new TopicDensityAssessment().getMarks( paper ) ).toEqual( expected );
 	} );
 
 	it( "returns no markers", function() {
 		const paper = new Paper( "This is a very interesting paper with a keyword and other keywords.", { keyword: "seaside" }  );
 		const expected = [];
-		expect( topicDensityAssessment.getMarks( paper ) ).toEqual( expected );
+		expect( new TopicDensityAssessment().getMarks( paper ) ).toEqual( expected );
 	} );
 } );
 

--- a/spec/researches/getTopicDensitySpec.js
+++ b/spec/researches/getTopicDensitySpec.js
@@ -1,0 +1,55 @@
+/* global describe it expect */
+const getTopicDensity = require( "../../js/researches/getTopicDensity.js" );
+const Paper = require( "../../js/values/Paper.js" );
+// todo: change this spec as soon as the proper synonyms interface is ready.
+describe( "Test for counting the keyword and synonyms in a text", function() {
+	it( "returns topic count equal to keyword count if only keyword is supplied", function() {
+		let mockPaper = new Paper( "a string of text with the keyword in it.", { keyword: "keyword" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 11.11111111111111111 );
+		mockPaper = new Paper( "a string of text without the keyword in it.", { keyword: "empty" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 0 );
+		mockPaper = new Paper( "Waltz keepin auf mitz auf keepin äöüß weiner blitz spitzen.", { keyword: "äöüß" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+		mockPaper = new Paper( "Lorem ipsum dolor sit amet, key word consectetur key-word adipiscing.", { keyword: "key-word" } );
+		expect( getTopicDensity( mockPaper  ) ).toBe( 10 );
+		mockPaper = new Paper( "a string of text with the beautiful kapaklı in it.", { keyword: "kapaklı" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+		mockPaper = new Paper( "a string of text with the beautiful key-word in it.", { keyword: "key-word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+		mockPaper = new Paper( "a string of text with the beautiful key_word in it.", { keyword: "key_word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+		mockPaper = new Paper( "a string of text with the beautiful key_word in it.", { keyword: "key word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 0 );
+		mockPaper = new Paper( "a string of text with the key-word in it.", { keyword: "key word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 0 );
+		mockPaper = new Paper( "a string of text with the beautiful key&word in it.", { keyword: "key&word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+		mockPaper = new Paper( "<img src='http://image.com/image.png'>", { keyword: "key&word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 0 );
+		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", { keyword: "keyword" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 30 );
+		mockPaper = new Paper( "a string of text with the beautiful Keyword in it.", { keyword: "keyword" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+		mockPaper = new Paper( "a string of text with the Key word in it.", { keyword: "key word" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+	} );
+
+	it( "returns topic count if both keyword and synonyms are supplied", function() {
+		let mockPaper = new Paper( "Site and website are essentially the same, so to say.", { keyword: "site, website" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 20 );
+		mockPaper = new Paper( "Site and website are essentially the same, so to say.", { keyword: "website, site" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 20 );
+		mockPaper = new Paper( "Site, web site and website are essentially the same, really.", { keyword: "website, site" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 30 );
+		mockPaper = new Paper( "Site and website are essentially the same, so to say.", { keyword: "keyword, anotherKeyword" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 0 );
+		mockPaper = new Paper( "Blog is essentially a website.", { keyword: "website, site" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 20 );
+		mockPaper = new Paper( "Waltz keepin auf mitz auf keepin äöüß weiner blitz spitzen. ", { keyword: "äöüß, spitzen" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 20 );
+		mockPaper = new Paper( "Another way to write key word is key-word or keyword.", { keyword: "key word, key-word, keyword" } );
+		expect( getTopicDensity( mockPaper  ) ).toBe( 30 );
+		mockPaper = new Paper( "a string of text with the beautiful kapaklı in it.", { keyword: "kapaklı" } );
+		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
+	} );
+} );

--- a/spec/researches/topicCountSpec.js
+++ b/spec/researches/topicCountSpec.js
@@ -1,0 +1,65 @@
+/* global describe it expect */
+const topicCount = require( "../../js/researches/topicCount.js" );
+const Paper = require( "../../js/values/Paper.js" );
+// todo: change this spec as soon as the proper synonyms interface is ready.
+describe( "Test for counting the keyword and synonyms in a text", function() {
+	it( "returns topic count equal to keyword count if only keyword is supplied", function() {
+		let mockPaper = new Paper( "a string of text with the keyword in it.", { keyword: "keyword" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text without the keyword in it.", { keyword: "empty" } );
+		expect( topicCount( mockPaper ).count ).toBe( 0 );
+		mockPaper = new Paper( "Waltz keepin auf mitz auf keepin äöüß weiner blitz deutsch spitzen.", { keyword: "äöüß" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "Lorem ipsum dolor sit amet, key word consectetur key-word adipiscing elit ", { keyword: "key-word" } );
+		expect( topicCount( mockPaper  ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the kapaklı in it.", { keyword: "kapaklı" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the key-word in it.", { keyword: "key-word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the key_word in it.", { keyword: "key_word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the key_word in it.", { keyword: "key word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 0 );
+		mockPaper = new Paper( "a string of text with the key-word in it.", { keyword: "key word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 0 );
+		mockPaper = new Paper( "a string of text with the key&word in it.", { keyword: "key&word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "<img src='http://image.com/image.png'>", { keyword: "key&word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 0 );
+		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", { keyword: "keyword" } );
+		expect( topicCount( mockPaper ).count ).toBe( 3 );
+		mockPaper = new Paper( "a string of text with the Keyword in it.", { keyword: "keyword" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the Key word in it.", { keyword: "key word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the Key Word in it.", { keyword: "key word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the KEY WORD in it.", { keyword: "key word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the keyword in it.", { keyword: "Keyword" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the key word in it.", { keyword: "Key word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the key word in it.", { keyword: "Key Word" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "a string of text with the key word in it.", { keyword: "KEY WORD" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+	} );
+
+	it( "returns topic count if both keyword and synonyms are supplied", function() {
+		let mockPaper = new Paper( "Site and website are essentially the same.", { keyword: "site, website" } );
+		expect( topicCount( mockPaper ).count ).toBe( 2 );
+		mockPaper = new Paper( "Site and website are essentially the same.", { keyword: "website, site" } );
+		expect( topicCount( mockPaper ).count ).toBe( 2 );
+		mockPaper = new Paper( "Site and website are essentially the same.", { keyword: "keyword, anotherKeyword" } );
+		expect( topicCount( mockPaper ).count ).toBe( 0 );
+		mockPaper = new Paper( "Blog is a website", { keyword: "website, site" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+		mockPaper = new Paper( "Waltz keepin auf mitz auf keepin äöüß weiner blitz deutsch spitzen. ", { keyword: "äöüß, spitzen" } );
+		expect( topicCount( mockPaper ).count ).toBe( 2 );
+		mockPaper = new Paper( "Another way to write key word is key-word or keyword.", { keyword: "key word, key-word, keyword" } );
+		expect( topicCount( mockPaper  ).count ).toBe( 3 );
+		mockPaper = new Paper( "a string of text with the kapaklı in it.", { keyword: "kapaklı" } );
+		expect( topicCount( mockPaper ).count ).toBe( 1 );
+	} );
+} );

--- a/spec/stringProcessing/parseSynonymsSpec.js
+++ b/spec/stringProcessing/parseSynonymsSpec.js
@@ -3,7 +3,7 @@ var parseSynonyms = require( "../../js/stringProcessing/parseSynonyms" );
 describe( "A test for parsing a comma-separated list of synonyms into an array of words or phrases", function() {
 	it( "Should return an array from a comma-separated string", function() {
 		expect( parseSynonyms( "Item 1, item 2, item 3" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
-		expect( parseSynonyms( "Item 1,item 2, item 3" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
+		expect( parseSynonyms( "Item 1,item 2,                 item 3" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
 		expect( parseSynonyms( "Item 1., !item 2, item 3?" ) ).toEqual( [ "Item 1", "item 2", "item 3" ] );
 		expect( parseSynonyms( ", ," ) ).toEqual( [] );
 		expect( parseSynonyms( "!, ,?" ) ).toEqual( [] );

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -4,7 +4,6 @@ var formatNumber = require( "../../helpers/formatNumber.js" );
 var inRange = require( "../../helpers/inRange.js" );
 
 var inRangeEndInclusive = inRange.inRangeEndInclusive;
-var inRangeStartInclusive = inRange.inRangeStartInclusive;
 var inRangeStartEndInclusive = inRange.inRangeStartEndInclusive;
 
 /**

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -99,6 +99,7 @@ module.exports = {
 	identifier: "keywordDensity",
 	getResult: keywordDensityAssessment,
 	isApplicable: function( paper ) {
-		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 100; // todo: as soon as Synonym interface is ready add !paper.hasSynonyms().
+		// todo: as soon as Synonym interface is ready add !paper.hasSynonyms().
+		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 100;
 	},
 };

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -16,7 +16,8 @@ var inRangeStartEndInclusive = inRange.inRangeStartEndInclusive;
  * @returns {{score: number, text: *}} The assessment result
  */
 var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount ) {
-	var score, text, max;
+	var score, text;
+	const max = "2.5%";
 	var roundedKeywordDensity = formatNumber( keywordDensity );
 	var keywordDensityPercentage = roundedKeywordDensity + "%";
 
@@ -25,11 +26,12 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 
 		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
 		%3$s expands to the maximum keyword density percentage. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
-			" which is way over the advised %3$s maximum;" +
-			" the focus keyword was found %2$d times." );
-
-		max = "2.5%";
+		text = i18n.dngettext(
+			"js-text-analysis",
+			"The keyword density is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d time.",
+			"The keyword density is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d times.",
+			keywordCount
+		);
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}
@@ -39,11 +41,12 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 
 		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
 		%3$s expands to the maximum keyword density percentage. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
-			" which is over the advised %3$s maximum;" +
-			" the focus keyword was found %2$d times." );
-
-		max = "2.5%";
+		text = i18n.dngettext(
+			"js-text-analysis",
+			"The keyword density is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d time.",
+			"The keyword density is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d times.",
+			keywordCount
+		);
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
 	}
@@ -52,18 +55,38 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		score = 9;
 
 		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is great;" +
-			" the focus keyword was found %2$d times." );
+		text = i18n.dngettext(
+			"js-text-analysis",
+			"The keyword density is %1$s, which is great; the focus keyword was found %2$d time.",
+			"The keyword density is %1$s, which is great; the focus keyword was found %2$d times.",
+			keywordCount
+		);
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
 	}
 
-	if ( inRangeStartInclusive( roundedKeywordDensity, 0, 0.5 ) ) {
+	if ( roundedKeywordDensity < 0.5 && keywordCount === 0 ) {
 		score = 4;
 
 		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is too low;" +
-			" the focus keyword was found %2$d times." );
+		text = i18n.dgettext(
+			"js-text-analysis",
+			"The keyword density is %1$s, which is too low; the focus keyword was found %2$d times."
+		);
+
+		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
+	}
+
+	if ( roundedKeywordDensity < 0.5 && ! ( keywordCount === 0 ) ) {
+		score = 4;
+
+		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
+		text = i18n.dngettext(
+			"js-text-analysis",
+			"The keyword density is %1$s, which is too low; the focus keyword was found %2$d time.",
+			"The keyword density is %1$s, which is too low; the focus keyword was found %2$d times.",
+			keywordCount
+		);
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
 	}

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -99,6 +99,6 @@ module.exports = {
 	identifier: "keywordDensity",
 	getResult: keywordDensityAssessment,
 	isApplicable: function( paper ) {
-		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 100;
+		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 100; // todo: as soon as Synonym interface is ready add !paper.hasSynonyms().
 	},
 };

--- a/src/assessments/seo/topicDensityAssessment.js
+++ b/src/assessments/seo/topicDensityAssessment.js
@@ -1,0 +1,129 @@
+const AssessmentResult = require( "../../values/AssessmentResult.js" );
+const topicCount = require( "../../researches/topicCount.js" );
+const countWords = require( "../../stringProcessing/countWords.js" );
+const formatNumber = require( "../../helpers/formatNumber.js" );
+const inRange = require( "../../helpers/inRange.js" );
+const Mark = require( "../../values/Mark.js" );
+const marker = require( "../../markers/addMark.js" );
+
+const inRangeEndInclusive = inRange.inRangeEndInclusive;
+const inRangeStartInclusive = inRange.inRangeStartInclusive;
+const inRangeStartEndInclusive = inRange.inRangeStartEndInclusive;
+const map = require( "lodash/map" );
+
+/**
+ * Returns the scores and result text for topic density
+ *
+ * @param {number} topicDensity The topic density
+ * @param {object} i18n The i18n object used for translations
+ * @param {number} topicCount The number of times the keyword has been found in the text.
+ * @returns {{score: number, text: string}} The assessment result
+ */
+const calculateTopicDensityResult = function( topicDensity, i18n, topicCount ) {
+	let score, text, max;
+	const roundedTopicDensity = formatNumber( topicDensity );
+	const topicDensityPercentage = roundedTopicDensity + "%";
+
+	if ( roundedTopicDensity > 3.5 ) {
+		score = -50;
+
+		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count,
+		%3$s expands to the maximum topic density percentage. */
+		text = i18n.dgettext( "js-text-analysis", "The topic density is %1$s," +
+			" which is way over the advised %3$s maximum;" +
+			" the focus keyword and its synonyms were found %2$d times." );
+
+		max = "2.5%";
+
+		text = i18n.sprintf( text, topicDensityPercentage, topicCount, max );
+	}
+
+	if ( inRangeEndInclusive( roundedTopicDensity, 2.5, 3.5 ) ) {
+		score = -10;
+
+		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count,
+		%3$s expands to the maximum topic density percentage. */
+		text = i18n.dgettext( "js-text-analysis", "The topic density is %1$s," +
+			" which is over the advised %3$s maximum;" +
+			" the focus keyword and its synonyms were found %2$d times." );
+
+		max = "2.5%";
+
+		text = i18n.sprintf( text, topicDensityPercentage, topicCount, max );
+	}
+
+	if ( inRangeStartEndInclusive( roundedTopicDensity, 0.5, 2.5 ) ) {
+		score = 9;
+
+		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count. */
+		text = i18n.dgettext( "js-text-analysis", "The topic density is %1$s, which is great;" +
+			" the focus keyword and its synonyms were found %2$d times." );
+
+		text = i18n.sprintf( text, topicDensityPercentage, topicCount );
+	}
+
+	if ( inRangeStartInclusive( roundedTopicDensity, 0, 0.5 ) ) {
+		score = 4;
+
+		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count. */
+		text = i18n.dgettext( "js-text-analysis", "The topic density is %1$s, which is too low;" +
+			" the focus keyword and its synonyms were found %2$d times." );
+
+		text = i18n.sprintf( text, topicDensityPercentage, topicCount );
+	}
+
+	return {
+		score: score,
+		text: text,
+		hasMarks: roundedTopicDensity > 0,
+	};
+};
+
+/**
+ * Runs the getTopicCountDensity module, based on this returns an assessment result with score.
+ *
+ * @param {object} paper The paper to use for the assessment.
+ * @param {object} researcher The researcher used for calling research.
+ * @param {object} i18n The object used for translations
+ * @returns {object} the AssessmentResult
+ */
+const topicDensityAssessment = function( paper, researcher, i18n ) {
+	const topicDensity = researcher.getResearch( "getTopicDensity" );
+	const topicCount = researcher.getResearch( "topicCount" ).count;
+
+	const topicDensityResult = calculateTopicDensityResult( topicDensity, i18n, topicCount );
+	const assessmentResult = new AssessmentResult();
+
+	assessmentResult.setScore( topicDensityResult.score );
+	assessmentResult.setText( topicDensityResult.text );
+	assessmentResult.setHasMarks( topicDensityResult.hasMarks );
+
+	return assessmentResult;
+};
+
+/**
+ * Marks keywords and synonyms in the text for the topic density assessment.
+ *
+ * @param {Object} paper The paper to use for the assessment.
+ *
+ * @returns {Array<Mark>} A list of marks that should be applied.
+ */
+const getMarks = function( paper ) {
+	const topicWords = topicCount( paper ).matches;
+
+	return map( topicWords, function( topicWord ) {
+		return new Mark( {
+			original: topicWord,
+			marked: marker( topicWord ),
+		} );
+	} );
+};
+
+module.exports = {
+	identifier: "topicDensity",
+	getResult: topicDensityAssessment,
+	isApplicable: function( paper ) {
+		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 100 && paper.getKeyword().indexOf( "," ) > 0;
+	},
+	getMarks: getMarks,
+};

--- a/src/assessments/seo/topicDensityAssessment.js
+++ b/src/assessments/seo/topicDensityAssessment.js
@@ -7,6 +7,7 @@ const inRange = require( "../../helpers/inRange.js" );
 const Mark = require( "../../values/Mark.js" );
 const marker = require( "../../markers/addMark.js" );
 
+const inRangeStartInclusive = inRange.inRangeStartInclusive;
 const inRangeEndInclusive = inRange.inRangeEndInclusive;
 const inRangeStartEndInclusive = inRange.inRangeStartEndInclusive;
 const map = require( "lodash/map" );
@@ -68,7 +69,7 @@ class TopicDensityAssessment extends Assessment {
 	/**
 	 * Returns the scores and result text for topic density
 	 *
-	 * @param {object} i18n The i18n object used for translations
+	 * @param {Object} i18n The i18n object used for translations
 	 *
 	 * @returns {{score: number, text: string}} The assessment result
 	 */
@@ -130,9 +131,33 @@ class TopicDensityAssessment extends Assessment {
 				score: this._config.scores.good,
 				resultText: i18n.sprintf(
 					/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The topic density is %1$s, which is great; the focus keyword and its synonyms were found %2$d time.",
+						"The topic density is %1$s, which is great; the focus keyword and its synonyms were found %2$d times.",
+						this._topicCount.count
+					),
+					topicDensityPercentage,
+					this._topicCount.count
+				),
+			};
+		}
+
+
+		if(
+			inRangeStartInclusive(
+				this._topicDensity,
+				0,
+				this._config.recommendedMinimum
+			) && ( this._topicCount.count === 0 )
+		) {
+			return {
+				score: this._config.scores.tooLittle,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"The topic density is %1$s, which is great; the focus keyword and its synonyms were found %2$d times."
+						"The topic density is %1$s, which is too low; the focus keyword and its synonyms were found %2$d times."
 					),
 					topicDensityPercentage,
 					this._topicCount.count
@@ -144,9 +169,11 @@ class TopicDensityAssessment extends Assessment {
 			score: this._config.scores.tooLittle,
 			resultText: i18n.sprintf(
 				/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count. */
-				i18n.dgettext(
+				i18n.dngettext(
 					"js-text-analysis",
-					"The topic density is %1$s, which is too low; the focus keyword and its synonyms were found %2$d times."
+					"The topic density is %1$s, which is too low; the focus keyword and its synonyms were found %2$d time.",
+					"The topic density is %1$s, which is too low; the focus keyword and its synonyms were found %2$d times.",
+					this._topicCount.count
 				),
 				topicDensityPercentage,
 				this._topicCount.count

--- a/src/assessments/seo/topicDensityAssessment.js
+++ b/src/assessments/seo/topicDensityAssessment.js
@@ -24,7 +24,10 @@ const calculateTopicDensityResult = function( topicDensity, i18n, topicCount ) {
 	const roundedTopicDensity = formatNumber( topicDensity );
 	const topicDensityPercentage = roundedTopicDensity + "%";
 
-	if ( roundedTopicDensity > 3.5 ) {
+	console.log("topicDensity=", topicDensity, "roundedTopicDensity = ", roundedTopicDensity, "topicDensityPercentage = ", topicDensityPercentage);
+
+
+	if ( roundedTopicDensity > 4 ) {
 		score = -50;
 
 		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count,
@@ -33,12 +36,12 @@ const calculateTopicDensityResult = function( topicDensity, i18n, topicCount ) {
 			" which is way over the advised %3$s maximum;" +
 			" the focus keyword and its synonyms were found %2$d times." );
 
-		max = "2.5%";
+		max = "3%";
 
 		text = i18n.sprintf( text, topicDensityPercentage, topicCount, max );
 	}
 
-	if ( inRangeEndInclusive( roundedTopicDensity, 2.5, 3.5 ) ) {
+	if ( inRangeEndInclusive( roundedTopicDensity, 3, 4 ) ) {
 		score = -10;
 
 		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count,
@@ -47,12 +50,12 @@ const calculateTopicDensityResult = function( topicDensity, i18n, topicCount ) {
 			" which is over the advised %3$s maximum;" +
 			" the focus keyword and its synonyms were found %2$d times." );
 
-		max = "2.5%";
+		max = "3%";
 
 		text = i18n.sprintf( text, topicDensityPercentage, topicCount, max );
 	}
 
-	if ( inRangeStartEndInclusive( roundedTopicDensity, 0.5, 2.5 ) ) {
+	if ( inRangeStartEndInclusive( roundedTopicDensity, 0.5, 3 ) ) {
 		score = 9;
 
 		/* Translators: %1$s expands to the topic density percentage, %2$d expands to the topic count. */
@@ -91,6 +94,9 @@ const topicDensityAssessment = function( paper, researcher, i18n ) {
 	const topicDensity = researcher.getResearch( "getTopicDensity" );
 	const topicCount = researcher.getResearch( "topicCount" ).count;
 
+	console.log("topicDensity = ", topicDensity);
+	console.log("topicCount = ", topicCount);
+
 	const topicDensityResult = calculateTopicDensityResult( topicDensity, i18n, topicCount );
 	const assessmentResult = new AssessmentResult();
 
@@ -110,6 +116,8 @@ const topicDensityAssessment = function( paper, researcher, i18n ) {
  */
 const getMarks = function( paper ) {
 	const topicWords = topicCount( paper ).matches;
+
+	console.log("topicWords = ", topicWords);
 
 	return map( topicWords, function( topicWord ) {
 		return new Mark( {

--- a/src/researcher.js
+++ b/src/researcher.js
@@ -37,6 +37,8 @@ var passiveVoice = require( "./researches/getPassiveVoice.js" );
 var getSentenceBeginnings = require( "./researches/getSentenceBeginnings.js" );
 var relevantWords = require( "./researches/relevantWords" );
 var readingTime = require( "./researches/readingTime" );
+var getTopicDensity = require( "./researches/getTopicDensity" );
+var topicCount = require( "./researches/topicCount" );
 
 /**
  * This contains all possible, default researches.
@@ -78,6 +80,8 @@ var Researcher = function( paper ) {
 		getSentenceBeginnings: getSentenceBeginnings,
 		relevantWords: relevantWords,
 		readingTime: readingTime,
+		getTopicDensity: getTopicDensity,
+		topicCount: topicCount,
 		sentences,
 	};
 

--- a/src/researches/getTopicDensity.js
+++ b/src/researches/getTopicDensity.js
@@ -6,7 +6,7 @@ const topicCount = require( "./topicCount.js" );
 /**
  * Calculates the topic density .
  *
- * @param {object} paper The paper containing keyword, (synonyms) and text.
+ * @param {Object} paper The paper containing keyword, (synonyms) and text.
  * @returns {number} The topic density.
  */
 module.exports = function( paper ) {

--- a/src/researches/getTopicDensity.js
+++ b/src/researches/getTopicDensity.js
@@ -1,0 +1,19 @@
+/** @module analyses/getTopicDensity */
+
+const countWords = require( "../stringProcessing/countWords.js" );
+
+/**
+ * Calculates the topic density .
+ *
+ * @param {object} paper The paper containing keyword, (synonyms) and text.
+ * @param {object} researcher The researcher.
+ * @returns {number} The topic density.
+ */
+module.exports = function( paper, researcher ) {
+	const wordCount = countWords( paper.getText() );
+	if ( wordCount === 0 ) {
+		return 0;
+	}
+	const topicCount = researcher.getResearch( "topicCount" ).count;
+	return ( topicCount / wordCount ) * 100;
+};

--- a/src/researches/getTopicDensity.js
+++ b/src/researches/getTopicDensity.js
@@ -1,19 +1,19 @@
 /** @module analyses/getTopicDensity */
 
 const countWords = require( "../stringProcessing/countWords.js" );
+const topicCount = require( "./topicCount.js" );
 
 /**
  * Calculates the topic density .
  *
  * @param {object} paper The paper containing keyword, (synonyms) and text.
- * @param {object} researcher The researcher.
  * @returns {number} The topic density.
  */
-module.exports = function( paper, researcher ) {
+module.exports = function( paper ) {
 	const wordCount = countWords( paper.getText() );
 	if ( wordCount === 0 ) {
 		return 0;
 	}
-	const topicCount = researcher.getResearch( "topicCount" ).count;
-	return ( topicCount / wordCount ) * 100;
+	const topicCountResult = topicCount( paper ).count;
+	return ( topicCountResult / wordCount ) * 100;
 };

--- a/src/researches/topicCount.js
+++ b/src/researches/topicCount.js
@@ -12,15 +12,17 @@ const unique = require( "lodash/uniq" );
  */
 module.exports = function( paper ) {
 	const getSynonymsResult = getSynonyms( paper );
-	const keyword = getSynonymsResult.keyword;
-	const synonyms = getSynonymsResult.synonyms;
-	const topicWords = keyword.concat( synonyms );
+	const topicWords = [].concat( getSynonymsResult.keyword, getSynonymsResult.synonyms );
 	const text = normalizeQuotes( paper.getText() );
+
 	const topicFound = matchTextWithArray( text, topicWords );
 
 	return {
 		count: topicFound.length,
-		matches: unique( topicFound ),
+		matches: unique( topicFound ).sort(
+			function( a, b ) {
+				return b.length - a.length;
+			} ),
 	};
 };
 

--- a/src/researches/topicCount.js
+++ b/src/researches/topicCount.js
@@ -7,12 +7,13 @@ const unique = require( "lodash/uniq" );
 /**
  * Calculates the topic count, i.e., how many times the keyword or its synonyms were encountered in the text.
  *
- * @param {object} paper The paper containing keyword, text and potentially synonyms.
+ * @param {Object} paper The paper containing keyword, text and potentially synonyms.
  * @returns {number} The keyword count.
  */
 module.exports = function( paper ) {
 	const getSynonymsResult = getSynonyms( paper );
-	const topicWords = [].concat( getSynonymsResult.keyword, getSynonymsResult.synonyms );
+	let topicWords = [].concat( getSynonymsResult.keyword, getSynonymsResult.synonyms );
+	topicWords.sort( ( a, b ) => b.length - a.length );
 	const text = normalizeQuotes( paper.getText() );
 
 	const topicFound = matchTextWithArray( text, topicWords );

--- a/src/researches/topicCount.js
+++ b/src/researches/topicCount.js
@@ -1,0 +1,27 @@
+/** @module analyses/getTopicCount */
+const matchTextWithArray = require( "../stringProcessing/matchTextWithArray.js" );
+const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
+const getSynonyms = require( "./getSynonyms.js" );
+const unique = require( "lodash/uniq" );
+
+/**
+ * Calculates the topic count, i.e., how many times the keyword or its synonyms were encountered in the text.
+ *
+ * @param {object} paper The paper containing keyword, text and potentially synonyms.
+ * @returns {number} The keyword count.
+ */
+module.exports = function( paper ) {
+	const getSynonymsResult = getSynonyms( paper );
+	const keyword = getSynonymsResult.keyword;
+	const synonyms = getSynonymsResult.synonyms;
+	const topicWords = keyword.concat( synonyms );
+	const text = normalizeQuotes( paper.getText() );
+	const topicFound = matchTextWithArray( text, topicWords );
+
+	return {
+		count: topicFound.length,
+		matches: unique( topicFound ),
+	};
+};
+
+

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -18,7 +18,7 @@ var UrlKeyword = require( "./assessments/seo/urlKeywordAssessment.js" );
 var UrlLength = require( "./assessments/seo/urlLengthAssessment.js" );
 var urlStopWords = require( "./assessments/seo/urlStopWordsAssessment.js" );
 // todo: remove topic density from seoAssessor and move it to seoAssessorPremium after it is ready.
-var topicDensity = require( "./assessments/seo/topicDensityAssessment.js" );
+var TopicDensity = require( "./assessments/seo/topicDensityAssessment.js" );
 /**
  * Creates the Assessor
  *
@@ -49,7 +49,7 @@ var SEOAssessor = function( i18n, options ) {
 		new UrlKeyword(),
 		new UrlLength(),
 		urlStopWords,
-		topicDensity,
+		new TopicDensity(),
 	];
 };
 

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -17,6 +17,8 @@ var TitleWidth = require( "./assessments/seo/pageTitleWidthAssessment.js" );
 var UrlKeyword = require( "./assessments/seo/urlKeywordAssessment.js" );
 var UrlLength = require( "./assessments/seo/urlLengthAssessment.js" );
 var urlStopWords = require( "./assessments/seo/urlStopWordsAssessment.js" );
+// todo: remove topic density from seoAssessor and move it to seoAssessorPremium after it is ready.
+var topicDensity = require( "./assessments/seo/topicDensityAssessment.js" );
 /**
  * Creates the Assessor
  *
@@ -47,6 +49,7 @@ var SEOAssessor = function( i18n, options ) {
 		new UrlKeyword(),
 		new UrlLength(),
 		urlStopWords,
+		topicDensity,
 	];
 };
 

--- a/src/stringProcessing/matchTextWithArray.js
+++ b/src/stringProcessing/matchTextWithArray.js
@@ -1,7 +1,7 @@
 /** @module stringProcessing/matchTextWithArray */
 
 var arrayToRegex = require( "../stringProcessing/createRegexFromArray.js" );
-var removeSpaces = require( "../stringProcessing/removeNonWordCharacters.js" );
+var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 
 /**
  * Matches strings from an array against a given text.
@@ -17,7 +17,7 @@ module.exports = function( text, array ) {
 	}
 
 	matches = matches.map( function( string ) {
-		return removeSpaces( string );
+		return stripSpaces( string );
 	} );
 
 	return matches;

--- a/src/stringProcessing/parseSynonyms.js
+++ b/src/stringProcessing/parseSynonyms.js
@@ -14,10 +14,9 @@ module.exports = function( synonyms ) {
 	let synonymsSplit = synonyms.split( "," );
 
 	synonymsSplit = synonymsSplit.map( function( synonym ) {
-		return removePunctuation( stripSpaces( synonym ) );
+		return removePunctuation( stripSpaces ( synonym ) );
 	} ).filter( function( synonym ) {
 		return synonym;
 	} );
-
 	return synonymsSplit;
 };

--- a/src/stringProcessing/parseSynonyms.js
+++ b/src/stringProcessing/parseSynonyms.js
@@ -14,7 +14,7 @@ module.exports = function( synonyms ) {
 	let synonymsSplit = synonyms.split( "," );
 
 	synonymsSplit = synonymsSplit.map( function( synonym ) {
-		return removePunctuation( stripSpaces ( synonym ) );
+		return removePunctuation( stripSpaces( synonym ) );
 	} ).filter( function( synonym ) {
 		return synonym;
 	} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Implements a topic density assessment that considers density of not only the keyword but also synonyms of the keyword, supplied by the user.

## Relevant technical choices:

* The keywordDensityAssessment is retained as it was.
* The keywordDensityAssessment is currently triggered all the time, but as soon as the Synonym Supply interface is ready it will only be triggered if no synonyms are supplied.
* The topicDensityAssessment has somewhat elevated boundaries compared to keywordDensityAssessment (by 0.5%), which is meant to allow those users who have already adjusted their writing style to keywordDensityAssessment to still get a green bullet with the new match functionality.

## Test instructions

This PR can be tested by following these steps:

* No changes have been implemented in WP-seo-premium yet, so please use browserified example.
* Paste a text and add a keyword. The keywordDensityAssessment should return meaningful result. The topicDensityAssessment should not be triggered.
* Add another word to the keyphrase, separated by a comma.
* The keywordDensityAssessment should change its result, most likely to 0% (unless you are extremely lucky and there is an exact combination of your keyword and synonym in your text).
* The topicDensityAssessment should appear and deliver a result similar to the original keywordDensityAssessment, but with somewhat higher %, in case both supplied words in the keyphrase occur in the text.
* Try adding multi-word items to the list, items with non-comma punctuation marks between words, words in different cases.

Fixes #1544
