### PR TITLE
Add links to SEO assessments

### DIFF
--- a/spec/assessments/internalLinksSpec.js
+++ b/spec/assessments/internalLinksSpec.js
@@ -28,7 +28,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed internal link(s) and 1 normal internal link(s)." );
+		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed <a href='https://yoa.st/2pm' target='_blank'>internal link(s)</a> and 1 normal internal link(s)." );
 
 		mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
 
@@ -48,7 +48,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
-		expect( assessment.getText() ).toEqual( "This page has 1 internal link(s), all nofollowed." );
+		expect( assessment.getText() ).toEqual( "This page has 1 <a href='https://yoa.st/2pm' target='_blank'>internal link(s)</a>, all nofollowed." );
 	} );
 
 	it( "Accepts a paper and i18nobject  ", function() {
@@ -56,6 +56,6 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "No internal links appear in this page, consider adding some as appropriate." );
+		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pm' target='_blank'>internal links</a> appear in this page, consider adding some as appropriate." );
 	} );
 } );

--- a/spec/assessments/introductionKeywordSpec.js
+++ b/spec/assessments/introductionKeywordSpec.js
@@ -9,20 +9,20 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 1 ), i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "The focus keyword appears in the first paragraph of the copy." );
+		expect( assessment.getText() ).toBe( "The focus keyword appears in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy." );
 	} );
 
 	it( "returns multiple keywords found in the first paragraph", function() {
 		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 10 ), i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "The focus keyword appears in the first paragraph of the copy." );
+		expect( assessment.getText() ).toBe( "The focus keyword appears in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy." );
 	} );
 
 	it( "returns no keyword found in the first paragraph", function() {
 		var assessment = firstParagraphAssessment.getResult( paper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The focus keyword doesn't appear in the first paragraph of the copy. Make sure the topic is clear immediately." );
+		expect( assessment.getText() ).toBe( "The focus keyword doesn't appear in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy. Make sure the topic is clear immediately." );
 	} );
 } );

--- a/spec/assessments/keyphraseLengthSpec.js
+++ b/spec/assessments/keyphraseLengthSpec.js
@@ -12,7 +12,7 @@ describe( "the keyphrase length assessment", function() {
 		var result = keyphraseLengthAssessment.getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toEqual( -999 );
-		expect( result.getText() ).toEqual( "No focus keyword was set for this page. " +
+		expect( result.getText() ).toEqual( "No <a href='https://yoa.st/2pdd' target='_blank'>focus keyword</a> was set for this page. " +
 		   "If you do not set a focus keyword, no score can be calculated." );
 	} );
 
@@ -23,7 +23,7 @@ describe( "the keyphrase length assessment", function() {
 		var result = keyphraseLengthAssessment.getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toEqual( 0 );
-		expect( result.getText() ).toEqual( "The keyphrase is over 10 words, a keyphrase should be shorter." );
+		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2pd' target='_blank'>keyphrase</a> is over 10 words, a keyphrase should be shorter." );
 	} );
 
 	it( "should not assess a paper with a keyphrase that's the correct length", function() {

--- a/spec/assessments/keywordDensitySpec.js
+++ b/spec/assessments/keywordDensitySpec.js
@@ -13,7 +13,7 @@ describe( "An assessment for the keywordDensity", function() {
 			keywordCount: 0,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "The keyword density is 0%, which is too low; the focus keyword was found 0 times." );
+		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0%, which is too low; the focus keyword was found 0 times." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -21,7 +21,7 @@ describe( "An assessment for the keywordDensity", function() {
 			keywordCount: 1,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "The keyword density is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 times." );
+		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 times." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -29,7 +29,7 @@ describe( "An assessment for the keywordDensity", function() {
 			keywordCount: 1,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The keyword density is 2%, which is great; the focus keyword was found 1 times." );
+		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 2%, which is great; the focus keyword was found 1 times." );
 
 		paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -37,7 +37,7 @@ describe( "An assessment for the keywordDensity", function() {
 			keywordCount: 2,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -10 );
-		expect( result.getText() ).toBe( "The keyword density is 3%, which is over the advised 2.5% maximum; the focus keyword was found 2 times." );
+		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 3%, which is over the advised 2.5% maximum; the focus keyword was found 2 times." );
 
 		paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -45,6 +45,6 @@ describe( "An assessment for the keywordDensity", function() {
 			keywordCount: 2,
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The keyword density is 0.5%, which is great; the focus keyword was found 2 times." );
+		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.5%, which is great; the focus keyword was found 2 times." );
 	} );
 } );

--- a/spec/assessments/metaDescriptionKeywordSpec.js
+++ b/spec/assessments/metaDescriptionKeywordSpec.js
@@ -12,7 +12,7 @@ describe( "the metadescription keyword assessment", function() {
 		var result = metaDescriptionKeyword.getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "A meta description has been specified, but it does not contain the focus keyword." );
+		expect( result.getText() ).toBe( "A meta description has been specified, but it <a href='https://yoa.st/2pf' target='_blank'>does not contain the focus keyword</a>." );
 	} );
 
 	it( "should score a meta with no matching keyword as bad", function() {
@@ -22,7 +22,7 @@ describe( "the metadescription keyword assessment", function() {
 		var result = metaDescriptionKeyword.getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The meta description contains the focus keyword." );
+		expect( result.getText() ).toBe( "The meta description <a href='https://yoa.st/2pf' target='_blank'>contains the focus keyword</a>." );
 	} );
 
 	it( "should not score since there is no meta", function() {

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -11,7 +11,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual( "No meta description has been specified. Search engines will display copy from the page instead." );
+		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has been specified. Search engines will display copy from the page instead." );
 	} );
 
 	it( "assesses a short description", function() {
@@ -19,7 +19,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The meta description is under 120 characters long. However, up to 156 characters are available." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> is under 120 characters long. However, up to 156 characters are available." );
 	} );
 
 	it( "assesses a too long description", function() {
@@ -27,7 +27,7 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The meta description is over 156 characters. Reducing the length will ensure the entire description will be visible." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> is over 156 characters. Reducing the length will ensure the entire description will be visible." );
 	} );
 
 	it( "assesses a good description", function() {
@@ -35,6 +35,6 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The meta description has a nice length." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has a nice length." );
 	} );
 } );

