### PR TITLE
Increase boundaries for topicDistribution

### DIFF
--- a/spec/assessments/topicDensitySpec.js
+++ b/spec/assessments/topicDensitySpec.js
@@ -25,7 +25,7 @@ describe( "An assessment for the topicDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "The topic density is 10%, which is way over the advised 3% maximum; the focus keyword and its synonyms were found 50 times." );
+		expect( result.getText() ).toBe( "The topic density is 10%, which is way over the advised 3.5% maximum; the focus keyword and its synonyms were found 50 times." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
@@ -39,13 +39,13 @@ describe( "An assessment for the topicDensity", function() {
 
 		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
 		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {
-			getTopicDensity: 3.5,
+			getTopicDensity: 3.8,
 			topicCount: {
 				count: 2,
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -10 );
-		expect( result.getText() ).toBe( "The topic density is 3.5%, which is over the advised 3% maximum; the focus keyword and its synonyms were found 2 times." );
+		expect( result.getText() ).toBe( "The topic density is 3.8%, which is over the advised 3.5% maximum; the focus keyword and its synonyms were found 2 times." );
 
 		paper = new Paper( "string with the keyword and keyword ", { keyword: "keyword" } );
 		result = new TopicDensityAssessment().getResult( paper, factory.buildMockResearcher( {

--- a/src/assessments/seo/topicDensityAssessment.js
+++ b/src/assessments/seo/topicDensityAssessment.js
@@ -24,10 +24,10 @@ class TopicDensityAssessment extends Assessment {
 
 		let defaultConfig = {
 			parameters: {
-				maxText: "3%",
+				maxText: "3.5%",
 				recommendedMinimum: 0.5,
-				recommendedMaximum: 3,
-				slightlyOverMaximum: 4,
+				recommendedMaximum: 3.5,
+				slightlyOverMaximum: 4.5,
 			},
 			scores: {
 				tooLittle: 4,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Establishes new boundaries for the assessment that calculates the density of keyword and its synonyms in the text.

## Relevant technical choices:

* n/a

## Test instructions

This PR can be tested by following these steps:

* In browserified or using a beta script
* Enter a text and one keyword, check if the old boundaries still apply (OKAY if <0.5%, GOOD if 0.5-2.5%, OKAY if 2.5-3.5%, BAD if >3.5%)
* Enter a synonym to the keyword, check if the new boundaries apply (OKAY if <0.5%, GOOD if 0.5-3.5%, OKAY if 3.5-4.5%, BAD if >4.5%)

Fixes #1562 
