### PR TITLE
Register assessment interface including custom messages.

### DIFF
--- a/src/researches/sentences.js
+++ b/src/researches/sentences.js
@@ -1,8 +1,12 @@
 const getSentences = require( "../stringProcessing/getSentences" );
 
 /**
+ * Returns the sentences from a paper.
+ *
  * @param {Paper} paper The paper to analyze.
+ *
+ * @returns {Array} Sentences found in the paper.
  */
-export default function( paper: any ) {
+export default function( paper ) {
     return getSentences( paper.getText() );
 }

--- a/src/stringProcessing/index.js
+++ b/src/stringProcessing/index.js
@@ -4,6 +4,7 @@ const transliterate = require( "./transliterate" );
 const replaceDiacritics = require( "./replaceDiacritics" );
 const imageInText = require( "./imageInText" );
 const relevantWords = require( "./relevantWords" );
+const removeHtmlBlocks = require( "./htmlParser" );
 
 export {
 	stripHTMLTags,
@@ -12,4 +13,5 @@ export {
 	replaceDiacritics,
 	imageInText,
 	relevantWords,
+	removeHtmlBlocks,
 };

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -101,11 +101,12 @@ export default class AnalysisWebWorker {
 		this.loadScriptDone = this.loadScriptDone.bind( this );
 		this.customMessage = this.customMessage.bind( this );
 		this.customMessageDone = this.customMessageDone.bind( this );
+		this.clearCache = this.clearCache.bind( this );
 
 		// Bind register functions to this scope.
 		this.registerAssessment = this.registerAssessment.bind( this );
 		this.registerMessageHandler = this.registerMessageHandler.bind( this );
-		this.clearCache = this.clearCache.bind( this );
+		this.refreshAssessment = this.refreshAssessment.bind( this );
 
 		// Bind event handlers to this scope.
 		this.handleMessage = this.handleMessage.bind( this );
@@ -121,7 +122,7 @@ export default class AnalysisWebWorker {
 		this._scope.analysisWorker = {
 			registerAssessment: this.registerAssessment,
 			registerMessageHandler: this.registerMessageHandler,
-			clearCache: this.clearCache,
+			refreshAssessment: this.refreshAssessment,
 		};
 		this._scope.YoastSEO = YoastSEO;
 	}
@@ -312,7 +313,7 @@ export default class AnalysisWebWorker {
 	}
 
 	/**
-	 * Register an assessment for a specific plugin
+	 * Register an assessment for a specific plugin.
 	 *
 	 * @param {string}   name       The name of the assessment.
 	 * @param {function} assessment The function to run as an assessment.
@@ -345,7 +346,7 @@ export default class AnalysisWebWorker {
 	}
 
 	/**
-	 * Register a message handler for a specific plugin
+	 * Register a message handler for a specific plugin.
 	 *
 	 * @param {string}   name       The name of the message handler.
 	 * @param {function} handler    The function to run as an message handler.
@@ -372,6 +373,30 @@ export default class AnalysisWebWorker {
 		name = pluginName + "-" + name;
 
 		this._registeredMessageHandlers[ name ] = handler;
+	}
+
+	/**
+	 * Refreshes an assessment in the analysis.
+	 *
+	 * Custom assessments can use this to mark their assessment as needing a
+	 * refresh.
+	 *
+	 * @param {string} name The name of the assessment.
+	 * @param {string} pluginName The name of the plugin associated with the assessment.
+	 *
+	 * @returns {boolean} Whether refreshing the assessment was successful.
+	 */
+	refreshAssessment( name, pluginName ) {
+		if ( ! isString( name ) ) {
+			throw new InvalidTypeError( "Failed to refresh assessment for plugin " + pluginName + ". Expected parameter `name` to be a string." );
+		}
+
+		if ( ! isString( pluginName ) ) {
+			throw new InvalidTypeError( "Failed to refresh assessment for plugin " + pluginName +
+				". Expected parameter `pluginName` to be a string." );
+		}
+
+		this.clearCache();
 	}
 
 	/**

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -412,7 +412,7 @@ export default class AnalysisWebWorker {
 	 * @returns {Object} The result, may not contain readability or seo.
 	 */
 	analyze( id, { paper } ) {
-		paper.text = string.stripHTMLTags( paper.text );
+		paper.text = string.removeHtmlBlocks( paper.text );
 		const newPaper = Paper.parse( paper );
 		const paperIsIdentical = isEqual( this._paper, newPaper );
 		const textIsIdentical = this._paper.getText() === newPaper.getText();

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -22,7 +22,7 @@ class AnalysisWorkerWrapper {
 		// Bind actions to this scope.
 		this.initialize = this.initialize.bind( this );
 		this.analyze = this.analyze.bind( this );
-		this.importScript = this.importScript.bind( this );
+		this.loadScript = this.loadScript.bind( this );
 		this.sendMessage = this.sendMessage.bind( this );
 
 		// Bind event handlers to this scope.
@@ -72,9 +72,6 @@ class AnalysisWorkerWrapper {
 				if ( payload.readability ) {
 					payload.readability.results = payload.readability.results.map( result => AssessmentResult.parse( result ) );
 				}
-
-				request.resolve( payload );
-				break;
 
 				request.resolve( payload );
 				break;
@@ -128,13 +125,14 @@ class AnalysisWorkerWrapper {
 	/**
 	 * Creates a new request inside a Promise.
 	 *
-	 * @param {number} id The request id.
+	 * @param {number} id     The request id.
+	 * @param {Object} [data] Optional extra data.
 	 *
 	 * @returns {Promise} The callback promise.
 	 */
-	createRequestPromise( id ) {
+	createRequestPromise( id, data = {} ) {
 		return new Promise( ( resolve, reject ) => {
-			this._requests[ id ] = new Request( resolve, reject );
+			this._requests[ id ] = new Request( resolve, reject, data );
 		} );
 	}
 
@@ -143,12 +141,13 @@ class AnalysisWorkerWrapper {
 	 *
 	 * @param {string} action  The action of the request.
 	 * @param {Object} payload The payload of the request.
+	 * @param {Object} [data]  Optional extra data.
 	 *
 	 * @returns {Promise} A promise that will resolve or reject once the worker finishes.
 	 */
-	sendRequest( action, payload ) {
+	sendRequest( action, payload, data = {} ) {
 		const id = this.createRequestId();
-		const promise = this.createRequestPromise( id );
+		const promise = this.createRequestPromise( id, data );
 
 		this.send( action, id, payload );
 		return promise;
@@ -202,8 +201,8 @@ class AnalysisWorkerWrapper {
 	 *
 	 * @returns {Promise} The promise of the script import.
 	 */
-	importScript( url ) {
-		return this.sendRequest( "importScript", { url } );
+	loadScript( url ) {
+		return this.sendRequest( "loadScript", { url } );
 	}
 
 	/**
@@ -217,7 +216,7 @@ class AnalysisWorkerWrapper {
 	 */
 	sendMessage( name, data, pluginName ) {
 		name = pluginName + "-" + name;
-		return this.sendRequest( "customMessage", { name, data } );
+		return this.sendRequest( "customMessage", { name, data }, data );
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a `loadScript( script )` function to the web worker wrapper to allow loading custom scripts.
* Adds a `sendMessage( name, data, pluginName )` function to the web worker wrapper to allow sending custom messages to your custom script.
* Adds a `analysisWorker.registerAssessment( name, assessment, pluginName )` function to the global worker scope to allow registering custom assessments.
* Adds a `analysisWorker.registerMessageHandler( name, handler, pluginName )` function to the global worker scope to allow registering custom message handlers to process message by `sendMessage`.
* Exposes `YoastSEO` to the global worker scope to allow defining this as an external for web worker scripts.

## Relevant technical choices:

* Custom messages are used instead of passing initial data to `loadScript` to allow updating data that may change at a later date.
* The worker itself and the App are not exposed as these shouldn't be used inside the worker context.

## Test instructions

This PR can be tested by following these steps:

* See the instructions in: https://github.com/Yoast/wordpress-seo/pull/10689 to test a custom assessment.
* You can also use the console to switch between the worker context and the main window.
* You can run `analysisWorker.registerMessageHandler( "greet", function( name ) { return "Hello " + name + "!"  }, "greeter" );` in the web worker context.
* Then run `window.YoastSEO.analysisWorker.sendMessage( "greet", "world", "greeter" ).then( function ( message ) { console.log( message.result ); } );` in the top context to test a simple custom message. 

Fixes #1680.