--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -30,7 +30,7 @@ describe( "An assessor running the linkStatistics", function() {
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed outbound link(s) and 1 normal outbound link(s)." );
+		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a> and 1 normal outbound link(s)." );
 
 		mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
 
@@ -50,7 +50,7 @@ describe( "An assessor running the linkStatistics", function() {
 		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
-		expect( assessment.getText() ).toEqual( "This page has 1 outbound link(s), all nofollowed." );
+		expect( assessment.getText() ).toEqual( "This page has 1 <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a>, all nofollowed." );
 	} );
 
 	it( "Accepts a paper and i18nobject  ", function() {
@@ -58,6 +58,6 @@ describe( "An assessor running the linkStatistics", function() {
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "No outbound links appear in this page, consider adding some as appropriate." );
+		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pl' target='_blank'>outbound links</a> appear in this page, consider adding some as appropriate." );
 	} );
 } );

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -7,7 +7,7 @@ var i18n = factory.buildJed();
 let pageTitleLengthAssessment = new PageTitleLengthAssessment();
 
 describe( "the SEO title length assessment", function() {
-	it( "should assess a paper without a SEO title", function() {
+	it( "should assess a paper without a <a href='https://yoa.st/2po' target='_blank'>SEO title</a>", function() {
 		var paper = new Paper( "" );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
@@ -19,27 +19,27 @@ describe( "the SEO title length assessment", function() {
 		var paper = new Paper( "", { title: "The Title" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 9 ), i18n );
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "The SEO title is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
+		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
 	} );
 
 	it( "should assess a paper with a SEO title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 450 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The SEO title has a nice length." );
+		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length." );
 	} );
 
 	it( "should assess a paper with a SEO title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The SEO title has a nice length." );
+		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length." );
 	} );
 
 	it( "should assess a paper with a SEO title that's longer than the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );
 		expect( result.getScore() ).toEqual( 3 );
-		expect( result.getText() ).toEqual( "The SEO title is wider than the viewable limit." );
+		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> is wider than the viewable limit." );
 	} );
 } );

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -12,7 +12,7 @@ describe( "the SEO title length assessment", function() {
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toEqual( 1 );
-		expect( result.getText() ).toEqual( "Please create an SEO title." );
+		expect( result.getText() ).toEqual( "Please create an <a href='https://yoa.st/2po' target='_blank'>SEO title</a>." );
 	} );
 
 	it( "should assess a paper with a SEO title that's under the recommended value", function() {

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -19,20 +19,20 @@ describe( "An assessment for matching keywords in subheadings", function() {
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "You have not used the focus keyword in any subheading (such as an H2) in your copy." );
+		expect( assessment.getText() ).toEqual( "You have not used the focus keyword in any <a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2) in your copy." );
 	} );
 	it( "assesses a string with subheadings and keywords", function() {
 		var mockPaper = new Paper();
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 1) subheadings in your copy." );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 1) <a href='https://yoa.st/2ph' target='_blank'>subheadings</a> in your copy." );
 	} );
 	it( "assesses a string with subheadings and keywords", function() {
 		var mockPaper = new Paper();
 		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 10, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 10) subheadings in your copy." );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 10) <a href='https://yoa.st/2ph' target='_blank'>subheadings</a> in your copy." );
 	} );
 } );

--- a/spec/assessments/taxonomyTextLengthSpec.js
+++ b/spec/assessments/taxonomyTextLengthSpec.js
@@ -9,7 +9,7 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 1 word. This is far below the recommended minimum of 150 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 1 word. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -18,7 +18,7 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 5 words. This is far below the recommended minimum of 150 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 5 words. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -27,7 +27,7 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 90 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -10 );
-		expect( assessment.getText() ).toEqual( "The text contains 90 words. This is below the recommended minimum of 150 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 90 words. This is below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -36,7 +36,7 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 110 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 5 );
-		expect( assessment.getText() ).toEqual( "The text contains 110 words. This is below the recommended minimum of 150 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 110 words. This is below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -45,7 +45,7 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 130 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
-		expect( assessment.getText() ).toEqual( "The text contains 130 words. This is slightly below the recommended minimum of 150 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 130 words. This is slightly below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
 			"Add a bit more copy." );
 	} );
 
@@ -54,6 +54,6 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 175 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The text contains 175 words. This is more than or equal to the recommended minimum of 150 words." );
+		expect( assessment.getText() ).toEqual( "The text contains 175 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words." );
 	} );
 } );

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -12,7 +12,7 @@ describe( "An image count assessment", function() {
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "No images appear in this page, consider adding some as appropriate." );
+		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pj' target='_blank'>images</a> appear in this page, consider adding some as appropriate." );
 	} );
 
 	it( "assesses a single image, without a keyword and alt-tag set", function() {
@@ -26,7 +26,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The images on this page are missing alt attributes." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page are missing alt attributes." );
 	} );
 
 	it( "assesses a single image, without a keyword, but with an alt-tag set", function() {
@@ -40,7 +40,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The images on this page contain alt attributes." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
@@ -56,7 +56,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The images on this page do not have alt attributes containing the focus keyword." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page do not have alt attributes containing the focus keyword." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword", function() {

--- a/spec/assessments/textLengthSpec.js
+++ b/spec/assessments/textLengthSpec.js
@@ -11,7 +11,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 1 word. This is far below the recommended minimum of 300 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 1 word. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -20,7 +20,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 5 words. This is far below the recommended minimum of 300 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 5 words. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -29,7 +29,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 150 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -10 );
-		expect( assessment.getText() ).toEqual( "The text contains 150 words. This is far below the recommended minimum of 300 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 150 words. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -38,7 +38,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 225 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "The text contains 225 words. This is below the recommended minimum of 300 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 225 words. This is below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
 			"Add more content that is relevant for the topic." );
 	} );
 
