### PR TITLE
Change feedback strings

### DIFF
--- a/spec/assessments/keywordDensitySpec.js
+++ b/spec/assessments/keywordDensitySpec.js
@@ -15,7 +15,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0%, which is too low; the focus keyword was found 0 times." );
+		expect( result.getText() ).toBe( "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0%, which is too low; the focus keyword was found 0 times." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -25,7 +25,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.1%, which is too low; the focus keyword was found 1 time." );
+		expect( result.getText() ).toBe( "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.1%, which is too low; the focus keyword was found 1 time." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -35,7 +35,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 time." );
+		expect( result.getText() ).toBe( "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 10%, which is way over the advised 2.5% maximum; the focus keyword was found 1 time." );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -45,7 +45,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 2%, which is great; the focus keyword was found 1 time." );
+		expect( result.getText() ).toBe( "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 2%, which is great; the focus keyword was found 1 time." );
 
 		paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -55,7 +55,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -10 );
-		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 3%, which is over the advised 2.5% maximum; the focus keyword was found 2 times." );
+		expect( result.getText() ).toBe( "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 3%, which is over the advised 2.5% maximum; the focus keyword was found 2 times." );
 
 		paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		result = keywordDensityAssessment.getResult( paper, factory.buildMockResearcher( {
@@ -65,7 +65,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.5%, which is great; the focus keyword was found 2 times." );
+		expect( result.getText() ).toBe( "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.5%, which is great; the focus keyword was found 2 times." );
 	} );
 } );
 

--- a/src/assessments/seo/keywordDensityAssessment.js
+++ b/src/assessments/seo/keywordDensityAssessment.js
@@ -30,8 +30,8 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		about keyword density, %5$s expands to the anchor end tag. */
 		text = i18n.dngettext(
 			"js-text-analysis",
-			"The %4$skeyword density%5$s is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d time.",
-			"The %4$skeyword density%5$s is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d times.",
+			"The exact-match %4$skeyword density%5$s is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d time.",
+			"The exact-match %4$skeyword density%5$s is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d times.",
 			keywordCount
 		);
 
@@ -46,8 +46,8 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		about keyword density, %5$s expands to the anchor end tag. */
 		text = i18n.dngettext(
 			"js-text-analysis",
-			"The %4$skeyword density%5$s is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d time.",
-			"The %4$skeyword density%5$s is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d times.",
+			"The exact-match %4$skeyword density%5$s is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d time.",
+			"The exact-match %4$skeyword density%5$s is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d times.",
 			keywordCount
 		);
 
@@ -62,8 +62,8 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		%4$s expands to the anchor end tag. */
 		text = i18n.dngettext(
 			"js-text-analysis",
-			"The %3$skeyword density%4$s is %1$s, which is great; the focus keyword was found %2$d time.",
-			"The %3$skeyword density%4$s is %1$s, which is great; the focus keyword was found %2$d times.",
+			"The exact-match %3$skeyword density%4$s is %1$s, which is great; the focus keyword was found %2$d time.",
+			"The exact-match %3$skeyword density%4$s is %1$s, which is great; the focus keyword was found %2$d times.",
 			keywordCount
 		);
 
@@ -78,7 +78,7 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		%4$s expands to the anchor end tag. */
 		text = i18n.dgettext(
 			"js-text-analysis",
-			"The %3$skeyword density%4$s is %1$s, which is too low; the focus keyword was found %2$d times."
+			"The exact-match %3$skeyword density%4$s is %1$s, which is too low; the focus keyword was found %2$d times."
 		);
 
 		text = i18n.sprintf( text, keywordDensityPercentage, keywordCount, url, "</a>" );
@@ -92,8 +92,8 @@ var calculateKeywordDensityResult = function( keywordDensity, i18n, keywordCount
 		%4$s expands to the anchor end tag. */
 		text = i18n.dngettext(
 			"js-text-analysis",
-			"The %3$skeyword density%4$s is %1$s, which is too low; the focus keyword was found %2$d time.",
-			"The %3$skeyword density%4$s is %1$s, which is too low; the focus keyword was found %2$d times.",
+			"The exact-match %3$skeyword density%4$s is %1$s, which is too low; the focus keyword was found %2$d time.",
+			"The exact-match %3$skeyword density%4$s is %1$s, which is too low; the focus keyword was found %2$d times.",
 			keywordCount
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes feedback in the assessment that checks keyword density to make it more explicit that the synonyms are not taken into consideration when calculating the score.

## Relevant technical choices:

* n/a

## Test instructions

This PR can be tested by following these steps:

* Browserified or beta
* Add a text and a keyword that has 0 occurrences in the text. The assessment should return a red bullet and "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0%, which is too low; the focus keyword was found 0 times."
* Add a few occurrences in the text so that the density is < 0.5%. The assessment should return an orange bullet and "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.1%, which is too low; the focus keyword was found __ time(s)."
* Add a few more occurrences in the text so that the density is between 0.5% and 2.5%. The assessment should return a green bullet and "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 2%, which is great; the focus keyword was found __ times."
* Add a few more occurrences in the text so that the density is between 2.5% and 3.5. The assessment should return a red bullet and "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 3%, which is over the advised 2.5% maximum; the focus keyword was found __ times."
* Add a few more occurrences in the text so that the density is above 3.5. The assessment should return a red bullet and "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 3%, which is way over the advised 2.5% maximum; the focus keyword was found __ times."

Fixes #1601
