### PR TITLE
Refactor text images assessment

### DIFF
--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -56,7 +56,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page do not have alt attributes containing the focus keyword." );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page do not have alt attributes with the topic words." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword", function() {
@@ -72,6 +72,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
@@ -87,6 +88,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words." );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
@@ -102,5 +104,6 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words." );
 	} );
 } );

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -73,8 +73,8 @@ const expectedResults = {
 		resultText: "",
 	},
 	textImages: {
-		score: 6,
-		resultText: "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page do not have alt attributes containing the focus keyword.",
+		score: 9,
+		resultText: "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words.",
 	},
 	textLength: {
 		score: 9,

--- a/spec/researches/imageAltTagsSpec.js
+++ b/spec/researches/imageAltTagsSpec.js
@@ -1,10 +1,10 @@
-var altTagCountFunction = require( "../../js/researches/imageAltTags" );
-var Paper = require( "../../js/values/Paper" );
+const altTagCountFunction = require( "../../js/researches/imageAltTags" );
+const Paper = require( "../../js/values/Paper" );
 
 describe( "Counts images in an text", function() {
 	it( "returns an empty object with all alt-counts as zero", function() {
-		var stringToCheck = altTagCountFunction(
-			new Paper( "string", { keyword: "keyword" } )
+		const stringToCheck = altTagCountFunction(
+			new Paper( "string", { keyword: "keyword", synonyms: "synonym, another synonym" } )
 		);
 
 		expect( stringToCheck.noAlt ).toBe( 0 );
@@ -13,9 +13,9 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
 	} );
 
-	it( "returns object with the withAltKeyword as 1 when the keyword is set and present", function() {
-		var stringToCheck = altTagCountFunction(
-			new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword" } )
+	 it( "returns object with the withAltKeyword as 1 when the keyword is set and present", function() {
+		const stringToCheck = altTagCountFunction(
+			new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword", synonyms: "synonym, another synonym" } )
 		);
 
 		expect( stringToCheck.noAlt ).toBe( 0 );
@@ -25,7 +25,7 @@ describe( "Counts images in an text", function() {
 	} );
 
 	it( "returns object with the withAlt as 1 when there's an alt-tag, but no keyword is set", function() {
-		var stringToCheck = altTagCountFunction(
+		const stringToCheck = altTagCountFunction(
 			new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "" } )
 		);
 
@@ -36,7 +36,7 @@ describe( "Counts images in an text", function() {
 	} );
 
 	it( "returns object with the withAltNonKeyword as 1 when the keyword is set, but not present in the alt-tag", function() {
-		var stringToCheck = altTagCountFunction(
+		const stringToCheck = altTagCountFunction(
 			new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "sample" } )
 		);
 
@@ -46,8 +46,8 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
 	} );
 
-	it( "returns object with the noAlt as 1 when the alt-tag is empty or missing", function() {
-		var stringToCheck = altTagCountFunction(
+	it( "returns object with the noAlt as 1 when the alt-tag is empty", function() {
+		const stringToCheck = altTagCountFunction(
 			new Paper( "string <img src='http://plaatje' alt='' />", { keyword: "keyword" } )
 		);
 
@@ -55,8 +55,10 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAlt ).toBe( 0 );
 		expect( stringToCheck.withAltKeyword ).toBe( 0 );
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
 
-		var stringToCheck = altTagCountFunction(
+	it( "returns object with the noAlt as 1 when the alt-tag is missing", function() {
+		const stringToCheck = altTagCountFunction(
 			new Paper( "string <img src='http://plaatje' />", { keyword: "keyword" } )
 		);
 
@@ -67,7 +69,7 @@ describe( "Counts images in an text", function() {
 	} );
 
 	it( "returns object with a combination of present and missing alt-tags", function() {
-		var stringToCheck = altTagCountFunction(
+		const stringToCheck = altTagCountFunction(
 			new Paper( "string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='' />", { keyword: "keyword" } )
 		);
 
@@ -76,8 +78,9 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAltKeyword ).toBe( 1 );
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
 	} );
+
 	it( "returns object with the withAltKeyword as 1 when the keyword is set and present and has a $", function() {
-		var stringToCheck = altTagCountFunction(
+		const stringToCheck = altTagCountFunction(
 			new Paper( "string <img src='http://img' alt='$keyword' />", { keyword: "$keyword" } )
 		);
 
@@ -85,5 +88,56 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAlt ).toBe( 0 );
 		expect( stringToCheck.withAltKeyword ).toBe( 1 );
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with a combination of present and missing alt-tags with keyphrase and synonym words in it", function() {
+		const stringToCheck = altTagCountFunction(
+			new Paper( "string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='something empty' /> " +
+				"string <img src='http://plaatje' alt='synonym' /> <img src='http://plaatje' alt='' /> " +
+				"string <img src='http://plaatje' alt='test' /> <img src='http://plaatje' alt='' /> " +
+				"string <img src='http://plaatje' alt='paper interesting' /> <img src='http://plaatje' alt='paper' />", {
+				keyword: "keyword",
+				synonyms: "synonym, test, interesting paper",
+			} )
+		);
+
+		expect( stringToCheck.noAlt ).toBe( 2 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 5 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "returns object with a combination of present and missing alt-tags with \"keyphrase\" and synonym words in it", function() {
+		const stringToCheck = altTagCountFunction(
+			new Paper( "string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='something empty' /> " +
+				"string <img src='http://plaatje' alt='synonym' /> <img src='http://plaatje' alt='' /> " +
+				"string <img src='http://plaatje' alt='keyword in quotes' /> <img src='http://plaatje' alt='' /> " +
+				"string <img src='http://plaatje' alt='paper interesting' /> <img src='http://plaatje' alt='paper' />", {
+				keyword: "\"keyword in quotes\"",
+				synonyms: "synonym, test, interesting paper",
+			} )
+		);
+
+		expect( stringToCheck.noAlt ).toBe( 2 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 2 );
+	} );
+
+	it( "returns object with morphological forms", function() {
+		const stringToCheck = altTagCountFunction(
+			new Paper( "string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='something empty' /> " +
+				"string <img src='http://plaatje' alt='synonyms' /> <img src='http://plaatje' alt='' /> " +
+				"string <img src='http://plaatje' alt='keyword in quotes' /> <img src='http://plaatje' alt='' /> " +
+				"string <img src='http://plaatje' alt='paper interesting' /> <img src='http://plaatje' alt='papering' />", {
+				keyword: "\"keyword in quotes\"",
+				synonyms: "synonym, test, interesting paper",
+			} )
+		);
+
+		expect( stringToCheck.noAlt ).toBe( 2 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 2 );
 	} );
 } );

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -25,6 +25,7 @@ class TextImagesAssessment extends Assessment {
 				withAlt: 6,
 				noAlt: 6,
 			},
+			url: "<a href='https://yoa.st/2pj' target='_blank'>",
 		};
 
 		this.identifier = "textImages";
@@ -45,8 +46,10 @@ class TextImagesAssessment extends Assessment {
 		const imageCount = researcher.getResearch( "imageCount" );
 		const altProperties = researcher.getResearch( "altTagCount" );
 
-		assessmentResult.setScore( this.calculateScore( imageCount, altProperties ) );
-		assessmentResult.setText( this.translateScore( imageCount, altProperties, i18n ) );
+		const calculatedScore = this.calculateResult( imageCount, altProperties, i18n );
+
+		assessmentResult.setScore( calculatedScore.score );
+		assessmentResult.setText( calculatedScore.resultText );
 
 		return assessmentResult;
 	}
@@ -63,99 +66,77 @@ class TextImagesAssessment extends Assessment {
 	}
 
 	/**
-	 * Calculate the score based on the current image count and current image alt-tag count.
-	 *
-	 * @param {number} imageCount The amount of images to be checked against.
-	 * @param {Object} altProperties An object containing the various alt-tags.
-	 *
-	 * @returns {number} The calculated score.
-	 */
-	calculateScore( imageCount, altProperties ) {
-		if ( imageCount === 0 ) {
-			return this._config.scores.noImages;
-		}
-
-		// Has alt-tag and keywords
-		if ( altProperties.withAltKeyword > 0 ) {
-			return this._config.scores.withAltKeyword;
-		}
-
-		// Has alt-tag, but no keywords and it's not okay
-		if ( altProperties.withAltNonKeyword > 0 ) {
-			return this._config.scores.withAltNonKeyword;
-		}
-
-		// Has alt-tag, but no keyword is set
-		if ( altProperties.withAlt > 0 ) {
-			return this._config.scores.withAlt;
-		}
-
-		// Has no alt-tag
-		if ( altProperties.noAlt > 0 ) {
-			return this._config.scores.noAlt;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Translates the score to a message the user can understand.
+	 * Calculate the score and the feedback string based on the current image count and current image alt-tag count.
 	 *
 	 * @param {number} imageCount The amount of images to be checked against.
 	 * @param {Object} altProperties An object containing the various alt-tags.
 	 * @param {Jed} i18n The object used for translations.
 	 *
-	 * @returns {string} The translated string.
+	 * @returns {Object} The calculated score and the feedback string.
 	 */
-	translateScore( imageCount, altProperties, i18n ) {
-		const url = "<a href='https://yoa.st/2pj' target='_blank'>";
+	calculateResult( imageCount, altProperties, i18n ) {
 
 		if ( imageCount === 0 ) {
-			return i18n.sprintf(
-				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "No %1$simages%2$s appear in this page, consider adding some as appropriate." ),
-				url,
-				"</a>"
-			);
+			return {
+				score: this._config.scores.noImages,
+				resultText: i18n.sprintf(
+					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "No %1$simages%2$s appear in this page, consider adding some as appropriate." ),
+					this._config.url,
+					"</a>"
+				),
+			}
 		}
 
 		// Has alt-tag and keywords
 		if ( altProperties.withAltKeyword > 0 ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes with the focus keyword." ),
-				url,
-				"</a>"
-			);
+			return {
+				score: this._config.scores.withAltKeyword,
+				resultText: i18n.sprintf(
+					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes with the focus keyword." ),
+					this._config.url,
+					"</a>"
+				),
+			}
 		}
 
 		// Has alt-tag, but no keywords and it's not okay
 		if ( altProperties.withAltNonKeyword > 0 ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page do not have alt attributes containing the focus keyword." ),
-				url,
-				"</a>"
-			);
+			return {
+				score: this._config.scores.withAltNonKeyword,
+				resultText: i18n.sprintf(
+					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page do not have alt attributes containing the focus keyword." ),
+					this._config.url,
+					"</a>"
+				),
+			}
 		}
 
 		// Has alt-tag, but no keyword is set
 		if ( altProperties.withAlt > 0 ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes." ),
-				url,
-				"</a>"
-			);
+			return {
+				score: this._config.scores.withAlt,
+				resultText: i18n.sprintf(
+					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes." ),
+					this._config.url,
+					"</a>"
+				),
+			}
 		}
 
 		// Has no alt-tag
 		if ( altProperties.noAlt > 0 ) {
-			return i18n.sprintf(
-				i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page are missing alt attributes." ),
-				url,
-				"</a>"
-			);
+			return {
+				score: this._config.scores.noAlt,
+				resultText: i18n.sprintf(
+					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page are missing alt attributes." ),
+					this._config.url,
+					"</a>"
+				),
+			}
 		}
-
-		return "";
+		return null;
 	}
 }
 

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -85,7 +85,7 @@ class TextImagesAssessment extends Assessment {
 					this._config.url,
 					"</a>"
 				),
-			}
+			};
 		}
 
 		// Has alt-tag and keywords
@@ -94,11 +94,11 @@ class TextImagesAssessment extends Assessment {
 				score: this._config.scores.withAltKeyword,
 				resultText: i18n.sprintf(
 					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes with the focus keyword." ),
+					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes with the topic words." ),
 					this._config.url,
 					"</a>"
 				),
-			}
+			};
 		}
 
 		// Has alt-tag, but no keywords and it's not okay
@@ -106,11 +106,11 @@ class TextImagesAssessment extends Assessment {
 			return {
 				score: this._config.scores.withAltNonKeyword,
 				resultText: i18n.sprintf(
-					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page do not have alt attributes containing the focus keyword." ),
+					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page do not have alt attributes with the topic words." ),
 					this._config.url,
 					"</a>"
 				),
-			}
+			};
 		}
 
 		// Has alt-tag, but no keyword is set
@@ -122,7 +122,7 @@ class TextImagesAssessment extends Assessment {
 					this._config.url,
 					"</a>"
 				),
-			}
+			};
 		}
 
 		// Has no alt-tag
@@ -134,7 +134,7 @@ class TextImagesAssessment extends Assessment {
 					this._config.url,
 					"</a>"
 				),
-			}
+			};
 		}
 		return null;
 	}