@@ -47,7 +47,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 275 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The text contains 275 words. This is slightly below the recommended minimum of 300 words. " +
+		expect( assessment.getText() ).toEqual( "The text contains 275 words. This is slightly below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
 			 "Add a bit more copy." );
 	} );
 
@@ -57,6 +57,6 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 325 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The text contains 325 words. This is more than or equal to the recommended minimum of 300 words." );
+		expect( assessment.getText() ).toEqual( "The text contains 325 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words." );
 	} );
 } );

--- a/spec/assessments/titleKeywordSpec.js
+++ b/spec/assessments/titleKeywordSpec.js
@@ -11,7 +11,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { matches: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toBe( 2 );
-		expect( assessment.getText() ).toBe( "The focus keyword 'keyword' does not appear in the SEO title." );
+		expect( assessment.getText() ).toBe( "The focus keyword 'keyword' does not appear in the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>." );
 	} );
 
 	it( "returns an assementresult with keyword found at start", function() {
@@ -21,7 +21,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { matches: 1, position: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "The SEO title contains the focus keyword, at the beginning which is considered to improve rankings." );
+		expect( assessment.getText() ).toBe( "The <a href='https://yoa.st/2pn' target='_blank'>SEO title</a> contains the focus keyword, at the beginning which is considered to improve rankings." );
 	} );
 
 	it( "returns an assementresult with keyword found at start", function() {
@@ -31,6 +31,6 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		var assessment = pageTitleKeywordAssessment.getResult( paper, Factory.buildMockResearcher( { matches: 1, position: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "The SEO title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning." );
+		expect( assessment.getText() ).toBe( "The <a href='https://yoa.st/2pn' target='_blank'>SEO title</a> contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning." );
 	} );
 } );

--- a/spec/assessments/urlKeywordSpec.js
+++ b/spec/assessments/urlKeywordSpec.js
@@ -15,7 +15,7 @@ describe( "A keyword in url count assessment", function() {
 		var assessment = keywordInUrl.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The focus keyword does not appear in the URL for this page. If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!" );
+		expect( assessment.getText() ).toEqual( "The focus keyword does not appear in the <a href='https://yoa.st/2pp' target='_blank'>URL</a> for this page. If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!" );
 	} );
 
 	it( "assesses a keyword was found in the url", function() {
@@ -26,6 +26,6 @@ describe( "A keyword in url count assessment", function() {
 		var assessment = keywordInUrl.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in the URL for this page." );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears in the <a href='https://yoa.st/2pp' target='_blank'>URL</a> for this page." );
 	} );
 } );

--- a/src/assessments/seo/internalLinksAssessment.js
+++ b/src/assessments/seo/internalLinksAssessment.js
@@ -9,39 +9,61 @@ var isEmpty = require( "lodash/isEmpty" );
  * @returns {object} resultObject with score and text
  */
 var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
+	const url = "<a href='https://yoa.st/2pm' target='_blank'>";
+
 	if ( linkStatistics.internalTotal === 0 ) {
 		return {
 			score: 3,
-			text: i18n.dgettext( "js-text-analysis", "No internal links appear in this page, consider adding some as appropriate." ),
+			text: i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "No %1$sinternal links%2$s appear in this page, consider adding some as appropriate." ),
+				url,
+				"</a>"
+			)
 		};
 	}
 
 	if ( linkStatistics.internalNofollow === linkStatistics.total ) {
 		return {
 			score: 7,
-			/* Translators: %1$s expands the number of internal links */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s internal link(s), all nofollowed." ),
-				linkStatistics.internalNofollow ),
+			text: i18n.sprintf(
+				/* Translators: %1$s expands the number of internal links, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$sinternal link(s)%3$s, all nofollowed." ),
+				linkStatistics.internalNofollow,
+				url,
+				"</a>"
+			)
 		};
 	}
 
 	if ( linkStatistics.internalNofollow < linkStatistics.internalTotal ) {
 		return {
 			score: 8,
-			/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of internal links */
-			text: i18n.sprintf( i18n.dgettext(
+			text: i18n.sprintf(
+				/* Translators: %1$s expands to the number of nofollow links, %2$s expands to a link on yoast.com,
+				%3$s expands to the anchor end tag, %4$s to the number of internal links */
+				i18n.dgettext(
 				"js-text-analysis",
-				"This page has %1$s nofollowed internal link(s) and %2$s normal internal link(s)."
+				"This page has %1$s nofollowed %2$sinternal link(s)%3$s and %4$s normal internal link(s)."
 			),
-			linkStatistics.internalNofollow, linkStatistics.internalDofollow ),
+				linkStatistics.internalNofollow,
+				url,
+				"</a>",
+				linkStatistics.internalDofollow
+			),
 		};
 	}
 
 	if ( linkStatistics.internalDofollow === linkStatistics.total ) {
 		return {
 			score: 9,
-			/* Translators: %1$s expands to the number of internal links */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s internal link(s)." ), linkStatistics.internalTotal ),
+			text: i18n.sprintf(
+				/* Translators: %1$s expands to the number of internal links, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$sinternal link(s)%3$s." ),
+				linkStatistics.internalTotal,
+				url,
+				"</a>"
+			),
 		};
 	}
 

--- a/src/assessments/seo/internalLinksAssessment.js
+++ b/src/assessments/seo/internalLinksAssessment.js
@@ -19,7 +19,7 @@ var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
 				i18n.dgettext( "js-text-analysis", "No %1$sinternal links%2$s appear in this page, consider adding some as appropriate." ),
 				url,
 				"</a>"
-			)
+			),
 		};
 	}
 
@@ -32,7 +32,7 @@ var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
 				linkStatistics.internalNofollow,
 				url,
 				"</a>"
-			)
+			),
 		};
 	}
 
@@ -43,9 +43,9 @@ var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
 				/* Translators: %1$s expands to the number of nofollow links, %2$s expands to a link on yoast.com,
 				%3$s expands to the anchor end tag, %4$s to the number of internal links */
 				i18n.dgettext(
-				"js-text-analysis",
-				"This page has %1$s nofollowed %2$sinternal link(s)%3$s and %4$s normal internal link(s)."
-			),
+					"js-text-analysis",
+					"This page has %1$s nofollowed %2$sinternal link(s)%3$s and %4$s normal internal link(s)."
+				),
 				linkStatistics.internalNofollow,
 				url,
 				"</a>",
@@ -58,7 +58,8 @@ var calculateLinkStatisticsResult = function( linkStatistics, i18n ) {
 		return {
 			score: 9,
 			text: i18n.sprintf(
-				/* Translators: %1$s expands to the number of internal links, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+				/* Translators: %1$s expands to the number of internal links, %2$s expands to a link on yoast.com,
+				%3$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$sinternal link(s)%3$s." ),
 				linkStatistics.internalTotal,
 				url,

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -8,17 +8,29 @@ var AssessmentResult = require( "../../values/AssessmentResult.js" );
  * @returns {object} resultObject with score and text
  */
 var calculateFirstParagraphResult = function( firstParagraphMatches, i18n ) {
+	const url = "<a href='https://yoa.st/2pc' target='_blank'>";
+
 	if ( firstParagraphMatches > 0 ) {
 		return {
 			score: 9,
-			text: i18n.dgettext( "js-text-analysis", "The focus keyword appears in the first paragraph of the copy." ),
+			text: i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "The focus keyword appears in the %1$sfirst paragraph%2$s of the copy." ),
+				url,
+				"</a>"
+			)
 		};
 	}
 
 	return {
 		score: 3,
-		text: i18n.dgettext( "js-text-analysis", "The focus keyword doesn't appear in the first paragraph of the copy. " +
+		text: i18n.sprintf(
+			/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "The focus keyword doesn't appear in the %1$sfirst paragraph%2$s of the copy. " +
 			"Make sure the topic is clear immediately." ),
+			url,
+			"</a>"
+		)
 	};
 };
 

--- a/src/assessments/seo/introductionKeywordAssessment.js
+++ b/src/assessments/seo/introductionKeywordAssessment.js
@@ -18,7 +18,7 @@ var calculateFirstParagraphResult = function( firstParagraphMatches, i18n ) {
 				i18n.dgettext( "js-text-analysis", "The focus keyword appears in the %1$sfirst paragraph%2$s of the copy." ),
 				url,
 				"</a>"
-			)
+			),
 		};
 	}
 
@@ -30,7 +30,7 @@ var calculateFirstParagraphResult = function( firstParagraphMatches, i18n ) {
 			"Make sure the topic is clear immediately." ),
 			url,
 			"</a>"
-		)
+		),
 	};
 };
 

