### PR TITLE
Change boundaries, add gray bullet, enable markings in good condition

### DIFF
--- a/spec/assessments/largestKeywordDistanceAssessmentSpec.js
+++ b/spec/assessments/largestKeywordDistanceAssessmentSpec.js
@@ -6,9 +6,17 @@ const Mark = require( "../../js/values/Mark.js" );
 
 let keywordDistanceAssessment = new largestKeyWordDistanceAssessment();
 
-describe( "An assessment to check the largest percentage of text in which no keyword occurs", function() {
-	it( "returns a bad score when the largest keyword distance is between more than 50%", function() {
+describe( "An assessment to check the largest percentage of text in your text in which no keyword occurs", function() {
+	it( "returns a gray score when there are too few keyword occurrences to calculate the keyword distribution", function() {
 		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 10 ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 0 );
+		expect( assessment.getText() ).toEqual( "Use your keyword or synonyms more often in your text so we can check <a href='https://yoa.st/2w7' target='_blank'>keyword distribution</a>." );
+	} );
+
+	it( "returns a bad score when the largest keyword distance is between more than 50%", function() {
+		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 55 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
@@ -17,7 +25,7 @@ describe( "An assessment to check the largest percentage of text in which no key
 	} );
 
 	it( "returns an okay score when the largest keyword distance is between 40 and 50%", function() {
-		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 45 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -26,7 +34,7 @@ describe( "An assessment to check the largest percentage of text in which no key
 	} );
 
 	it( "returns an good score when the largest keyword distance is less than 40%", function() {
-		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword" } );
+		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -37,8 +45,8 @@ describe( "An assessment to check the largest percentage of text in which no key
 
 describe( "An assessment to check the largest percentage of text in which no keyword or synonyms occurred", function() {
 	it( "returns a bad score when the largest keyword distance is more than 40%", function() {
-		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword", synonyms: "synonym" } );
-		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 45 ), i18n );
+		let mockPaper = new Paper( "string with the keyword and the synonym", { keyword: "keyword", synonyms: "synonym" } );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 55 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
 		expect( assessment.getText() ).toEqual( "Large parts of your text do not contain the keyword or its synonyms. " +
@@ -46,8 +54,8 @@ describe( "An assessment to check the largest percentage of text in which no key
 	} );
 
 	it( "returns an okay score when the largest keyword distance is between 30 and 40%", function() {
-		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword", synonyms: "synonym, synonyms" } );
-		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 35 ), i18n );
+		let mockPaper = new Paper( "string with the keyword and the synonym", { keyword: "keyword", synonyms: "synonym, synonyms" } );
+		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 45 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "Some parts of your text do not contain the keyword or its synonyms. " +
@@ -55,7 +63,7 @@ describe( "An assessment to check the largest percentage of text in which no key
 	} );
 
 	it( "returns an good score when the largest keyword distance is less than 30%", function() {
-		let mockPaper = new Paper( "string with the keyword", { keyword: "keyword", synonyms: "synonym" } );
+		let mockPaper = new Paper( "string with the keyword and the synonym", { keyword: "keyword", synonyms: "synonym" } );
 		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -84,7 +92,7 @@ describe( "Checks if the assessment is applicable", function() {
 		expect( assessment ).toBe( true );
 	} );
 
-	it( "is not applicable to papers with more than 200 words and only 1 keyword", function() {
+	it( "is applicable to papers with more than 200 words and only 1 keyword", function() {
 		let mockPaper = new Paper( "This is the keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
 			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
 			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
@@ -100,7 +108,7 @@ describe( "Checks if the assessment is applicable", function() {
 			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } );
 		let assessment = keywordDistanceAssessment.isApplicable( mockPaper );
 
-		expect( assessment ).toBe( false );
+		expect( assessment ).toBe( true );
 	} );
 
 	it( "is not applicable to papers with less than 100 words that contain the keyword more than once", function() {

--- a/spec/assessments/largestKeywordDistanceAssessmentSpec.js
+++ b/spec/assessments/largestKeywordDistanceAssessmentSpec.js
@@ -12,7 +12,7 @@ describe( "An assessment to check the largest percentage of text in your text in
 		let assessment = keywordDistanceAssessment.getResult( mockPaper, Factory.buildMockResearcher( 10 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual( "Use your keyword or synonyms more often in your text so we can check <a href='https://yoa.st/2w7' target='_blank'>keyword distribution</a>." );
+		expect( assessment.getText() ).toEqual( "Use your keyword or synonyms more often in your text so that we can check <a href='https://yoa.st/2w7' target='_blank'>keyword distribution</a>." );
 	} );
 
 	it( "returns a bad score when the largest keyword distance is between more than 50%", function() {
@@ -111,7 +111,7 @@ describe( "Checks if the assessment is applicable", function() {
 		expect( assessment ).toBe( true );
 	} );
 
-	it( "is not applicable to papers with less than 100 words that contain the keyword more than once", function() {
+	it( "is not applicable to papers with less than 200 words that contain the keyword more than once", function() {
 		let mockPaper = new Paper( "Keyword and keyword. ", { keyword: "keyword" } );
 		let assessment = keywordDistanceAssessment.isApplicable( mockPaper );
 

--- a/src/assessments/seo/largestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/largestKeywordDistanceAssessment.js
@@ -48,6 +48,7 @@ class largestKeywordDistanceAssessment extends Assessment {
 		this._largestKeywordDistance = researcher.getResearch( "largestKeywordDistance" );
 
 		this._hasSynonyms = paper.hasSynonyms();
+		this._topicUsed = topicCount( paper ).count;
 
 		let assessmentResult = new AssessmentResult();
 
@@ -55,7 +56,7 @@ class largestKeywordDistanceAssessment extends Assessment {
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		assessmentResult.setHasMarks( calculatedResult.score < 9 );
+		assessmentResult.setHasMarks( calculatedResult.score > 0 );
 
 		return assessmentResult;
 	}
@@ -68,9 +69,17 @@ class largestKeywordDistanceAssessment extends Assessment {
 	 * @returns {Object} Object with score and feedback text.
 	 */
 	calculateResult( i18n ) {
-		if ( this._hasSynonyms ) {
-			this._config.overRecommendedMaximumKeywordDistance = 40;
-			this._config.recommendedMaximumKeywordDistance = 30;
+		if ( this._topicUsed < 2 ) {
+			return {
+				score: 0,
+				resultText: i18n.sprintf(
+					i18n.dgettext(
+					"js-text-analysis",
+					"Use your keyword or synonyms more often in your text so we can check %1$skeyword distribution%2$s.",
+				),
+					this._config.url,
+					"</a>"
+			) };
 		}
 
 		if ( this._largestKeywordDistance > this._config.overRecommendedMaximumKeywordDistance ) {
@@ -151,9 +160,7 @@ class largestKeywordDistanceAssessment extends Assessment {
 	 *                    with the keyword occurring more than one time.
 	 */
 	isApplicable( paper ) {
-		const topicUsed = topicCount( paper ).count;
-
-		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 200 && topicUsed > 1;
+		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 200;
 	}
 }
 

--- a/src/assessments/seo/largestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/largestKeywordDistanceAssessment.js
@@ -75,7 +75,7 @@ class largestKeywordDistanceAssessment extends Assessment {
 				resultText: i18n.sprintf(
 					i18n.dgettext(
 					"js-text-analysis",
-					"Use your keyword or synonyms more often in your text so we can check %1$skeyword distribution%2$s.",
+					"Use your keyword or synonyms more often in your text so we can check %1$skeyword distribution%2$s."
 				),
 					this._config.url,
 					"</a>"

--- a/src/assessments/seo/largestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/largestKeywordDistanceAssessment.js
@@ -73,6 +73,8 @@ class largestKeywordDistanceAssessment extends Assessment {
 			return {
 				score: 0,
 				resultText: i18n.sprintf(
+					/* Translators: %1$s expands to a link to a Yoast.com article about keyword and topic distribution,
+					%2$s expands to the anchor end tag */
 					i18n.dgettext(
 					"js-text-analysis",
 					"Use your keyword or synonyms more often in your text so that we can check %1$skeyword distribution%2$s."

--- a/src/assessments/seo/largestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/largestKeywordDistanceAssessment.js
@@ -75,7 +75,7 @@ class largestKeywordDistanceAssessment extends Assessment {
 				resultText: i18n.sprintf(
 					i18n.dgettext(
 					"js-text-analysis",
-					"Use your keyword or synonyms more often in your text so we can check %1$skeyword distribution%2$s."
+					"Use your keyword or synonyms more often in your text so that we can check %1$skeyword distribution%2$s."
 				),
 					this._config.url,
 					"</a>"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Makes boundaries the same regardless of whether or not there are synonyms (50% for orange, 40% for green).
* Enable markings also in the good condition.
* Show a gray bullet when there are not enough keyword occurrences to calculate instead of not triggering the assessment.

## Test instructions

This PR can be tested by following these steps:

* Add a text (>200 words) and a keyword.
* You should get a gray bullet and feedback about adding the keyword/synoym more often.
* Add the keyword once in the text. You should still get the same feedback.
* Add the keyword in the text again. The assessment should show feedback about the distribution.
* Distribute your keyword so that you just about get a green/orange result. Replace your keyword with a synoynm. The result should still be the same.
* Distribute your keyword so that you get a green result. Make sure you can still switch on markings.

Fixes #1584 
