### PR TITLE
Support related keywords

### DIFF
--- a/src/values/Paper.js
+++ b/src/values/Paper.js
@@ -1,5 +1,6 @@
 var defaults = require( "lodash/defaults" );
 const isEmpty = require( "lodash/isEmpty" );
+const isEqual = require( "lodash/isEqual" );
 
 /**
  * Default attributes to be used by the Paper if they are left undefined.
@@ -18,8 +19,18 @@ var defaultAttributes = {
 
 /**
  * Construct the Paper object and set the keyword property.
- * @param {string} text The text to use in the analysis.
- * @param {object} attributes The object containing all attributes.
+ *
+ * @param {string} text                     The text to use in the analysis.
+ * @param {object} [attributes]             The object containing all attributes.
+ * @param {Object} [attributes.keyword]     The main keyword.
+ * @param {Object} [attributes.synonyms]    The main keyword's synonyms.
+ * @param {Object} [attributes.title]       The SEO title.
+ * @param {Object} [attributes.description] The SEO description.
+ * @param {Object} [attributes.titleWidth]  The width of the title in pixels.
+ * @param {Object} [attributes.url]         The slug.
+ * @param {Object} [attributes.permalink]   The base url + slug.
+ * @param {Object} [attributes.locale]      The locale.
+ *
  * @constructor
  */
 var Paper = function( text, attributes ) {
@@ -195,6 +206,17 @@ Paper.prototype.serialize = function() {
 		text: this._text,
 		...this._attributes,
 	};
+};
+
+/**
+ * Checks whether the given paper has the same properties as this instance.
+ *
+ * @param {Paper} paper The paper to compare to.
+ *
+ * @returns {boolean} Whether the given paper is identical or not.
+ */
+Paper.prototype.equals = function( paper ) {
+	return this._text === paper.getText() && isEqual( this._attributes, paper._attributes );
 };
 
 /**

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -281,7 +281,7 @@ export default class AnalysisWebWorker {
 	 *
 	 * @returns {boolean} True if there are changes detected.
 	 */
