### PR TITLE
Add sentence beginnings assessment for Polish

### DIFF
--- a/spec/assessments/sentenceBeginningsSpec.js
+++ b/spec/assessments/sentenceBeginningsSpec.js
@@ -6,23 +6,44 @@ var Mark = require( "../../js/values/Mark.js" );
 
 var paper = new Paper();
 describe( "An assessment for scoring repeated sentence beginnings.", function() {
-	it( "scores one instance with 4 consecutive sentences starting with the same word.", function() {
+	it( "scores one instance with 4 consecutive English sentences starting with the same word.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 }, { word: "cup", count: 2 }, { word: "laptop", count: 1 },
 			{ word: "table", count: 4 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "The text contains 4 consecutive sentences starting with the same word. Try to mix things up!" );
 	} );
 
-	it( "scores two instance with too many consecutive sentences starting with the same word, 5 being the lowest count.", function() {
+	it( "scores two instance with too many consecutive English sentences starting with the same word, 5 being the lowest count.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 }, { word: "banana", count: 6 }, { word: "pencil", count: 1 },
 			{ word: "bottle", count: 5 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "The text contains 2 instances where 5 or more consecutive sentences start with the same word. Try to mix things up!" );
 	} );
 
-	it( "scores zero instance with too many consecutive sentences starting with the same word.", function() {
+	it( "scores zero instance with too many consecutive English sentences starting with the same word.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 1 }, { word: "telephone", count: 2 }, { word: "towel", count: 2 },
 			{ word: "couch", count: 1 } ] ), i18n );
+		expect( assessment.getScore() ).toBe( 0 );
+		expect( assessment.getText() ).toBe( "" );
+	} );
+
+	it( "scores one instance with 4 consecutive German sentences starting with the same word.", function() {
+		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 }, { word: "Stuhl", count: 2 }, { word: "Banane", count: 1 },
+			{ word: "Tafel", count: 4 } ] ), i18n );
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "The text contains 4 consecutive sentences starting with the same word. Try to mix things up!" );
+	} );
+
+	it( "scores two instance with too many consecutive German sentences starting with the same word, 5 being the lowest count.", function() {
+		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 }, { word: "Banane", count: 6 }, { word: "Blatt", count: 1 },
+			{ word: "Schloss", count: 5 } ] ), i18n );
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "The text contains 2 instances where 5 or more consecutive sentences start with the same word. Try to mix things up!" );
+	} );
+
+	it( "scores zero instance with too many consecutive German sentences starting with the same word.", function() {
+		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 1 }, { word: "Telefon", count: 2 }, { word: "Hund", count: 2 },
+			{ word: "Haus", count: 1 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 0 );
 		expect( assessment.getText() ).toBe( "" );
 	} );
@@ -42,7 +63,67 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		expect( assessment ).toBe( true );
 	} );
 
