### PR TITLE
Add kb link to the previouslyUsedKeyword assessment

### DIFF
--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -31,7 +31,7 @@ describe( "checks for keyword doubles", function() {
 			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
 
 		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).score ).toBe( 9 );
-		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "You've never used this focus keyword before, very good." );
+		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "You've <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>never used this focus keyword before</a>, very good." );
 	} );
 
 	it( "escapes the keyword's special characters in the url", function() {

--- a/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/src/bundledPlugins/previouslyUsedKeywords.js
@@ -66,7 +66,14 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 	var id = previouslyUsedKeywords.id;
 	if( count === 0 ) {
 		return {
-			text: i18n.dgettext( "js-text-analysis", "You've never used this focus keyword before, very good." ),
+			text: i18n.sprintf(
+				/* Translators:
+				%1$s expands to a link to an article on yoast.com about why you should not use a keyword more than once,
+				%2$s expands to an anchor tag. */
+				i18n.dgettext( "js-text-analysis", "You've %1$snever used this focus keyword before%2$s, very good." ),
+				"<a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>",
+				"</a>"
+			),
 			score: 9,
 		};
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a link to a relevant article about re-using keywords to the feedback of the assessment that checks if the keyword was used previously.

## Relevant technical choices:

* n/a

## Test instructions

This PR can be tested by following these steps:

* Create an article and enter a keyword that has never been used before. Check if the link appears and leads to the correct article.

Fixes #1576 
