### PR TITLE
Check synonyms type

### DIFF
--- a/spec/stringProcessing/parseSynonymsSpec.js
+++ b/spec/stringProcessing/parseSynonymsSpec.js
@@ -9,5 +9,6 @@ describe( "A test for parsing a comma-separated list of synonyms into an array o
 		expect( parseSynonyms( "!, ,?" ) ).toEqual( [] );
 		expect( parseSynonyms( "To be, or not to be, that is the question:" ) ).toEqual( [ "To be", "or not to be", "that is the question" ] );
 		expect( parseSynonyms( "To be,or not to be,that is the question:" ) ).toEqual( [ "To be", "or not to be", "that is the question" ] );
+		expect( parseSynonyms( null ) ).toEqual( [] );
 	} );
 } );

--- a/src/stringProcessing/parseSynonyms.js
+++ b/src/stringProcessing/parseSynonyms.js
@@ -11,6 +11,10 @@ const removePunctuation = require( "../stringProcessing/removePunctuation.js" );
  * @returns {Array} An array with all synonyms.
  */
 module.exports = function( synonyms ) {
+	if ( typeof synonyms !== "string" ) {
+		synonyms = "";
+	}
+
 	let synonymsSplit = synonyms.split( "," );
 
 	synonymsSplit = synonymsSplit.map( function( synonym ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Adds functionality for checking whether synonyms are a string to YoastSEO.js. After this has been merged, this functionality can be removed on the plugin side (see issue).

## Test instructions

This PR can be tested by following these steps:

* t.b.a

Fixes #1700 
