### PR TITLE
Uses HTML parser in the worker

### DIFF
--- a/src/worker/analysis.worker.js
+++ b/src/worker/analysis.worker.js
@@ -10,6 +10,7 @@ import * as ContentAssessor from "yoastseo/contentAssessor";
 import * as SEOAssessor from "yoastseo/seoAssessor";
 import * as CornerstoneContentAssessor from "yoastseo/cornerstone/contentAssessor";
 import * as CornerstoneSEOAssessor from "yoastseo/cornerstone/seoAssessor";
+const removeHtmlBlocks = require( "../stringProcessing/htmlParser.js" );
 
 // Internal dependencies.
 import { Scheduler } from "./scheduler";
@@ -194,7 +195,7 @@ class AnalysisWebWorker {
 		console.log( "run analyze", id, paper, configuration );
 		const result = { id };
 
-		this._paper = new Paper( paper.text, omit( paper, "text" ) );
+		this._paper = new Paper( removeHtmlBlocks( paper.text ), omit( paper, "text" ) );
 		this._researcher.setPaper( this._paper );
 
 		if ( this._configuration.contentAnalysisActive && this._contentAssessor ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

* Use html parser in the analysisWorker

## Test instructions

This PR can be tested by following these steps:

* Create a text that and use your focus keyword in it. Check if it correctly recognized by the keyword density assessment
* Put tags  `<script>` - `</script>`, `<style>` - `</style>`, `<code>` - `</code>`, or `<pre>`-`</pre>`around the text  - the focus keyword should not any more be found.

Fixes #1673