--- a/src/assessments/seo/keyphraseLengthAssessment.js
+++ b/src/assessments/seo/keyphraseLengthAssessment.js
@@ -10,16 +10,25 @@ var AssessmentResult = require( "../../values/AssessmentResult.js" );
 */
 function keyphraseAssessment( paper, researcher, i18n ) {
 	var keyphraseLength = researcher.getResearch( "keyphraseLength" );
-
 	var assessmentResult = new AssessmentResult();
+	const urlNoKeyword = "<a href='https://yoa.st/2pdd' target='_blank'>";
+	const urlKeyphraseTooLong = "<a href='https://yoa.st/2pd' target='_blank'>";
 
 	if ( ! paper.hasKeyword() ) {
 		assessmentResult.setScore( -999 );
-		assessmentResult.setText( i18n.dgettext( "js-text-analysis", "No focus keyword was set for this page. " +
-			"If you do not set a focus keyword, no score can be calculated." ) );
+		assessmentResult.setText( i18n.sprintf(
+			/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "No %1$sfocus keyword%2$s was set for this page. " +
+			"If you do not set a focus keyword, no score can be calculated." ),
+			urlNoKeyword, "</a>" )
+		);
 	} else if ( keyphraseLength > 10 ) {
 		assessmentResult.setScore( 0 );
-		assessmentResult.setText( i18n.dgettext( "js-text-analysis", "The keyphrase is over 10 words, a keyphrase should be shorter." ) );
+		assessmentResult.setText( i18n.sprintf(
+			/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "The %1$skeyphrase%2$s is over 10 words, a keyphrase should be shorter." ),
+			urlKeyphraseTooLong, "</a>" )
+		);
 	}
 
 	return assessmentResult;

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -19,53 +19,58 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 	var score, text, max;
 	var roundedKeywordDensity = formatNumber( keywordDensity );
 	var keywordDensityPercentage = roundedKeywordDensity + "%";
+	const url = "<a href='https://yoa.st/2pe' target='_blank'>";
 
 	if ( roundedKeywordDensity > 3.5 ) {
 		score = -50;
 
-		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
-		%3$s expands to the maximum keyword density percentage. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
-			" which is way over the advised %3$s maximum;" +
-			" the focus keyword was found %2$d times." );
+		/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+		%3$s expands to the keyword density percentage, %4$d expands to the keyword count,
+		%5$s expands to the maximum keyword density percentage. */
+		text = i18n.dgettext( "js-text-analysis", "The %1$skeyword density%2$s is %3$s," +
+			" which is way over the advised %5$s maximum;" +
+			" the focus keyword was found %4$d times." );
 
 		max = "2.5%";
 
-		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
+		text = i18n.sprintf( text, url, "</a>", keywordDensityPercentage, keywordCount, max );
 	}
 
 	if ( inRangeEndInclusive( roundedKeywordDensity, 2.5, 3.5 ) ) {
 		score = -10;
 
-		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
-		%3$s expands to the maximum keyword density percentage. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s," +
-			" which is over the advised %3$s maximum;" +
-			" the focus keyword was found %2$d times." );
+		/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+		%3$s expands to the keyword density percentage, %4$d expands to the keyword count,
+		%5$s expands to the maximum keyword density percentage. */
+		text = i18n.dgettext( "js-text-analysis", "The %1$skeyword density%2$s is %3$s," +
+			" which is over the advised %5$s maximum;" +
+			" the focus keyword was found %4$d times." );
 
 		max = "2.5%";
 
