### PR TITLE
Fix apostrophes in word boundaries

### DIFF
--- a/spec/researches/getTopicDensitySpec.js
+++ b/spec/researches/getTopicDensitySpec.js
@@ -26,7 +26,7 @@ describe( "Test for counting the keyword and synonyms in a text", function() {
 		mockPaper = new Paper( "<img src='http://image.com/image.png'>", { keyword: "key&word" } );
 		expect( getTopicDensity( mockPaper ) ).toBe( 0 );
 		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", { keyword: "keyword" } );
-		expect( getTopicDensity( mockPaper ) ).toBe( 30 );
+		expect( getTopicDensity( mockPaper ) ).toBe( 20 );
 		mockPaper = new Paper( "a string of text with the beautiful Keyword in it.", { keyword: "keyword" } );
 		expect( getTopicDensity( mockPaper ) ).toBe( 10 );
 		mockPaper = new Paper( "a string of text with the Key word in it.", { keyword: "key word" } );

--- a/spec/researches/topicCountSpec.js
+++ b/spec/researches/topicCountSpec.js
@@ -26,7 +26,7 @@ describe( "Test for counting the keyword and synonyms in a text", function() {
 		mockPaper = new Paper( "<img src='http://image.com/image.png'>", { keyword: "key&word" } );
 		expect( topicCount( mockPaper ).count ).toBe( 0 );
 		mockPaper = new Paper( "This is a nice string with a keyword keyword keyword.", { keyword: "keyword" } );
-		expect( topicCount( mockPaper ).count ).toBe( 3 );
+		expect( topicCount( mockPaper ).count ).toBe( 2 );
 		mockPaper = new Paper( "a string of text with the Keyword in it.", { keyword: "keyword" } );
 		expect( topicCount( mockPaper ).count ).toBe( 1 );
 		mockPaper = new Paper( "a string of text with the Key word in it.", { keyword: "key word" } );

--- a/spec/stringProcessing/addWordBoundarySpec.js
+++ b/spec/stringProcessing/addWordBoundarySpec.js
@@ -2,15 +2,23 @@ import addWordBoundary from "../../js/stringProcessing/addWordboundary";
 
 describe( "a test adding wordboundaries to a string", function() {
 	it( "adds start and end boundaries", function() {
-		expect( addWordBoundary( "keyword" ) ).toBe( "(^|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])keyword($|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])" );
+		expect( addWordBoundary( "keyword" ) ).toEqual(
+			"(^|[ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›<>'‘’‛`])keyword($|([ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›<>])|((['‘’‛`])([ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›<>])))"
+		);
 	} );
 	it( "adds start and end boundaries and an extra boundary", function() {
-		expect( addWordBoundary( "keyword", false, "extra" ) ).toBe( "(^|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])keyword($|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])" );
+		expect( addWordBoundary( "keyword", false, "#" ) ).toEqual(
+			"(^|[ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›#<>'‘’‛`])keyword($|([ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›#<>])|((['‘’‛`])([ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›#<>])))"
+		);
 	} );
 	it( "adds start boundaries, and end boundaries with positive lookahead", function() {
-		expect( addWordBoundary( "keyword", true, "" ) ).toBe( "(^|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>])keyword($|(?=[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›<>]))" );
+		expect( addWordBoundary( "keyword", true, "" ) ).toEqual(
+			"(^|[ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›<>'‘’‛`])keyword($|((?=[ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›<>]))|((['‘’‛`])([ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›<>])))"
+		);
 	} );
 	it( "adds start boundaries with an extra boundary, and end boundaries with positive lookahead and an extra boundary", function() {
-		expect( addWordBoundary( "keyword", true, "extra" ) ).toBe( "(^|[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>])keyword($|(?=[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›extra<>]))" );
+		expect( addWordBoundary( "keyword", true, "#" ) ).toEqual(
+			"(^|[ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›#<>'‘’‛`])keyword($|((?=[ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›#<>]))|((['‘’‛`])([ \\u00a0 \\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!?:/»«‹›#<>])))"
+		);
 	} );
 } );

--- a/spec/stringProcessing/createWordRegexSpec.js
+++ b/spec/stringProcessing/createWordRegexSpec.js
@@ -3,13 +3,21 @@ var createWordRegex = require( "../../js/stringProcessing/createWordRegex.js" );
 
 describe( "creates regex from keyword", function() {
 	it( "returns a regex", function() {
-		expect( createWordRegex( "keyword" ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])keyword($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "keyword" ) ).toEqual(
+			/(^|[ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>'‘’‛`])keyword($|([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])|((['‘’‛`])([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])))/gi
+		);
 	} );
 	it( "returns a regex - words with diacritics", function() {
-		expect( createWordRegex( "maïs", "", false ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])maïs($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
-		expect( createWordRegex( "Slovníček pojmû", "", false ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])Slovníček pojmû($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "maïs", "", false ) ).toEqual(
+			/(^|[ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>'‘’‛`])maïs($|([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])|((['‘’‛`])([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])))/gi
+		);
+		expect( createWordRegex( "Slovníček pojmû", "", false ) ).toEqual(
+			/(^|[ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>'‘’‛`])Slovníček pojmû($|([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])|((['‘’‛`])([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])))/gi
+		);
 	} );
 	it( "returns a regex - words with characters that break regexes", function() {
-		expect( createWordRegex( "keyword*" ) ).toEqual( /(^|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])keyword\*($|[ \u00a0 \n\r\t.,'()"+-;!?:\/»«‹›<>])/gi );
+		expect( createWordRegex( "keyword*" ) ).toEqual(
+			/(^|[ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>'‘’‛`])keyword\*($|([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])|((['‘’‛`])([ \u00a0 \n\r\t.,()”“〝〞〟‟„"+\-;!?:\/»«‹›<>])))/gi
+		);
 	} );
 } );

--- a/spec/stringProcessing/matchTextWithArraySpec.js
+++ b/spec/stringProcessing/matchTextWithArraySpec.js
@@ -2,7 +2,37 @@ var arrayMatch = require( "../../js/stringProcessing/matchTextWithArray.js" );
 
 describe( "a test matching strings in an array", function() {
 	it( "returns the matches in the array", function() {
-		expect( arrayMatch( "this is a test with words.", [ "test", "string", "words" ] ) ).toEqual( [ "test", "words" ] );
-		expect( arrayMatch( "this is a test with words.", [ "something" ] ) ).toEqual( [] );
+		expect( arrayMatch( "this is a test with words.", [ "test", "string", "words" ] ) ).toEqual(
+			{ count: 2, matches: [ "test", "words" ] }
+		);
+
+		expect( arrayMatch( "This is a test with words. Now comes another test with more words", [ "test", "string", "words" ] ) ).toEqual(
+			{ count: 4, matches: [ "test", "test", "words", "words" ] }
+		);
+
+		expect( arrayMatch( "This is a test with words. Now comes another Test with more Words", [ "test", "string", "words" ] ) ).toEqual(
+			{ count: 4, matches: [ "test", "Test", "words", "Words" ] }
+		);
+
+		expect( arrayMatch( "This is a test with some testwords. Now comes another Test with more Words", [ "test", "string", "words" ] ) ).toEqual(
+			{ count: 3, matches: [ "test", "Test", "Words" ] }
+		);
+
+		expect( arrayMatch( "This is a test with some test's words. Now comes another Test with more Words", [ "test", "string", "words" ] ) ).toEqual(
+			{ count: 4, matches: [ "test", "Test", "words", "Words" ] }
+		);
+
+		expect( arrayMatch( "This is a test with some test's words. Now comes another Test with more Words", [ "test", "test's", "string", "words" ] ) ).toEqual(
+			{ count: 5, matches: [ "test", "Test", "test's", "words", "Words" ] }
+		);
+
+		// Test if the matches are found correctly if one of the words in the array is a substring of another word in the array.
+		expect( arrayMatch( "This is a test with some test’s words. Now comes another Test with more Words", [ "test", "te", "string", "words" ] ) ).toEqual(
+			{ count: 4, matches: [ "test", "Test", "words", "Words" ] }
+		);
+
+		expect( arrayMatch( "this is a test with words.", [ "something" ] ) ).toEqual(
+			{ count: 0, matches: [] }
+		);
 	} );
 } );

--- a/src/markers/addMarkSingleWord.js
+++ b/src/markers/addMarkSingleWord.js
@@ -1,4 +1,4 @@
-const stripWordBoundaries = require( "../stringProcessing/stripWordBoundaries" ).stripWordBoundariesStart;
+const { stripWordBoundariesStart, stripWordBoundariesEnd } = require( "../stringProcessing/stripWordBoundaries" );
 
 /**
  * Marks a text with HTML tags, deals with word boundaries that were matched by regexes, but which should not be marked.
@@ -8,12 +8,24 @@ const stripWordBoundaries = require( "../stringProcessing/stripWordBoundaries" )
  * @returns {string} The marked text.
  */
 module.exports = function( text ) {
-	const strippedText = stripWordBoundaries( text );
-	let wordBoundary = "";
+	// Strip the word boundaries at the start of the text.
+	const strippedTextStart = stripWordBoundariesStart( text );
+	let wordBoundaryStart = "";
+	let wordBoundaryEnd = "";
 
-	if ( ! ( strippedText === text ) ) {
-		wordBoundary = text.substr( 0, text.search( strippedText ) );
+	// Get the actual word boundaries from the start of the text.
+	if ( strippedTextStart !== text ) {
+		const wordBoundaryStartIndex = text.search( strippedTextStart );
+		wordBoundaryStart = text.substr( 0, wordBoundaryStartIndex );
 	}
 
-	return wordBoundary + "<yoastmark class='yoast-text-mark'>" + strippedText + "</yoastmark>";
+	// Strip word boundaries at the end of the text.
+	const strippedTextEnd = stripWordBoundariesEnd( strippedTextStart );
+	// Get the actual word boundaries from the end of the text.
+	if ( strippedTextEnd !== strippedTextStart ) {
+		const wordBoundaryEndIndex = strippedTextStart.search( strippedTextEnd ) + strippedTextEnd.length;
+		wordBoundaryEnd = strippedTextStart.substr( wordBoundaryEndIndex );
+	}
+
+	return wordBoundaryStart + "<yoastmark class='yoast-text-mark'>" + strippedTextEnd + "</yoastmark>" + wordBoundaryEnd;
 };

--- a/src/researches/topicCount.js
+++ b/src/researches/topicCount.js
@@ -48,7 +48,7 @@ module.exports = function( paper, onlyKeyword = false ) {
 	let matchesIndices = [];
 
 	sentences.forEach( function( sentence ) {
-		topicFoundInSentence = matchTextWithArray( sentence, topicWords );
+		topicFoundInSentence = matchTextWithArray( sentence, topicWords ).matches;
 		if ( topicFoundInSentence.length > 0 ) {
 			topicFoundInSentence.forEach( function( occurrence ) {
 				const indexOfOccurrenceInSentence = sentence.indexOf( occurrence, indexRunningThroughSentence );

--- a/src/stringProcessing/addWordboundary.js
+++ b/src/stringProcessing/addWordboundary.js
@@ -12,11 +12,13 @@
 module.exports = function( matchString, positiveLookAhead = false, extraWordBoundary = "" ) {
 	var wordBoundary, wordBoundaryStart, wordBoundaryEnd;
 
-	wordBoundary = "[ \\u00a0 \\n\\r\\t\.,'\(\)\"\+\-;!?:\/»«‹›" + extraWordBoundary + "<>]";
-	wordBoundaryStart = "(^|" + wordBoundary + ")";
+	wordBoundary = "[ \\u00a0 \\n\\r\\t\.,\(\)”“〝〞〟‟„\"+\\-;!?:\/»«‹›" + extraWordBoundary + "<>";
+	wordBoundaryStart = "(^|" + wordBoundary + "'‘’‛`])";
 	if( positiveLookAhead ) {
-		wordBoundary = "(?=" + wordBoundary + ")";
+		wordBoundaryEnd = "($|((?=" + wordBoundary + "]))|((['‘’‛`])(" + wordBoundary + "])))";
+	} else{
+		wordBoundaryEnd = "($|(" + wordBoundary + "])|((['‘’‛`])(" + wordBoundary + "])))";
 	}
-	wordBoundaryEnd = "($|" + wordBoundary + ")";
+
 	return wordBoundaryStart + matchString + wordBoundaryEnd;
 };

--- a/src/stringProcessing/matchTextWithArray.js
+++ b/src/stringProcessing/matchTextWithArray.js
@@ -1,17 +1,27 @@
 /** @module stringProcessing/matchTextWithArray */
 
-const arrayToRegex = require( "../stringProcessing/createRegexFromArray.js" );
 const stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 const removePunctuation = require( "../stringProcessing/removePunctuation.js" );
+const matchTextWithWord = require( "../stringProcessing/matchTextWithWord" );
+const unique = require( "lodash/uniq" );
 /**
  * Matches strings from an array against a given text.
  *
  * @param {String} text The text to match
  * @param {Array} array The array with strings to match
+ * @param {String} [locale = "en_EN"] The locale of the text to get transliterations
+ *
  * @returns {Array} array An array with all matches of the text.
  */
-module.exports = function( text, array ) {
-	var matches = text.match( arrayToRegex( array ) );
+module.exports = function( text, array, locale = "en_EN" ) {
+	let count = 0;
+	let matches = [];
+	unique( array ).forEach( function( wordToMatch ) {
+		const occurrence = matchTextWithWord( text, wordToMatch, locale );
+		count += occurrence.count;
+		matches = matches.concat( occurrence.matches );
+	} );
+
 	if ( matches === null ) {
 		matches = [];
 	}
@@ -20,5 +30,8 @@ module.exports = function( text, array ) {
 		return stripSpaces( removePunctuation( string ) );
 	} );
 
-	return matches;
+	return {
+		count: count,
+		matches: matches,
+	};
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug that caused keywords to be incorrectly recognized within possessive forms (e.g. `Natalia` in `Natalia's fix`.

## Relevant technical choices:

* Adjusted `matchTextWithArray` to use `matchTextToWord`.
* Match single quotes only when it is on the edge of a word boundary. This is to not count possessives like: `Natalia's fix`.

## Not fixed in this PR

The original text is changed. Then the matches are being found. However the index AND the actual match are not lining up with the original text at all. The markings are done by searching for the original text and replacing it. But the original text is not the original text!
In `stringProcessing/matchTextWithWord.js` you can see an place where the original text is changed before the matches are run.

## Test instructions

This PR can be tested by following these steps:

* Add a text with at least 200 words and set the focus keyword to `Natalia`. Add `Natalia's` in the text. No keyword occurrence should be found.