### PR TITLE
Run research in worker

### DIFF
--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -200,6 +200,14 @@ export default class AnalysisWebWorker {
 					data: payload,
 				} );
 				break;
+			case "runResearch":
+				// this._scheduler.schedule( {
+				// 	id,
+				// 	execute: this.loadScript,
+				// 	done: this.loadScriptDone,
+				// 	data: payload,
+				// } );
+				// break;
 			case "customMessage": {
 				const name = payload.name;
 				if ( name && this._registeredMessageHandlers[ name ] ) {

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -132,6 +132,8 @@ export default class AnalysisWebWorker {
 		this.customMessage = this.customMessage.bind( this );
 		this.customMessageDone = this.customMessageDone.bind( this );
 		this.clearCache = this.clearCache.bind( this );
+		this.runResearch = this.runResearch.bind( this );
+		this.runResearchDone = this.runResearchDone.bind( this );
 
 		// Bind register functions to this scope.
 		this.registerAssessment = this.registerAssessment.bind( this );
@@ -201,13 +203,13 @@ export default class AnalysisWebWorker {
 				} );
 				break;
 			case "runResearch":
-				// this._scheduler.schedule( {
-				// 	id,
-				// 	execute: this.loadScript,
-				// 	done: this.loadScriptDone,
-				// 	data: payload,
-				// } );
-				// break;
+				this._scheduler.schedule( {
+					id,
+					execute: this.runResearch,
+					done: this.runResearchDone,
+					data: payload,
+				} );
+				break;
 			case "customMessage": {
 				const name = payload.name;
 				if ( name && this._registeredMessageHandlers[ name ] ) {
@@ -697,5 +699,36 @@ export default class AnalysisWebWorker {
 			return;
 		}
 		this.send( "customMessage:failed", result.error );
+	}
+
+	/**
+	 * Runs the specified research in the worker. Optionally pass a paper.
+	 *
+	 * @param {number} id     The request id.
+	 * @param {string} name   The name of the research to run.
+	 * @param {Paper} [paper] The paper to run the research on if it shouldn't
+	 *                        be run on the latest paper.
+	 *
+	 * @returns {Promise} The promise of the research.
+	 */
+	runResearch( id, { name, paper = null } ) {
+		// When a specific paper is passed we create a temporary new researcher.
+		const researcher = paper === null
+			? this._researcher
+			: new Researcher( paper );
+
+		return researcher.getResearch( name );
+	}
+
+	/**
+	 * Send the result of a custom message back.
+	 *
+	 * @param {number} id     The request id.
+	 * @param {Object} result The result.
+	 *
+	 * @returns {void}
+	 */
+	runResearchDone( id, result ) {
+		this.send( "runResearch:done", id, result );
 	}
 }

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -236,6 +236,18 @@ class AnalysisWorkerWrapper {
 		name = pluginName + "-" + name;
 		return this.sendRequest( "customMessage", { name, data }, data );
 	}
+
+	/**
+	 * Runs the specified research in the worker. Optionally pass a paper.
+	 *
+	 * @param {string} name    The name of the research to run.
+	 * @param {Object} [paper] The paper to run the research on if it shouldn't be run on the latest paper.
+	 *
+	 * @returns {Promise} The promise of the research.
+	 */
+	runResearch( name, paper = null ) {
+		return this.sendRequest( "runResearch", { name, paper } );
+	}
 }
 
 export default AnalysisWorkerWrapper;

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -28,6 +28,7 @@ class AnalysisWorkerWrapper {
 		this.analyzeRelatedKeywords = this.analyzeRelatedKeywords.bind( this );
 		this.loadScript = this.loadScript.bind( this );
 		this.sendMessage = this.sendMessage.bind( this );
+		this.runResearch = this.runResearch.bind( this );
 
 		// Bind event handlers to this scope.
 		this.handleMessage = this.handleMessage.bind( this );
@@ -66,6 +67,7 @@ class AnalysisWorkerWrapper {
 			case "initialize:done":
 			case "loadScript:done":
 			case "customMessage:done":
+			case "runResearch:done":
 				request.resolve( payload );
 				break;
 			case "analyzeRelatedKeywords:done":
@@ -241,7 +243,8 @@ class AnalysisWorkerWrapper {
 	 * Runs the specified research in the worker. Optionally pass a paper.
 	 *
 	 * @param {string} name    The name of the research to run.
-	 * @param {Object} [paper] The paper to run the research on if it shouldn't be run on the latest paper.
+	 * @param {Object} [paper] The paper to run the research on if it shouldn't
+	 *                         be run on the latest paper.
 	 *
 	 * @returns {Promise} The promise of the research.
 	 */

--- a/src/worker/scheduler/Scheduler.js
+++ b/src/worker/scheduler/Scheduler.js
@@ -20,8 +20,8 @@ class Scheduler {
 	constructor( configuration = {} ) {
 		this._configuration = merge( DEFAULT_CONFIGURATION, configuration );
 		this._tasks = {
-			customMessage: [],
-			loadScript: [],
+			standard: [],
+			extensions: [],
 			analyze: [],
 			analyzeRelatedKeywords: [],
 		};
@@ -69,23 +69,18 @@ class Scheduler {
 	schedule( { id, execute, done, data, type } ) {
 		const task = new Task( id, execute, done, data, type );
 		switch( type ) {
-			case "customMessage": {
-				this._tasks.customMessage.push( task );
+			case "customMessage":
+			case "loadScript":
+				this._tasks.extensions.push( task );
 				break;
-			}
-			case "loadScript": {
-				this._tasks.loadScript.push( task );
+			case "analyze":
+				this._tasks.analyze = [ task ];
 				break;
-			}
-			case "analyzeRelatedKeywords": {
-				this._tasks.analyzeRelatedKeywords = [];
-				this._tasks.analyzeRelatedKeywords.push( task );
+			case "analyzeRelatedKeywords":
+				this._tasks.analyzeRelatedKeywords = [ task ];
 				break;
-			}
-			default: {
-				this._tasks.analyze = [];
-				this._tasks.analyze.push( task );
-			}
+			default:
+				this._tasks.standard.push( task );
 		}
 	}
 
@@ -95,12 +90,8 @@ class Scheduler {
 	 * @returns {Task|null} The next task or null if none are available.
 	 */
 	getNextTask() {
-		if ( this._tasks.loadScript.length > 0 ) {
-			return this._tasks.loadScript.shift();
-		}
-
-		if ( this._tasks.customMessage.length > 0 ) {
-			return this._tasks.customMessage.shift();
+		if ( this._tasks.extensions.length > 0 ) {
+			return this._tasks.extensions.shift();
 		}
 
 		if ( this._tasks.analyze.length > 0 ) {
@@ -109,6 +100,10 @@ class Scheduler {
 
 		if ( this._tasks.analyzeRelatedKeywords.length > 0 ) {
 			return this._tasks.analyzeRelatedKeywords.shift();
+		}
+
+		if ( this._tasks.standard.length > 0 ) {
+			return this._tasks.standard.shift();
 		}
 
 		return null;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Add `runResearch` action to the worker.
* Refactor scheduler tasks to have groups separate from the types: standard, extensions, analyze and analyzeRelatedKeywords.

## Test instructions

This PR can be tested by following these steps:

* See related PR.

Fixes #1721 