-		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, max );
+		text = i18n.sprintf( text, url, "</a>", keywordDensityPercentage, keywordCount, max );
 	}
 
 	if ( inRangeStartEndInclusive( roundedKeywordDensity, 0.5, 2.5 ) ) {
 		score = 9;
 
-		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is great;" +
-			" the focus keyword was found %2$d times." );
+		/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+		%3$s expands to the keyword density percentage, %4$d expands to the keyword count. */
+		text = i18n.dgettext( "js-text-analysis", "The %1$skeyword density%2$s is %3$s, which is great;" +
+			" the focus keyword was found %4$d times." );
 
-		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
+		text = i18n.sprintf( text, url, "</a>", keywordDensityPercentage, keywordCount );
 	}
 
 	if ( inRangeStartInclusive( roundedKeywordDensity, 0, 0.5 ) ) {
 		score = 4;
 
-		/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-		text = i18n.dgettext( "js-text-analysis", "The keyword density is %1$s, which is too low;" +
-			" the focus keyword was found %2$d times." );
+		/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+		%3$s expands to the keyword density percentage, %4$d expands to the keyword count. */
+		text = i18n.dgettext( "js-text-analysis", "The %1$skeyword density%2$s is %3$s, which is too low;" +
+			" the focus keyword was found %4$d times." );
 
-		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount );
+		text = i18n.sprintf( text, url, "</a>", keywordDensityPercentage, keywordCount );
 	}
 
 	return {

--- a/src/assessments/seo/metaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/metaDescriptionKeywordAssessment.js
@@ -7,16 +7,28 @@ var AssessmentResult = require( "../../values/AssessmentResult.js" );
  * @returns {Object} An object with values for the assessment result.
  */
 var calculateKeywordMatchesResult = function( keywordMatches, i18n ) {
+	const url = "<a href='https://yoa.st/2pf' target='_blank'>";
+
 	if ( keywordMatches > 0 ) {
 		return {
 			score: 9,
-			text: i18n.dgettext( "js-text-analysis", "The meta description contains the focus keyword." ),
+			text: i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "The meta description %1$scontains the focus keyword%2$s." ),
+				url,
+				"</a>"
+			)
 		};
 	}
 	if ( keywordMatches === 0 ) {
 		return {
 			score: 3,
-			text: i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it does not contain the focus keyword." ),
+			text: i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it %1$sdoes not contain the focus keyword%2$s." ),
+				url,
+				"</a>"
+			)
 		};
 	}
 	return {};

--- a/src/assessments/seo/metaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/metaDescriptionKeywordAssessment.js
@@ -17,7 +17,7 @@ var calculateKeywordMatchesResult = function( keywordMatches, i18n ) {
 				i18n.dgettext( "js-text-analysis", "The meta description %1$scontains the focus keyword%2$s." ),
 				url,
 				"</a>"
-			)
+			),
 		};
 	}
 	if ( keywordMatches === 0 ) {
@@ -28,7 +28,7 @@ var calculateKeywordMatchesResult = function( keywordMatches, i18n ) {
 				i18n.dgettext( "js-text-analysis", "A meta description has been specified, but it %1$sdoes not contain the focus keyword%2$s." ),
 				url,
 				"</a>"
-			)
+			),
 		};
 	}
 	return {};

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -103,23 +103,51 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( descriptionLength, i18n ) {
+		const url = "<a href='https://yoa.st/2pg' target='_blank'>";
+
 		if ( descriptionLength === 0 ) {
-			return i18n.dgettext( "js-text-analysis", "No meta description has been specified. " +
-				"Search engines will display copy from the page instead." );
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "No %1$smeta description%2$s has been specified. " +
+				"Search engines will display copy from the page instead." ),
+				url,
+				"</a>"
+			);
 		}
 
 		if ( descriptionLength <= this._config.recommendedMaximumLength ) {
-			return i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is under %1$d characters long. " +
-				"However, up to %2$d characters are available." ), this._config.recommendedMaximumLength, this._config.maximumLength );
+			return i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+				%3$d expands to the number of characters in the meta description, %4$d expands to
+				the total available number of characters in the meta description */
+				i18n.dgettext( "js-text-analysis", "The %1$smeta description%2$s is under %3$d characters long. " +
+				"However, up to %4$d characters are available." ),
+				url,
+				"</a>",
+				this._config.recommendedMaximumLength,
+				this._config.maximumLength
+			);
 		}
 
 		if ( descriptionLength > this._config.maximumLength ) {
-			return i18n.sprintf( i18n.dgettext( "js-text-analysis", "The meta description is over %1$d characters. " +
-				"Reducing the length will ensure the entire description will be visible." ), this._config.maximumLength );
+			return i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+				%3$d expands to	the total available number of characters in the meta description */
+				i18n.dgettext( "js-text-analysis", "The %1$smeta description%2$s is over %3$d characters. " +
+				"Reducing the length will ensure the entire description will be visible." ),
+				url,
+				"</a>",
+				this._config.maximumLength
+			);
 		}
 
 		if ( descriptionLength >= this._config.recommendedMaximumLength && descriptionLength <= this._config.maximumLength ) {
-			return i18n.dgettext( "js-text-analysis", "The meta description has a nice length." );
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "The %1$smeta description%2$s has a nice length." ),
+				url,
+				"</a>"
+			);
 		}
 	}
 }

