### PR TITLE
Move taxonomy assesssor to YoastSEO.js

### DIFF
--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -1,0 +1,125 @@
+const Assessor = require( "../src/taxonomyAssessor.js" );
+const Paper = require( "../js/values/Paper.js" );
+const factory = require( "./helpers/factory.js" );
+const i18n = factory.buildJed();
+const assessor = new Assessor( i18n );
+
+const getResults = function( Results ) {
+	let assessments = [];
+
+	for ( let Result of Results ) {
+		assessments.push( Result._identifier );
+	}
+
+	return assessments;
+};
+
+describe( "running assessments in the assessor", function() {
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a keyword and a title", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", title: "title" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleKeyword",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a url", function() {
+		assessor.assess( new Paper( "text", { url: "www.website.com" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { url: "sample url", keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+			"urlKeyword",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a keyword and a meta description", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionKeyword",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+} );

--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -1,4 +1,4 @@
-const Assessor = require( "../src/taxonomyAssessor.js" );
+const Assessor = require( "../js/taxonomyAssessor.js" );
 const Paper = require( "../js/values/Paper.js" );
 const factory = require( "./helpers/factory.js" );
 const i18n = factory.buildJed();

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -1,0 +1,44 @@
+import { inherits } from "util";
+
+import IntroductionKeywordAssessment from "./assessments/seo/IntroductionKeywordAssessment";
+import KeyphraseLengthAssessment from "./assessments/seo/KeyphraseLengthAssessment";
+import KeywordDensityAssessment from "./assessments/seo/KeywordDensityAssessment";
+import MetaDescriptionKeywordAssessment from "./assessments/seo/MetaDescriptionKeywordAssessment";
+import TitleKeywordAssessment from "./assessments/seo/TitleKeywordAssessment";
+import UrlKeywordAssessment from "./assessments/seo/UrlKeywordAssessment";
+const Assessor = require( "./assessor" );
+const keywordStopWordsAssessment = require( "./assessments/seo/keywordStopWordsAssessment" );
+const MetaDescriptionLengthAssessment = require( "./assessments/seo/metaDescriptionLengthAssessment" );
+const taxonomyTextLengthAssessment = require( "./assessments/seo/taxonomyTextLengthAssessment" );
+const PageTitleWidthAssessment = require( "./assessments/seo/pageTitleWidthAssessment" );
+const UrlLengthAssessment = require( "./assessments/seo/urlLengthAssessment" );
+const urlStopWordsAssessment = require( "./assessments/seo/urlStopWordsAssessment" );
+
+/**
+ * Creates the Assessor used for taxonomy pages.
+ *
+ * @param {object} i18n The i18n object used for translations.
+ * @constructor
+ */
+const TaxonomyAssessor = function( i18n ) {
+	Assessor.call( this, i18n );
+
+	this._assessments = [
+		new IntroductionKeywordAssessment(),
+		new KeyphraseLengthAssessment(),
+		new KeywordDensityAssessment(),
+		keywordStopWordsAssessment,
+		new MetaDescriptionKeywordAssessment(),
+		new MetaDescriptionLengthAssessment(),
+		taxonomyTextLengthAssessment,
+		new TitleKeywordAssessment(),
+		new PageTitleWidthAssessment(),
+		new UrlKeywordAssessment(),
+		new UrlLengthAssessment(),
+		urlStopWordsAssessment,
+	];
+};
+
+module.exports = TaxonomyAssessor;
+
+inherits( module.exports, Assessor );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Moves the taxonomy assessor to YoastSEO.js

## Test instructions

This PR can be tested by following these steps:

* Link with this branch on the plugin: tba
* Add a new category or tage page and check whether the taxonomy assessor is used (you can see this by the fact that you're asked to write a minimum of 150 words).
* Add a new post and check whether the normal SEO assessor is used (you can see this by the fact that you're asked to write a minimum of 300 words).


Fixes #1706