-	paperHasReadabilityChanges( paper ) {
+	shouldReadabilityUpdate( paper ) {
 		if ( this._paper.getText() !== paper.getText() ) {
 			return true;
 		}
@@ -299,7 +299,7 @@ export default class AnalysisWebWorker {
 	 *
 	 * @returns {boolean} True if there are changes detected.
 	 */
-	relatedKeywordHasChanges( key, { keyword, synonyms } ) {
+	shouldSeoUpdate( key, { keyword, synonyms } ) {
 		if ( isUndefined( this._relatedKeywords[ key ] ) ) {
 			return true;
 		}
@@ -330,7 +330,7 @@ export default class AnalysisWebWorker {
 		paper.text = removeHtmlBlocks( paper.text );
 		const newPaper = Paper.parse( paper );
 		const paperHasChanges = ! this._paper.equals( newPaper );
-		const paperHasReadabilityChanges = this.paperHasReadabilityChanges( newPaper );
+		const shouldReadabilityUpdate = this.shouldReadabilityUpdate( newPaper );
 
 		if ( paperHasChanges ) {
 			this._paper = newPaper;
@@ -357,7 +357,7 @@ export default class AnalysisWebWorker {
 			forEach( relatedKeywords, ( relatedKeyword, key ) => {
 				requestedRelatedKeywordKeys.push( key );
 
-				if ( this.relatedKeywordHasChanges( key, relatedKeyword ) ) {
+				if ( this.shouldSeoUpdate( key, relatedKeyword ) ) {
 					this._relatedKeywords[ key ] = relatedKeyword;
 
 					const relatedPaper = Paper.parse( {
@@ -380,7 +380,7 @@ export default class AnalysisWebWorker {
 			}
 		}
 
-		if ( this._configuration.contentAnalysisActive && this._contentAssessor && paperHasReadabilityChanges ) {
+		if ( this._configuration.contentAnalysisActive && this._contentAssessor && shouldReadabilityUpdate ) {
 			this._contentAssessor.assess( this._paper );
 
 			this._results.readability = {

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -126,6 +126,7 @@ export default class AnalysisWebWorker {
 		// Bind actions to this scope.
 		this.analyze = this.analyze.bind( this );
 		this.analyzeDone = this.analyzeDone.bind( this );
+		this.analyzeRelatedKeywordsDone = this.analyzeRelatedKeywordsDone.bind( this );
 		this.loadScript = this.loadScript.bind( this );
 		this.loadScriptDone = this.loadScriptDone.bind( this );
 		this.customMessage = this.customMessage.bind( this );

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -183,6 +183,14 @@ export default class AnalysisWebWorker {
 					data: payload,
 				} );
 				break;
+			case "analyzeRelatedKeywords":
+				this._scheduler.schedule( {
+					id,
+					execute: this.analyze,
+					done: this.analyzeRelatedKeywordsDone,
+					data: payload,
+				} );
+				break;
 			case "loadScript":
 				this._scheduler.schedule( {
 					id,
@@ -632,6 +640,18 @@ export default class AnalysisWebWorker {
 	 */
 	analyzeDone( id, result ) {
 		this.send( "analyze:done", id, result );
+	}
+
+	/**
+	 * Sends the analyze related keywords result back.
+	 *
+	 * @param {number} id     The request id.
+	 * @param {Object} result The result.
+	 *
+	 * @returns {void}
+	 */
+	analyzeRelatedKeywordsDone( id, result ) {
+		this.send( "analyzeRelatedKeywords:done", id, result );
 	}
 
 	/**

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -1,7 +1,9 @@
 // External dependencies.
 const Jed = require( "jed" );
+const forEach = require( "lodash/forEach" );
 const merge = require( "lodash/merge" );
-const isEqual = require( "lodash/isEqual" );
+const pickBy = require( "lodash/pickBy" );
+const includes = require( "lodash/includes" );
 const isUndefined = require( "lodash/isUndefined" );
 
 // YoastSEO.js dependencies.
@@ -43,17 +45,39 @@ export default class AnalysisWebWorker {
 			// The locale used for language-specific configurations in Flesch-reading ease and Sentence length assessments.
 			locale: "en_US",
 		};
+
 		this._scheduler = new Scheduler( { resetQueue: true } );
-		this._paper = new Paper( "" );
+
+		this._paper = new Paper( "", {} );
+		this._relatedKeywords = {};
+
 		this._researcher = new Researcher( this._paper );
 		this._contentAssessor = null;
 		this._seoAssessor = null;
-		this._result = {
+
+		/*
+		 * The cached analyses results.
+		 *
+		 * A single result has the following structure:
+		 * {AssessmentResult[]} readability.results An array of assessment results; in serialized format.
+		 * {number}             readability.score   The overall score.
+		 *
+		 * The results have the following structure.
+		 * {Object} readability Content assessor results.
+		 * {Object} seo         SEO assessor results, per keyword identifier or empty string for the main.
+		 * {Object} seo[ "" ]   The result of the paper analysis for the main keyword.
+		 * {Object} seo[ key ]  Same as above, but instead for a related keyword.
+		 */
+		this._results = {
 			readability: {
 				results: [],
+				score: 0,
 			},
 			seo: {
-				results: [],
+				"": {
+					results: [],
+					score: 0,
+				},
 			},
 		};
 
@@ -251,55 +275,121 @@ export default class AnalysisWebWorker {
 	}
 
 	/**
+	 * Checks if the paper contains changes that are used for readability.
+	 *
+	 * @param {Paper} paper The paper to check against the cached paper.
+	 *
+	 * @returns {boolean} True if there are changes detected.
+	 */
+	paperHasReadabilityChanges( paper ) {
+		if ( this._paper.getText() !== paper.getText() ) {
+			return true;
+		}
+
+		return this._paper.getLocale() !== paper.getLocale();
+	}
+
+	/**
+	 * Checks if the related keyword contains changes that are used for seo.
+	 *
+	 * @param {string} key                     The identifier of the related keyword.
+	 * @param {Object} relatedKeyword          The related keyword object.
+	 * @param {string} relatedKeyword.keyword  The keyword.
+	 * @param {string} relatedKeyword.synonyms The synonyms.
+	 *
+	 * @returns {boolean} True if there are changes detected.
+	 */
+	relatedKeywordHasChanges( key, { keyword, synonyms } ) {
+		if ( isUndefined( this._relatedKeywords[ key ] ) ) {
+			return true;
+		}
+
+		if ( this._relatedKeywords[ key ].keyword !== keyword ) {
+			return true;
+		}
+
+		return this._relatedKeywords[ key ].synonyms !== synonyms;
+	}
+
+	/**
 	 * Runs analyses on a paper.
 	 *
-	 * @param {number} id                      The request id.
-	 * @param {Object} payload                 The payload object.
-	 * @param {Object} payload.paper           The paper to analyze.
+	 * The paper includes the keyword and synonyms data. However, this is
+	 * possibly just one instance of these. From here we are going to split up
+	 * this data and keep track of the different sets of keyword-synonyms and
+	 * their results.
+	 *
+	 * @param {number} id                        The request id.
+	 * @param {Object} payload                   The payload object.
+	 * @param {Object} payload.paper             The paper to analyze.
+	 * @param {Object} [payload.relatedKeywords] The related keywords.
 	 *
 	 * @returns {Object} The result, may not contain readability or seo.
 	 */
-	analyze( id, { paper } ) {
+	analyze( id, { paper, relatedKeywords = {} } ) {
 		paper.text = removeHtmlBlocks( paper.text );
 		const newPaper = Paper.parse( paper );
-		const paperIsIdentical = isEqual( this._paper, newPaper );
-		const textIsIdentical = this._paper.getText() === newPaper.getText();
+		const paperHasChanges = ! this._paper.equals( newPaper );
+		const paperHasReadabilityChanges = this.paperHasReadabilityChanges( newPaper );
 
-		if ( paperIsIdentical ) {
-			console.log( "The paper has not changed since you analyzed it last." );
-			return this._result;
+		if ( paperHasChanges ) {
+			this._paper = newPaper;
+			this._researcher.setPaper( this._paper );
+
+			// Update the configuration locale to the paper locale.
+			this.setLocale( this._paper.getLocale() );
 		}
 
-		this._paper = newPaper;
-		this._researcher.setPaper( this._paper );
-
-		// Update the configuration locale to the paper locale.
-		this.setLocale( this._paper.getLocale() );
-
-		// Rerunning the SEO analysis if the text or attributes of the paper have changed.
 		if ( this._configuration.keywordAnalysisActive && this._seoAssessor ) {
-			this._seoAssessor.assess( this._paper );
-			this._result.seo = {
-				results: this._seoAssessor.results.map( result => result.serialize() ),
-				score: this._seoAssessor.calculateOverallScore(),
-			};
+			if ( paperHasChanges ) {
+				this._seoAssessor.assess( this._paper );
+
+				// Reset the cached results for the related keywords here too.
+				this._results.seo = {};
+				this._results.seo[ "" ] = {
+					results: this._seoAssessor.results.map( result => result.serialize() ),
+					score: this._seoAssessor.calculateOverallScore(),
+				};
+			}
+
+			// Start an analysis for every related keyword.
+			const requestedRelatedKeywordKeys = [ "" ];
+			forEach( relatedKeywords, ( relatedKeyword, key ) => {
+				requestedRelatedKeywordKeys.push( key );
+
+				if ( this.relatedKeywordHasChanges( key, relatedKeyword ) ) {
+					this._relatedKeywords[ key ] = relatedKeyword;
+
+					const relatedPaper = Paper.parse( {
+						...this._paper.serialize(),
+						keyword: this._relatedKeywords[ key ].keyword,
+						synonyms: this._relatedKeywords[ key ].synonyms,
+					} );
+					this._seoAssessor.assess( relatedPaper );
+
+					this._results.seo[ key ] = {
+						results: this._seoAssessor.results.map( result => result.serialize() ),
+						score: this._seoAssessor.calculateOverallScore(),
+					};
+				}
+			} );
+
+			// Clear the unrequested results, but only if there are requested related keywords.
+			if ( requestedRelatedKeywordKeys.length > 1 ) {
+				this._results.seo = pickBy( this._results.seo, ( relatedKeyword, key ) => includes( requestedRelatedKeywordKeys, key ) );
+			}
 		}
 
-		// Return old readability results if the text of the paper has not changed.
-		if ( textIsIdentical ) {
-			console.log( "The text of your paper has not changed, returning the content analysis results from the previous analysis." );
-			return this._result;
-		}
-
-		if ( this._configuration.contentAnalysisActive && this._contentAssessor ) {
+		if ( this._configuration.contentAnalysisActive && this._contentAssessor && paperHasReadabilityChanges ) {
 			this._contentAssessor.assess( this._paper );
-			this._result.readability = {
+
+			this._results.readability = {
 				results: this._contentAssessor.results.map( result => result.serialize() ),
 				score: this._contentAssessor.calculateOverallScore(),
 			};
 		}
 
-		return this._result;
+		return this._results;
 	}
 
 	/**

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -25,6 +25,7 @@ class AnalysisWorkerWrapper {
 		// Bind actions to this scope.
 		this.initialize = this.initialize.bind( this );
 		this.analyze = this.analyze.bind( this );
+		this.analyzeRelatedKeywords = this.analyzeRelatedKeywords.bind( this );
 		this.loadScript = this.loadScript.bind( this );
 		this.sendMessage = this.sendMessage.bind( this );
 

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -170,16 +170,16 @@ class AnalysisWorkerWrapper {
 	/**
 	 * Analyzes the paper.
 	 *
-	 * @param {Object} paper         The paper to analyze.
-	 * @param {Object} configuration The configuration specific to these analyses.
+	 * @param {Object} paper           The paper to analyze.
+	 * @param {Object} relatedKeywords The related keywords.
 	 *
 	 * @returns {Promise} The promise of analyses.
 	 */
-	analyze( paper, configuration = {} ) {
+	analyze( paper, relatedKeywords = {} ) {
 		const id = this.createRequestId();
 		const promise = this.createRequestPromise( id );
 
-		this.send( "analyze", id, { paper, configuration } );
+		this.send( "analyze", id, { paper, relatedKeywords } );
 		return promise;
 	}
 }

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -205,12 +205,11 @@ class AnalysisWorkerWrapper {
 	 * Analyzes the paper.
 	 *
 	 * @param {Object} paper           The paper to analyze.
-	 * @param {Object} relatedKeywords The related keywords.
 	 *
 	 * @returns {Promise} The promise of analyses.
 	 */
-	analyze( paper, relatedKeywords = {} ) {
-		return this.sendRequest( "analyze", { paper, relatedKeywords } );
+	analyze( paper ) {
+		return this.sendRequest( "analyze", { paper } );
 	}
 
 	/**

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -67,6 +67,7 @@ class AnalysisWorkerWrapper {
 			case "customMessage:done":
 				request.resolve( payload );
 				break;
+			case "analyzeRelatedKeywords:done":
 			case "analyze:done":
 				// Map the results back to classes, because we encode and decode the message payload.
 				if ( payload.seo ) {
@@ -185,6 +186,18 @@ class AnalysisWorkerWrapper {
 	 */
 	initialize( configuration ) {
 		return this.sendRequest( "initialize", configuration );
+	}
+
+	/**
+	 * Analyzes the paper.
+	 *
+	 * @param {Object} paper           The paper to analyze.
+	 * @param {Object} relatedKeywords The related keywords.
+	 *
+	 * @returns {Promise} The promise of analyses.
+	 */
+	analyzeRelatedKeywords( paper, relatedKeywords = {} ) {
+		return this.sendRequest( "analyzeRelatedKeywords", { paper, relatedKeywords } );
 	}
 
 	/**

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -1,3 +1,6 @@
+// External dependencies.
+const forEach = require( "lodash/forEach" );
+
 // Internal dependencies.
 import Request from "./request";
 const AssessmentResult = require( "../values/AssessmentResult" );
@@ -70,7 +73,9 @@ class AnalysisWorkerWrapper {
 
 				// Map the results back to classes, because we encode and decode the message payload.
 				if ( payload.seo ) {
-					payload.seo.results = payload.seo.results.map( result => AssessmentResult.parse( result ) );
+					forEach( payload.seo, ( { results }, key ) => {
+						payload.seo[ key ].results = results.map( result => AssessmentResult.parse( result ) );
+					} );
 				}
 				if ( payload.readability ) {
 					payload.readability.results = payload.readability.results.map( result => AssessmentResult.parse( result ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Implements related keywords in the web worker.
* The SEO results object now contains results per key. Where the key is an empty string for the main keyword or an `id` (a, b, c, d) for related keywords.
* Refactored the caching in the webworker, also to accommodate the related keywords.

## Test instructions

This PR can be tested by following these steps:

* Check if the web worker still functions like before.
* Use in combination with the premium branch and check if other keywords are matched with the correct results.

Fixes #1703 
