### PR TITLE
Remove window reliance in assessor

### DIFF
--- a/src/assessor.js
+++ b/src/assessor.js
@@ -75,10 +75,6 @@ Assessor.prototype.isApplicable = function( assessment, paper, researcher ) {
  * @returns {boolean} Whether or not the assessment has a marker.
  */
 Assessor.prototype.hasMarker = function( assessment ) {
-	if ( ! isUndefined( window ) && ! isUndefined( window.yoastHideMarkers ) && window.yoastHideMarkers ) {
-		return false;
-	}
-
 	return isFunction( this._options.marker ) && ( assessment.hasOwnProperty( "getMarks" ) || typeof assessment.getMarks === "function" );
 };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

* Removes the check of the window presence and window parameters in assessor.js. Assessor is used by the worker, who has no access to window.
* `yoastHideMarkers` in only used in the term-scrapper to disable the markings in Category pages. @CarolineGeven why don't we show makings on Category pages? Also see #1426.
* In general, we want to implement architecture where YoastSEO.js simply provides a list of markings, while the plugin (or any other plugin that makes use of this library) decides whether or not and how to show the markings.

## Test instructions

This PR can be tested by following these steps:

* Run the `analyze spam` and check console that all assessments have run successfully.

Fixes #1669 