--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -96,28 +96,44 @@ class OutboundLinksAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( linkStatistics, i18n ) {
+		const url = "<a href='https://yoa.st/2pl' target='_blank'>";
+
 		if ( linkStatistics.externalTotal === 0 ) {
-			return i18n.dgettext( "js-text-analysis", "No outbound links appear in this page, consider adding some as appropriate." );
+			return i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "No %1$soutbound links%2$s appear in this page, consider adding some as appropriate." ),
+				url,
+				"</a>"
+			);
 		}
 
 		if ( linkStatistics.externalNofollow === linkStatistics.total ) {
-			/* Translators: %1$s expands the number of outbound links */
-			return i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s outbound link(s), all nofollowed." ),
-				linkStatistics.externalNofollow );
+			return i18n.sprintf(
+				/* Translators: %1$s expands the number of outbound links, %2$s expands to a link on yoast.com,
+				%3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$soutbound link(s)%3$s, all nofollowed." ),
+				linkStatistics.externalNofollow,
+				url,
+				"</a>"
+			);
 		}
 
 		if ( linkStatistics.externalNofollow < linkStatistics.externalTotal ) {
-			/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of outbound links */
-			return i18n.sprintf( i18n.dgettext(
-				"js-text-analysis",
-				"This page has %1$s nofollowed outbound link(s) and %2$s normal outbound link(s)."
-			),
-			linkStatistics.externalNofollow, linkStatistics.externalDofollow );
+			return i18n.sprintf(
+				/* Translators: %1$s expands to the number of nofollow links, %2$s expands to a link on yoast.com,
+				%3$s expands to the anchor end tag, %4$s to the number of outbound links */
+				i18n.dgettext( "js-text-analysis", "This page has %1$s nofollowed %2$soutbound link(s)%3$s and %4$s normal outbound link(s)." ),
+				linkStatistics.externalNofollow,
+				url,
+				"</a>",
+				linkStatistics.externalDofollow );
 		}
 
 		if ( linkStatistics.externalDofollow === linkStatistics.total ) {
-			/* Translators: %1$s expands to the number of outbound links */
-			return i18n.sprintf( i18n.dgettext( "js-text-analysis", "This page has %1$s outbound link(s)." ), linkStatistics.externalTotal );
+			return i18n.sprintf(
+				/* Translators: %1$s expands to the number of outbound links, %2$s expands to a link on yoast.com,
+				%3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$soutbound link(s)%3$s." ), linkStatistics.externalTotal );
 		}
 
 		return "";

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -125,7 +125,11 @@ class PageTitleWidthAssesment extends Assessment {
 				),  url, "</a>" );
 		}
 
-		return i18n.dgettext( "js-text-analysis", "Please create an SEO title." );
+		return i18n.sprintf(
+			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "Please create an %1$sSEO title%2$s." ),
+			url, "</a>"
+		);
 	}
 }
 

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -97,25 +97,32 @@ class PageTitleWidthAssesment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( pageTitleWidth, i18n ) {
+		const url = "<a href='https://yoa.st/2po' target='_blank'>";
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
-			return i18n.dgettext(
-				"js-text-analysis",
-				"The SEO title is too short. Use the space to add keyword variations or create compelling call-to-action copy."
-			);
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext(
+					"js-text-analysis",
+					"The %1$sSEO title%2$s is too short. Use the space to add keyword variations or create compelling call-to-action copy."
+				), url, "</a>" );
 		}
 
 		if ( inRange( pageTitleWidth, this._config.minLength, this._config.maxLength ) ) {
-			return i18n.dgettext(
-				"js-text-analysis",
-				"The SEO title has a nice length."
-			);
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext(
+					"js-text-analysis",
+					"The %1$sSEO title%2$s has a nice length."
+				), url, "</a>" );
 		}
 
 		if ( pageTitleWidth > this._config.maxLength ) {
-			return i18n.dgettext(
-				"js-text-analysis",
-				"The SEO title is wider than the viewable limit."
-			);
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext(
+					"js-text-analysis",
+					"The %1$sSEO title%2$s is wider than the viewable limit."
+				),  url, "</a>" );
 		}
 
 		return i18n.dgettext( "js-text-analysis", "Please create an SEO title." );

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -91,18 +91,24 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( score, subHeadings, i18n ) {
+		const url = "<a href='https://yoa.st/2ph' target='_blank'>";
+
 		if ( score === this._config.scores.multipleMatches || score === this._config.scores.oneMatch ) {
 			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The focus keyword appears in %2$d (out of %1$d) subheadings in your copy." ),
-				subHeadings.count, subHeadings.matches
+				/* Translators: %1$d expands to the number of subheadings containing the keyword, %2$d expands to the
+				total number of subheadings, %3$s expands to a link on yoast.com, %4$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "The focus keyword appears in %1$d (out of %2$d) %3$ssubheadings%4$s in your copy." ),
+				subHeadings.matches, subHeadings.count, url, "</a>"
 			);
 		}
 
 		if ( score === this._config.scores.noMatches ) {
-			return i18n.dgettext(
-				"js-text-analysis",
-				"You have not used the focus keyword in any subheading (such as an H2) in your copy."
-			);
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext(
+					"js-text-analysis",
+					"You have not used the focus keyword in any %1$ssubheading%2$s (such as an H2) in your copy."
+				), url, "</a>" );
 		}
 
 		return "";

--- a/src/assessments/seo/taxonomyTextLengthAssessment.js
+++ b/src/assessments/seo/taxonomyTextLengthAssessment.js
@@ -9,22 +9,29 @@ var recommendedMinimum = 150;
  * @returns {object} The resulting score object.
  */
 var calculateWordCountResult = function( wordCount, i18n ) {
+	const url = "<a href='https://yoa.st/2pk' target='_blank'>";
+
 	if ( wordCount >= 150 ) {
 		return {
 			score: 9,
-			text: i18n.dngettext(
-
-
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text. */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is more than or equal to the recommended minimum of %2$d word.",
-				"This is more than or equal to the recommended minimum of %2$d words.",
+			text: i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text. */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag,	%4$s expands to the recommended minimum of words. */
+					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d word.",
+					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d words.",
+					recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				recommendedMinimum
 			),
 		};
@@ -33,17 +40,24 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 	if ( inRange( wordCount, 125, 150 ) ) {
 		return {
 			score: 7,
-			text: i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text. */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is slightly below the recommended minimum of %2$d word. Add a bit more copy.",
-				"This is slightly below the recommended minimum of %2$d words. Add a bit more copy.",
+			text: i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text. */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
+					"This is slightly below the %2$srecommended minimum%3$s of %4$d word. Add a bit more copy.",
+					"This is slightly below the %2$srecommended minimum%3$s of %4$d words. Add a bit more copy.",
+					recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				recommendedMinimum
 			),
 		};
@@ -52,17 +66,24 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 	if ( inRange( wordCount, 100, 125 ) ) {
 		return {
 			score: 5,
-			text: i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text. */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
+			text: i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text. */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
+					"This is below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
+					"This is below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				recommendedMinimum
 			),
 		};
@@ -71,17 +92,24 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 	if ( inRange( wordCount, 50, 100 ) ) {
 		return {
 			score: -10,
-			text: i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text. */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
+			text: i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text. */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
+					"This is below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
+					"This is below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				recommendedMinimum
 			),
 		};
@@ -90,17 +118,24 @@ var calculateWordCountResult = function( wordCount, i18n ) {
 	if ( inRange( wordCount, 0, 50 ) ) {
 		return {
 			score: -20,
-			text: i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text. */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
+			text: i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text. */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag,  %4$s expands to the recommended minimum of words. */
+					"This is far below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
+					"This is far below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				recommendedMinimum
 			),
 		};

--- a/src/assessments/seo/textCompetingLinksAssessment.js
+++ b/src/assessments/seo/textCompetingLinksAssessment.js
@@ -13,12 +13,16 @@ var map = require( "lodash/map" );
  * @returns {object} resultObject with score and text
  */
 var calculateLinkCountResult = function( linkStatistics, i18n ) {
+	const url = "<a href='https://yoa.st/2pi' target='_blank'>";
+
 	if ( linkStatistics.keyword.totalKeyword > 0 ) {
 		return {
 			score: 2,
 			hasMarks: true,
-			text: i18n.dgettext( "js-text-analysis", "You're linking to another page with the focus keyword you want this page to rank for. " +
-				"Consider changing that if you truly want this page to rank." ),
+			text: i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "You're %1$slinking to another page with the focus keyword%2$s you want this page to rank for. " +
+				"Consider changing that if you truly want this page to rank." ), url, "</a>" ),
 		};
 	}
 	return {};

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -107,28 +107,51 @@ class TextImagesAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( imageCount, altProperties, i18n ) {
+		const url = "<a href='https://yoa.st/2pj' target='_blank'>";
+
 		if ( imageCount === 0 ) {
-			return i18n.dgettext( "js-text-analysis", "No images appear in this page, consider adding some as appropriate." );
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "No %1$simages%2$s appear in this page, consider adding some as appropriate." ),
+				url,
+				"</a>"
+			);
 		}
 
 		// Has alt-tag and keywords
 		if ( altProperties.withAltKeyword > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes with the focus keyword." );
+			return i18n.sprintf(
+				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes with the focus keyword." ),
+				url,
+				"</a>"
+			);
 		}
 
 		// Has alt-tag, but no keywords and it's not okay
 		if ( altProperties.withAltNonKeyword > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page do not have alt attributes containing the focus keyword." );
+			return i18n.sprintf(
+				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page do not have alt attributes containing the focus keyword." ),
+				url,
+				"</a>"
+			);
 		}
 
 		// Has alt-tag, but no keyword is set
 		if ( altProperties.withAlt > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page contain alt attributes." );
+			return i18n.sprintf(
+				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes." ),
+				url,
+				"</a>"
+			);
 		}
 
 		// Has no alt-tag
 		if ( altProperties.noAlt > 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The images on this page are missing alt attributes." );
+			return i18n.sprintf(
+				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page are missing alt attributes." ),
+				url,
+				"</a>"
+			);
 		}
 
 		return "";

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -97,66 +97,96 @@ class TextLengthAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( score, wordCount, i18n ) {
+		const url = "<a href='https://yoa.st/2pk' target='_blank'>";
+
 		if ( score === this._config.scores.recommendedMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-				"This is more than or equal to the recommended minimum of %2$d word.",
-				"This is more than or equal to the recommended minimum of %2$d words.",
+			return i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag,	%4$s expands to the recommended minimum of words. */
+					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d word.",
+					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d words.",
+					this._config.recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				this._config.recommendedMinimum
 			);
 		}
 
 		if ( score === this._config.scores.slightlyBelowMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is slightly below the recommended minimum of %2$d word. Add a bit more copy.",
-				"This is slightly below the recommended minimum of %2$d words. Add a bit more copy.",
+			return i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
+					"This is slightly below the %2$srecommended minimum%3$s of %4$d word. Add a bit more copy.",
+					"This is slightly below the %2$srecommended minimum%3$s of %4$d words. Add a bit more copy.",
+					this._config.recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				this._config.recommendedMinimum
 			);
 		}
 
 		if ( score === this._config.scores.belowMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
+			return i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
+					"This is below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
+					"This is below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					this._config.recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				this._config.recommendedMinimum
 			);
 		}
 
 		if ( score === this._config.scores.farBelowMinimum || score === this._config.scores.veryFarBelowMinimum ) {
-			return i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text */
-				"The text contains %1$d word.",
-				"The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-				"This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.",
-				"This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.",
+			return i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text */
+					"The text contains %1$d word.",
+					"The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
+					%3$s expands to the anchor end tag,  %4$s expands to the recommended minimum of words. */
+					"This is far below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
+					"This is far below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					this._config.recommendedMinimum
+				),
+				wordCount,
+				url,
+				"</a>",
 				this._config.recommendedMinimum
 			);
 		}

