### PR TITLE
Deprecate switchAssessors in the app

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -999,6 +999,9 @@ App.prototype.createSnippetPreview = function() {
  * @returns {void}
  */
 App.prototype.switchAssessors = function( useCornerStone ) {
+	// eslint-disable-next-line no-console
+	console.warn( "Switch assessor is deprecated since YoastSEO.js version 1.35.0" );
+
 	this.changeAssessorOptions( {
 		useCornerStone,
 	} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Deprecates switch assessors.