-	it( "is not applicable for a paper with text and a locale that is not en or de.", function() {
+	it( "is not applicable for a French paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "fr_FR" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for a French paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "bonjour", { locale: "fr_FR" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for a Spanish paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "es_ES" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for a Spanish paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hola", { locale: "es_ES" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for a Dutch paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "nl_NL" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for a Dutch paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hallo", { locale: "nl_NL" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for an Italian paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "it_IT" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for an Italian paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "ciao", { locale: "it_IT" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for a Russian paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "ru_RU" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for a Russian paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "почему", { locale: "ru_RU" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for a Polish paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "pl_PL" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for a Polish paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "cześć", { locale: "pl_PL" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable for a paper with text and a non-existing locale.", function() {
 		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hello", { locale: "xx_YY" } ) );
 		expect( assessment ).toBe( false );
 	} );

--- a/spec/helpers/getFirstWordExceptionsSpec.js
+++ b/spec/helpers/getFirstWordExceptionsSpec.js
@@ -30,7 +30,7 @@ describe( "a test for getting the correct first word exception array", function(
 	} );
 
 	it( "returns the Polish first word exception array in case of pl_PL locale", function() {
-		expect( firstWordExceptions( "pl_PL" )() ).toEqual( [ "jeden", "jedna", "jedno", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć", "ta", "to", "ten", "te", "ci", "taki", "tacy", "taka", "taką", "takich", "takie", "takiego", "takiej", "takiemu", "takim", "takimi", "tamten", "tamta", "tamto", "tamci", "tamte", "tamtą", "tamtego", "tamtej", "tamtemu", "tamtych", "tamtym", "tamtymi", "tą", "tę", "tego", "tej", "temu", "tych", "tymi", "tym", "tak" ] );
+		expect( firstWordExceptions( "pl_PL" )() ).toEqual( [ "jeden", "jedna", "jedno", "dwa", "dwie", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć", "ta", "to", "ten", "te", "ci", "taki", "tacy", "taka", "taką", "takich", "takie", "takiego", "takiej", "takiemu", "takim", "takimi", "tamten", "tamta", "tamto", "tamci", "tamte", "tamtą", "tamtego", "tamtej", "tamtemu", "tamtych", "tamtym", "tamtymi", "tą", "tę", "tego", "tej", "temu", "tych", "tymi", "tym", "tak" ] );
 	} );
 
 	it( "returns the English first word exception array in case of empty locale", function() {

--- a/spec/helpers/getFirstWordExceptionsSpec.js
+++ b/spec/helpers/getFirstWordExceptionsSpec.js
@@ -29,6 +29,10 @@ describe( "a test for getting the correct first word exception array", function(
 		expect( firstWordExceptions( "ru_RU" )() ).toEqual( [ "один", "одна", "одно", "два", "две", "три", "четыре", "пять", "шесть", "семь", "восемь", "девять", "десять", "этот", "этого", "этому", "этим", "этом", "эта", "этой", "эту", "это", "этого", "этому", "эти", "этих", "этим", "этими", "тот", "того", "тому", "тем", "том", "та", "той", "ту", "те", "тех", "тем", "теми", "тех", "такой", "такого", "такому", "таким", "такая", "такую", "такое", "такие", "таких", "таким", "такими", "стольких", "стольким", "столько", "столькими", "вот" ] );
 	} );
 
+	it( "returns the Polish first word exception array in case of pl_PL locale", function() {
+		expect( firstWordExceptions( "pl_PL" )() ).toEqual( [ "jeden", "jedna", "jedno", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć", "ta", "to", "ten", "te", "ci", "taki", "tacy", "taka", "taką", "takich", "takie", "takiego", "takiej", "takiemu", "takim", "takimi", "tamten", "tamta", "tamto", "tamci", "tamte", "tamtą", "tamtego", "tamtej", "tamtemu", "tamtych", "tamtym", "tamtymi", "tą", "tę", "tego", "tej", "temu", "tych", "tymi", "tym", "tak" ] );
+	} );
+
 	it( "returns the English first word exception array in case of empty locale", function() {
 		expect( firstWordExceptions( "" )() ).toEqual( [ "the", "a", "an", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "this", "that", "these", "those" ] );
 	} );

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -188,6 +188,26 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for two sentences in Polish starting with different words.", function() {
+		changePaper( { text: "Najpierw zjem jabłko. Potem zjem gruszkę. ", locale: "pl_PL" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "najpierw" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "potem" );
+		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Polish starting with the same word.", function() {
+		changePaper( { text: "Zawsze cię widzę. Zawsze cię słyszę.", locale: "pl_PL" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "zawsze" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Polish all starting with one of the exception words.", function() {
+		changePaper( { text: "To dziecko jest ładne. To dziecko jest brzydkie. To dziecko jest małe.", locale: "pl_PL" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "to dziecko" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
 	it( "returns an object with English sentence beginnings in lists", function() {
 		changePaper( { text: "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "item", { locale: "en_US" } );

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -13,7 +13,7 @@ let marker = require( "../../markers/addMark.js" );
 let maximumConsecutiveDuplicates = 2;
 
 let getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
-let availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru" ];
+let availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/src/helpers/getFirstWordExceptions.js
+++ b/src/helpers/getFirstWordExceptions.js
@@ -5,6 +5,7 @@ let firstWordExceptionsFrench = require( "../researches/french/firstWordExceptio
 let firstWordExceptionsDutch = require( "../researches/dutch/firstWordExceptions.js" );
 let firstWordExceptionsItalian = require( "../researches/italian/firstWordExceptions.js" );
 let firstWordExceptionsRussian = require( "../researches/russian/firstWordExceptions.js" );
+let firstWordExceptionsPolish = require( "../researches/polish/firstWordExceptions.js" );
 
 let getLanguage = require( "./getLanguage.js" );
 
@@ -22,6 +23,8 @@ module.exports = function( locale ) {
 			return firstWordExceptionsItalian;
 		case "ru":
 		    return firstWordExceptionsRussian;
+		case "pl":
+			return firstWordExceptionsPolish;
 		default:
 		case "en":
 			return firstWordExceptionsEnglish;

--- a/src/helpers/getFirstWordExceptions.js
+++ b/src/helpers/getFirstWordExceptions.js
@@ -1,11 +1,11 @@
-let firstWordExceptionsEnglish = require( "../researches/english/firstWordExceptions.js" );
-let firstWordExceptionsGerman = require( "../researches/german/firstWordExceptions.js" );
-let firstWordExceptionsSpanish = require( "../researches/spanish/firstWordExceptions.js" );
-let firstWordExceptionsFrench = require( "../researches/french/firstWordExceptions.js" );
-let firstWordExceptionsDutch = require( "../researches/dutch/firstWordExceptions.js" );
-let firstWordExceptionsItalian = require( "../researches/italian/firstWordExceptions.js" );
-let firstWordExceptionsRussian = require( "../researches/russian/firstWordExceptions.js" );
-let firstWordExceptionsPolish = require( "../researches/polish/firstWordExceptions.js" );
+const firstWordExceptionsEnglish = require( "../researches/english/firstWordExceptions.js" );
+const firstWordExceptionsGerman = require( "../researches/german/firstWordExceptions.js" );
+const firstWordExceptionsSpanish = require( "../researches/spanish/firstWordExceptions.js" );
+const firstWordExceptionsFrench = require( "../researches/french/firstWordExceptions.js" );
+const firstWordExceptionsDutch = require( "../researches/dutch/firstWordExceptions.js" );
+const firstWordExceptionsItalian = require( "../researches/italian/firstWordExceptions.js" );
+const firstWordExceptionsRussian = require( "../researches/russian/firstWordExceptions.js" );
+const firstWordExceptionsPolish = require( "../researches/polish/firstWordExceptions.js" );
 
 let getLanguage = require( "./getLanguage.js" );
 

--- a/src/researches/polish/firstWordExceptions.js
+++ b/src/researches/polish/firstWordExceptions.js
@@ -5,7 +5,7 @@
 module.exports = function() {
 	return [
 		// Numbers 1-10:
-		"jeden", "jedna", "jedno", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć",
+		"jeden", "jedna", "jedno", "dwa", "dwie", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć",
 		// Demonstrative pronouns:
 		"ta", "to", "ten", "te", "ci", "taki", "tacy", "taka", "taką", "takich", "takie", "takiego", "takiej", "takiemu",
 		"takim", "takimi", "tamten", "tamta", "tamto", "tamci", "tamte", "tamtą", "tamtego", "tamtej", "tamtemu", "tamtych",

--- a/src/researches/polish/firstWordExceptions.js
+++ b/src/researches/polish/firstWordExceptions.js
@@ -1,0 +1,14 @@
+/**
+ *  Returns an array with exceptions for the sentence beginning researcher.
+ *  @returns {Array} The array filled with exceptions.
+ *  */
+module.exports = function() {
+	return [
+		// Numbers 1-10:
+		"jeden", "jedna", "jedno", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć",
+		// Demonstrative pronouns:
+		"ta", "to", "ten", "te", "ci", "taki", "tacy", "taka", "taką", "takich", "takie", "takiego", "takiej", "takiemu",
+		"takim", "takimi", "tamten", "tamta", "tamto", "tamci", "tamte", "tamtą", "tamtego", "tamtej", "tamtemu", "tamtych",
+		"tamtym", "tamtymi", "tą", "tę", "tego", "tej", "temu", "tych", "tymi", "tym", "tak",
+	];
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Implements the assessment that checks if multiple sentences begin with the same word for Polish.

## Test instructions

This PR can be tested by following these steps:

### Browserified

* Set locale to Polish (pl_PL).
* Write a Polish text.
* Determine that the 'sentence beginning assessment' appears when there are three (or more) sentences that start with the same word.

### WordPress

* In your testing environment, set the language to Polish.
* Write a Polish text.
* Determine that the 'sentence beginning assessment' appears when there are three (or more) * sentences that start with the same word.

Fixes #1629