--- a/src/researches/findKeywordFormsInString.js
+++ b/src/researches/findKeywordFormsInString.js
@@ -86,7 +86,7 @@ const findTopicFormsInString = function( topicForms, text, useSynonyms, locale )
 	return result;
 };
 
-module.exports = {
-	findWordFormsInString: findWordFormsInString,
-	findTopicFormsInString: findTopicFormsInString,
+export {
+	findWordFormsInString,
+	findTopicFormsInString,
 };

--- a/src/values/Paper.js
+++ b/src/values/Paper.js
@@ -220,4 +220,20 @@ Paper.prototype.getSynonymsForms = function() {
 	return this._attributes.topicForms.synonymsForms;
 };
 
+/**
+ * Check whether topicForms are available.
+ * @returns {boolean} Returns true if the Paper has topic forms.
+ */
+Paper.prototype.hasTopicForms = function() {
+	return ! ( isEmpty( this._attributes.topicForms ) );
+};
+
+/**
+ * Return the topic forms or an empty object if no topic forms are available.
+ * @returns {Object} Returns topic forms
+ */
+Paper.prototype.getTopicForms = function() {
+	return this._attributes.topicForms;
+};
+
 module.exports = Paper;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the assessment that checks if the keyword is used in the alt-tags of images by including morphological forms of words (for English) and using synonyms (for Premium).

## Relevant technical choices:

* 

## Test instructions
Hereinafter, by content words I understand all words which are not listed as function words for this language. The lists of function words are available on github, e.g., [for English](https://github.com/Yoast/YoastSEO.js/blob/develop/src/researches/english/functionWords.js). If no function words list is available for a language, consider all words as content words.

This PR can be tested by following these steps:

### English, Premium
* Add a text without images > BAD score
* Add an image without alt-tags > OK score
* Write something in the alt-tag that has nothing to do with the keyphrase or synonyms > OK score
* Use the keyphrase as alt-tag for the image > GOOD score
* Use one of the content words from the keyphrase as alt-tag for the image > GOOD score
* Make a different form of the content word you used at the previous step (e.g., change "keyword" to "keywords", or "write" to "written"), the result should remain GOOD
* Use the synonym in the alt-tag > GOOD score
* Use one of the content words in the synonym or a different form of this word > GOOD score.

### English, Free
* Add a text without images > BAD score
* Add an image without alt-tags > OK score
* Write something in the alt-tag that has nothing to do with the keyphrase or synonyms > OK score
* Use the keyphrase as alt-tag for the image > GOOD score
* Use one of the content words from the keyphrase as alt-tag for the image > GOOD score

### Other languages, Premium
* Add a text without images > BAD score
* Add an image without alt-tags > OK score
* Write something in the alt-tag that has nothing to do with the keyphrase or synonyms > OK score
* Use the keyphrase as alt-tag for the image > GOOD score
* Use one of the content words from the keyphrase as alt-tag for the image > GOOD score
* Use the synonym in the alt-tag > GOOD score
* Use one of the content words in the synonym > GOOD score.

### Other languages, Free
* Add a text without images > BAD score
* Add an image without alt-tags > OK score
* Write something in the alt-tag that has nothing to do with the keyphrase or synonyms > OK score
* Use the keyphrase as alt-tag for the image > GOOD score
* Use one of the words from the keyphrase as alt-tag for the image > GOOD score

Fixes #1642 
