### PR TITLE
Search keyphrase and synonym word forms in text

### DIFF
--- a/spec/researches/findKeywordFormsInStringSpec.js
+++ b/spec/researches/findKeywordFormsInStringSpec.js
@@ -1,0 +1,276 @@
+const findKeywordFormsInString = require( "../../js/researches/findKeywordFormsInString.js" ).findWordFormsInString;
+const findTopicFormsInString = require( "../../js/researches/findKeywordFormsInString.js" ).findTopicFormsInString;
+
+describe( "Test findKeywordFormsInString: checks for the keyword forms are in the supplied string", function() {
+	it( "returns the number and the percentage of words matched", function() {
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+			"It's lunch time!",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 0,
+			percentWordMatches: 0,
+		} );
+
+
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+			"It's lunch time! I found my lunch!",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 1,
+			percentWordMatches: 50,
+		} );
+
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ], [ "key", "keys" ] ],
+			"It's lunch time! I found my lunch!",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 1,
+			percentWordMatches: 33,
+		} );
+
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ], [ "key", "keys" ] ],
+			"It's lunch time! I found my lunch! And I found my keys!",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 67,
+		} );
+
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ], [ "key", "keys" ] ],
+			"It's lunch time! I found my lunch! And I found my keys! And I found a keyword!",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 3,
+			percentWordMatches: 100,
+		} );
+	} );
+
+	it( "does not break if the array of word forms is empty", function() {
+		expect( findKeywordFormsInString(
+			[ [], [] ],
+			"It's lunch time!",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 0,
+			percentWordMatches: 0,
+		} );
+	} );
+
+	it( "does not break if the text is empty", function() {
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+			"",
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 0,
+			percentWordMatches: 0,
+		} );
+	} );
+
+	it( "does not break if the locale is empty", function() {
+		expect( findKeywordFormsInString(
+			[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+			"It's lunch time!"
+		) ).toEqual( {
+			countWordMatches: 0,
+			percentWordMatches: 0,
+		} );
+	} );
+} );
+
+describe( "Test findTopicFormsInString: checks for the keyword or synonyms forms are in the supplied string", function() {
+	it( "returns the number and the percentage of words matched, synonyms deprecated", function() {
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+				synonymsForms: [
+					[ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			false,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 0,
+			percentWordMatches: 0,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+				synonymsForms: [
+					[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			false,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 100,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+				synonymsForms: [
+					[ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+					[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			false,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 1,
+			percentWordMatches: 50,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+	} );
+	it( "returns the number and the percentage of words matched, synonyms required", function() {
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+				synonymsForms: [
+					[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 100,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+				synonymsForms: [
+					[ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 100,
+			keyphraseOrSynonym: "synonym",
+		} );
+
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+				synonymsForms: [
+					[ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+					[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 100,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+				synonymsForms: [
+					[ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+					[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 100,
+			keyphraseOrSynonym: "synonym",
+		} );
+
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+				synonymsForms: [
+					[ [ "lunch", "lunches" ], [ "time", "times", "timing" ] ],
+					[ [ "keyword", "keywords" ], [ "find", "finds", "found", "finding" ] ],
+					[ [ "dinner", "dinners" ], [ "moment", "moments" ] ],
+				],
+			},
+			"It's lunch time!",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 2,
+			percentWordMatches: 100,
+			keyphraseOrSynonym: "synonym",
+		} );
+	} );
+
+	it( "does not break if the synonyms array is empty", function() {
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+				synonymsForms: [],
+			},
+			"It's lunch time!",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 1,
+			percentWordMatches: 50,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+	} );
+
+	it( "does not break if the text is empty", function() {
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+				synonymsForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+			},
+			"",
+			true,
+			"en_EN"
+		) ).toEqual( {
+			countWordMatches: 0,
+			percentWordMatches: 0,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+	} );
+
+	it( "does not break if the locale is empty", function() {
+		expect( findTopicFormsInString(
+			{
+				keyphraseForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+				synonymsForms: [ [ "lunch", "lunches" ], [ "moment", "moments" ] ],
+			},
+			"It's lunch time!",
+			true
+		) ).toEqual( {
+			countWordMatches: 1,
+			percentWordMatches: 50,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+	} );
+} );

--- a/src/researches/findKeywordFormsInString.js
+++ b/src/researches/findKeywordFormsInString.js
@@ -1,0 +1,92 @@
+const matchTextWithArray = require( "../stringProcessing/matchTextWithArray.js" );
+const sum = require( "lodash/sum.js" );
+const isEmpty = require( "lodash/isEmpty.js" );
+
+/**
+ * Matches forms of words in the keyphrase against a given text.
+ *
+ * @param {Array} keywordForms The array with word forms of all (content) words from the keyphrase in a shape
+ *                             [ [ form1, form2, ... ], [ form1, form2, ... ] ]
+ * @param {string} text The string to match the word forms against.
+ * @param {string} locale The locale of the paper.
+ *
+ * @returns {Object} The number and the percentage fo the keyphrase words that were matched in the text by at least one form.
+ */
+const findWordFormsInString = function( keywordForms, text, locale ) {
+	const wordNumber = keywordForms.length;
+	let foundWords = Array( wordNumber );
+
+	for( let i = 0; i < wordNumber; i++ ) {
+		const found = matchTextWithArray( text, keywordForms[ i ], locale ).count > 0;
+		foundWords[ i ] = found ? 1 : 0;
+	}
+
+	const foundNumberOfWords = sum( foundWords );
+	const result = {
+		countWordMatches: foundNumberOfWords,
+		percentWordMatches: 0,
+	};
+
+	if ( wordNumber > 0 ) {
+		result.percentWordMatches = Math.round( foundNumberOfWords / wordNumber * 100 );
+	}
+
+	return result;
+};
+
+/**
+ * Matches forms of words in the keyphrase and in the synonyms against a given text.
+ *
+ * @param {Object} topicForms The object with word forms of all (content) words from the keyphrase and eventually synonyms,
+ * comes in a shape {
+ *                     keyphraseForms: [[ form1, form2, ... ], [ form1, form2, ... ]],
+ *                     synonymsForms: [
+ *                          [[ form1, form2, ... ], [ form1, form2, ... ]],
+ *                          [[ form1, form2, ... ], [ form1, form2, ... ]],
+ *                          [[ form1, form2, ... ], [ form1, form2, ... ]],
+ *                     ],
+ *                  }
+ * @param {string} text The string to match the word forms against.
+ * @param {boolean} useSynonyms Whether to use synonyms as if it was keyphrase or not (depends on the assessment).
+ * @param {string} locale The locale of the paper.
+ *
+ * @returns {Object} The number and the percentage fo the keyphrase words or synonyms that were matched in the text by at least one form,
+ * and whether the keyphrase or a synonym was matched.
+ */
+const findTopicFormsInString = function( topicForms, text, useSynonyms, locale ) {
+	// First check if the keyword is found in the text
+	let result = findWordFormsInString( topicForms.keyphraseForms, text, locale );
+	result.keyphraseOrSynonym = "keyphrase";
+
+	// If a full match found with the keyword or if no synonyms are supplied or supposed to be used, return the keyphrase search result.
+	if ( result.percentWordMatches === 100 || useSynonyms === false || isEmpty( topicForms.synonymsForms ) ) {
+		return result;
+	}
+
+	// Collect results of matching of every synonym with the text.
+	let resultsSynonyms = [];
+	for( let i = 0; i < topicForms.synonymsForms.length; i++ ) {
+		const synonym = topicForms.synonymsForms[ i ];
+		resultsSynonyms[ i ] = findWordFormsInString( synonym, text, locale );
+	}
+
+	// Find which synonym occurred most fully.
+	const foundSynonyms = resultsSynonyms.map( resultSynonyms => resultSynonyms.percentWordMatches );
+	const bestSynonymIndex = foundSynonyms.indexOf( Math.max( ...foundSynonyms ) );
+
+	// If the best synonym showed lower results than the keyword, return the keyword.
+	if ( result.percentWordMatches >= resultsSynonyms[ bestSynonymIndex ].percentWordMatches ) {
+		return result;
+	}
+
+	// If the best synonym showed better results than the keyword, return the synonym.
+	result = resultsSynonyms[ bestSynonymIndex ];
+	result.keyphraseOrSynonym = "synonym";
+
+	return result;
+};
+
+module.exports = {
+	findWordFormsInString: findWordFormsInString,
+	findTopicFormsInString: findTopicFormsInString,
+};

--- a/src/researches/findKeywordFormsInString.js
+++ b/src/researches/findKeywordFormsInString.js
@@ -10,7 +10,7 @@ const isEmpty = require( "lodash/isEmpty.js" );
  * @param {string} text The string to match the word forms against.
  * @param {string} locale The locale of the paper.
  *
- * @returns {Object} The number and the percentage fo the keyphrase words that were matched in the text by at least one form.
+ * @returns {Object} The number and the percentage of the keyphrase words that were matched in the text by at least one form.
  */
 const findWordFormsInString = function( keywordForms, text, locale ) {
 	const wordNumber = keywordForms.length;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* no user-facing changes

## Relevant technical choices:

* For completeness, the function returns the number of words matched, % of words from the keyphrase that matched in the text and whether keyphrase or synonym was matched in the text. It might be that later some of these can be deprecated.

## Test instructions

This PR can be tested by following these steps:

* Add more specs to `findKeywordFormsInStringSpec.js`

Fixes #1634 