--- a/src/assessments/seo/titleKeywordAssessment.js
+++ b/src/assessments/seo/titleKeywordAssessment.js
@@ -11,23 +11,33 @@ var escape = require( "lodash/escape" );
 var titleHasKeywordAssessment = function( paper, researcher, i18n ) {
 	var keywordMatches = researcher.getResearch( "findKeywordInPageTitle" );
 	var score, text;
+	const url = "<a href='https://yoa.st/2pn' target='_blank'>";
 
 	if ( keywordMatches.matches === 0 ) {
 		score = 2;
-		text = i18n.sprintf( i18n.dgettext( "js-text-analysis", "The focus keyword '%1$s' does " +
-			"not appear in the SEO title." ), escape( paper.getKeyword() ) );
+		text = i18n.sprintf(
+			/* Translators: %1$s expands to the focus keyword, %2$s expands to a link on yoast.com,
+			%3$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "The focus keyword '%1$s' does " +
+				"not appear in the %2$sSEO title%3$s." ), escape( paper.getKeyword() ),	url, "</a>"
+		);
 	}
 
 	if ( keywordMatches.matches > 0 && keywordMatches.position === 0 ) {
 		score = 9;
-		text = i18n.dgettext( "js-text-analysis", "The SEO title contains the focus keyword, at the beginning which is considered " +
-			"to improve rankings." );
+		text = i18n.sprintf(
+			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "The %1$sSEO title%2$s contains the focus keyword, at the beginning which is considered " +
+			"to improve rankings." ), url, "</a>"
+		);
 	}
 
 	if ( keywordMatches.matches > 0 && keywordMatches.position > 0 ) {
 		score = 6;
-		text = i18n.dgettext( "js-text-analysis", "The SEO title contains the focus keyword, but it does not appear at the beginning;" +
-			" try and move it to the beginning." );
+		text = i18n.sprintf(
+			i18n.dgettext( "js-text-analysis", "The %1$sSEO title%2$s contains the focus keyword, but it does not appear at the beginning;" +
+			" try and move it to the beginning." ), url, "</a>"
+		);
 	}
 	var assessmentResult = new AssessmentResult();
 

--- a/src/assessments/seo/urlKeywordAssessment.js
+++ b/src/assessments/seo/urlKeywordAssessment.js
@@ -80,12 +80,24 @@ class UrlKeywordAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( totalKeywords, i18n ) {
+		const url = "<a href='https://yoa.st/2pp' target='_blank'>";
+
 		if ( totalKeywords === 0 ) {
-			return i18n.dgettext( "js-text-analysis", "The focus keyword does not appear in the URL for this page. " +
-				"If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!" );
+			return i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "The focus keyword does not appear in the %1$sURL%2$s for this page. " +
+				"If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!" ),
+				url,
+				"</a>"
+			);
 		}
 
-		return i18n.dgettext( "js-text-analysis", "The focus keyword appears in the URL for this page." );
+		return i18n.sprintf(
+			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "The focus keyword appears in the %1$sURL%2$s for this page." ),
+			url,
+			"</a>"
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds links to relevant articles to all SEO assessments.

## Test instructions

This PR can be tested by following these steps:

Build a beta version using `trunk` for Yoast SEO and this branch for YoastSEO.js.

Trigger the following assessments, and check whether the feedback texts contain links to relevant articles. For each assessments, test all scenarios described and check the feedback text with the link.
* internalLinks
  * Don't add any links
  * Add a nofollowed internal link
  * Add a normal internal link.
  * Add a nofollowed and a normal internal link.
* introductionKeyword
  * Set a keyword and add a paragraph without the keyword.
  * Include the keyword in the paragraph.
* keyphraseLength
  * Don't set a keyword.
  * Set a keyword with > 10 words.
* keywordDensity
  * Add a keyword and a tet with more than 100 words.
  * Add the keyword to the text a number of times. Make sure to obtain the following densities:
    * Between 0 and 0.5
    * Between 0.5 and 2.5
    * Between 0.5 and 3.5
    * More than 3.5
* metaDescriptionKeyword
    * Add a keyword and don't include it in the meta description.
    * Add the keyword in the meta desription.
* metaDescriptionLength
    * Add a post without any metadescription.
    * Add a very short metadescription (under 120 characters).
    * Add more words to metadescription (between 120 and 156).
    * Add even more words to metadescription (above 156).
* outboundLinks
    * Add a post without any links to any external websites.
    * Refer from your post to an external website using a follow-link.
    * Change the follow-link into a no-follow-link.
    * Add another link (can be to the same external website) and make it follow.
* pageTitleWidth
    * Add no SEO title at all
    * Fill in a short SEO title (<400 pixels)
    * Add a few words to the SEO title so that the bullet turns green (between 400 and 600 pixels)
    * Add a few more words to the SEO title (>600 pixels) so that the bullet turns red
* subheadingsKeyword
    * Add a keyword. Add one or more subheadings and don't use the keyword in it.
    * Add the keyword in one or more of the subheadings.
* taxonomyTextLength
    * Make a new category page.
    * Add a very short text (less than 50 words). The assessment should return a red bullet.
    * Add a little more copy (between 50 and 100). The assessment should still return a red bullet.
    * Add a little more copy (between 100 and 125). The assessment should still return a red bullet.
    * Add a little more copy (125 and 150). The assessment should return an orange bullet.
    * Add a little more copy (more than 150 words). The assessment should return a green bullet.
* textCompetingLinks
    * Add a post and fill in a certain keyword.
    * Add a link with the keyword as the link text (the URL doesn't matter) The assessment should return a bad score.
* textImages
    * Add a text without images. The assessment should return a red bullet.
    * Add an image without alt tags. The assessment should return an orange bullet.
    * Add an alt tag. The assessment should return an orange bullet.
    * Add a keyword (in the keyword box). The assessment should return an orange bullet.
    * Add your keyword to the alt tag. The assessment should return a green bullet and "The images on this page contain alt attributes with the focus keyword."
* textLength
    * Add a very short text (5 words). The assessment should return a red bullet.
    * Add a little more copy (150 words). The assessment should still return a red bullet.
    * Add a little more copy (230 words). The assessment should still return a red bullet.
    * Add a little more copy (270 words). The assessment should return an orange bullet.
    *  Add a little more copy (310 words). The assessment should return a green bullet.
* titleKeyword
    * Add a keyword and a title that starts directly with that keyword - the assessment should return a green bullet.
    * Add a word before the keyword - the assessment should return an orange bullet.
    * Remove the keyword from the title - the assessment should return a red bullet.
* urlKeyword
    * Set a keyword and make sure it's not in the URL of the past.
    * Add the keyword to the URL.

Notes:
* No link has been added to the urlStopWords assessment, since that assessment will be removed soon.
* The following assessments already had links: keywordStopwords, urlStopWords, previouslyUsedKeywords.


Fixes #1493 
