### PR TITLE
Add array of mark objects to assessment results

### DIFF
--- a/src/assessor.js
+++ b/src/assessor.js
@@ -171,6 +171,10 @@ Assessor.prototype.executeAssessment = function( paper, researcher, assessment )
 		result = assessment.getResult( paper, researcher, this.i18n );
 		result.setIdentifier( assessment.identifier );
 
+		if ( result.hasMarks() ) {
+			result.marks = assessment.getMarks( paper, researcher );
+		}
+
 		if ( result.hasMarks() && this.hasMarker( assessment ) ) {
 			this.setHasMarkers( true );
 

--- a/src/assessor.js
+++ b/src/assessor.js
@@ -108,26 +108,11 @@ Assessor.prototype.getMarker = function( assessment, paper, researcher ) {
 	var specificMarker = this._options.marker;
 
 	return function() {
-		const marks = this.getMarks( assessment, paper, researcher );
+		let marks = assessment.getMarks( paper, researcher );
+		marks = removeDuplicateMarks( marks );
 
 		specificMarker( paper, marks );
 	};
-};
-
-/**
- * Returns the marks for a given assessment.
- *
- * @param {Object} assessment The assessment for which we are retrieving the marks.
- * @param {Paper} paper The paper to retrieve the marker for.
- * @param {Researcher} researcher The researcher for the paper.
-
- * @returns {Array} The assessment's marks.
- */
-Assessor.prototype.getMarks = function( assessment, paper, researcher ) {
-	let marks = assessment.getMarks( paper, researcher );
-	marks = removeDuplicateMarks( marks );
-
-	return marks;
 };
 
 /**
@@ -186,7 +171,8 @@ Assessor.prototype.executeAssessment = function( paper, researcher, assessment )
 		result.setIdentifier( assessment.identifier );
 
 		if ( result.hasMarks() ) {
-			result.marks = this.getMarks( assessment, paper, researcher );
+			result.marks = assessment.getMarks( paper, researcher );
+			result.marks = removeDuplicateMarks( result.marks );
 		}
 
 		if ( result.hasMarks() && this.hasMarker( assessment ) ) {

--- a/src/assessor.js
+++ b/src/assessor.js
@@ -108,12 +108,26 @@ Assessor.prototype.getMarker = function( assessment, paper, researcher ) {
 	var specificMarker = this._options.marker;
 
 	return function() {
-		var marks = assessment.getMarks( paper, researcher );
-
-		marks = removeDuplicateMarks( marks );
+		const marks = this.getMarks( assessment, paper, researcher );
 
 		specificMarker( paper, marks );
 	};
+};
+
+/**
+ * Returns the marks for a given assessment.
+ *
+ * @param {Object} assessment The assessment for which we are retrieving the marks.
+ * @param {Paper} paper The paper to retrieve the marker for.
+ * @param {Researcher} researcher The researcher for the paper.
+
+ * @returns {Array} The assessment's marks.
+ */
+Assessor.prototype.getMarks = function( assessment, paper, researcher ) {
+	let marks = assessment.getMarks( paper, researcher );
+	marks = removeDuplicateMarks( marks );
+
+	return marks;
 };
 
 /**
@@ -172,7 +186,7 @@ Assessor.prototype.executeAssessment = function( paper, researcher, assessment )
 		result.setIdentifier( assessment.identifier );
 
 		if ( result.hasMarks() ) {
-			result.marks = assessment.getMarks( paper, researcher );
+			result.marks = this.getMarks( assessment, paper, researcher );
 		}
 
 		if ( result.hasMarks() && this.hasMarker( assessment ) ) {

--- a/src/values/AssessmentResult.js
+++ b/src/values/AssessmentResult.js
@@ -24,6 +24,7 @@ var AssessmentResult = function( values ) {
 	this._marker = emptyMarker;
 	this.score = 0;
 	this.text = "";
+	this.marks = [];
 
 	if ( isUndefined( values ) ) {
 		values = {};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Adds the array of mark objects to the assessment result.

## Test instructions

This PR can be tested by following these steps:

* In the example, check whether the result for a given assessment contains the markers. E.g. when you write a sentence that contains the word "however", a mark object for this sentence should be added to the assessment result of the transition words assessment.

Fixes #1692 Fixes #1696
