### PR TITLE
Fixes issue with the parseClass with minified builds

### DIFF
--- a/src/values/AssessmentResult.js
+++ b/src/values/AssessmentResult.js
@@ -199,6 +199,7 @@ AssessmentResult.prototype.hasMarks = function() {
  */
 AssessmentResult.prototype.serialize = function() {
 	return {
+		_parseClass: "AssessmentResult",
 		identifier: this._identifier,
 		score: this.score,
 		text: this.text,

--- a/src/values/Mark.js
+++ b/src/values/Mark.js
@@ -51,6 +51,7 @@ Mark.prototype.applyWithReplace = function( text ) {
  */
 Mark.prototype.serialize = function() {
 	return {
+		_parseClass: "Mark",
 		...this._properties,
 	};
 };

--- a/src/values/Paper.js
+++ b/src/values/Paper.js
@@ -203,6 +203,7 @@ Paper.prototype.getPermalink = function() {
  */
 Paper.prototype.serialize = function() {
 	return {
+		_parseClass: "Paper",
 		text: this._text,
 		...this._attributes,
 	};

--- a/src/values/Participle.js
+++ b/src/values/Participle.js
@@ -143,6 +143,7 @@ Participle.prototype.setSentencePartPassiveness = function( passive ) {
  */
 Participle.prototype.serialize = function() {
 	return {
+		_parseClass: "Participle",
 		attributes: this._attributes,
 		participle: this._participle,
 		sentencePart: this._sentencePart,

--- a/src/values/Sentence.js
+++ b/src/values/Sentence.js
@@ -61,6 +61,7 @@ Sentence.prototype.setPassive = function( passive ) {
  */
 Sentence.prototype.serialize = function() {
 	return {
+		_parseClass: "Sentence",
 		sentenceText: this._sentenceText,
 		locale: this._locale,
 		isPassive: this._isPassive,

--- a/src/values/SentencePart.js
+++ b/src/values/SentencePart.js
@@ -67,6 +67,7 @@ SentencePart.prototype.setPassive = function( passive ) {
  */
 SentencePart.prototype.serialize = function() {
 	return {
+		_parseClass: "SentencePart",
 		sentencePartText: this._sentencePartText,
 		auxiliaries: this._auxiliaries,
 		locale: this._locale,

--- a/src/values/WordCombination.js
+++ b/src/values/WordCombination.js
@@ -182,6 +182,7 @@ WordCombination.prototype.getDensity = function( wordCount ) {
  */
 WordCombination.prototype.serialize = function() {
 	return {
+		_parseClass: "WordCombination",
 		words: this._words,
 		occurrences: this._occurrences,
 		functionWords: this._functionWords,

--- a/src/worker/transporter/serialize.js
+++ b/src/worker/transporter/serialize.js
@@ -17,10 +17,7 @@ export default function serialize( thing ) {
 	const thingIsObject = isObject( thing );
 
 	if ( thingIsObject && thing.serialize ) {
-		return {
-			...thing.serialize(),
-			_parseClass: thing.constructor.name,
-		};
+		return thing.serialize();
 	}
 
 	if ( thingIsObject ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* When minified we cannot use the constructor name.

## Test instructions

This PR can be tested by following these steps:

*