### PR TITLE
Increase debounce wait time

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -32,7 +32,7 @@ var removeHtmlBlocks = require( "./stringProcessing/htmlParser.js" );
 
 const largestKeywordDistance = new LargestKeywordDistanceAssessment();
 
-var inputDebounceDelay = 400;
+var inputDebounceDelay = 800;
 
 /**
  * Default config for YoastSEO.js


### PR DESCRIPTION
This will make the app a lot more workable because the analysis runs less often after a quick pause in typing.

The test instructions and relevant choices have been based on a WordPress SEO environment.

## Summary

This PR can be summarized in the following changelog entry:

* Increased debounce delay to 800 for less Refresh triggers in the App.

## Relevant technical choices:

* Looked into a couple of places to determine if we can avoid refreshes more often, but this proved to be difficult.
* The ReplaceVar class registers changes to the Plugin after it has been loaded, which triggers the refresh again. This results in two refreshes on App initialization, when the user already wants to start working with the content.

## Test instructions

This PR can be tested by following these steps:

* Check out the branch
* Type some data into input fields or change them otherwise (cornerstone content)
* See the Recalculation of the results being triggered not as fast as without the change

This will not completely resolve all the issues regarding delay in typing, but it should reduce the times the occur when still changing data.

Fixes https://github.com/Yoast/wordpress-seo/issues/10533