### PR TITLE
Change all usage of `lodash` to `lodash-es`.

### DIFF
--- a/examples/PerformanceAnalyses/run.js
+++ b/examples/PerformanceAnalyses/run.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const merge = require( "lodash/merge" );
+const merge = require( "lodash-es" ).merge;
 const analysis = require( "./analysis" );
 
 const texts = [

--- a/examples/browserified/example.js
+++ b/examples/browserified/example.js
@@ -3,8 +3,8 @@ var App = require( "../../js/app" );
 var PreviouslyUsedKeywords = require( "../../js/bundledPlugins/previouslyUsedKeywords.js" );
 var TestPlugin = require( "./example-plugin-test.js" );
 
-var forEach = require( "lodash/forEach" );
-var escape = require( "lodash/escape" );
+import { forEach } from "lodash-es";
+import { escape } from "lodash-es";
 
 /**
  * Set the locale.

--- a/examples/relevant-words-example/relevant-words-example.js
+++ b/examples/relevant-words-example/relevant-words-example.js
@@ -8,8 +8,8 @@ let WordCombination = require( "../../js/values/WordCombination" );
 let getWords = require( "../../js/stringProcessing/getWords" );
 let template = require( "../../js/templates.js" ).relevantWords;
 
-let map = require( "lodash/map" );
-let forEach = require( "lodash/forEach" );
+import { map } from "lodash-es";
+import { forEach } from "lodash-es";
 
 
 /**

--- a/examples/webpack/src/components/Button.js
+++ b/examples/webpack/src/components/Button.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import isFunction from "lodash/isFunction";
+import { isFunction } from "lodash-es";
 
 class Button extends React.PureComponent {
 	/**

--- a/examples/webpack/src/components/Input.js
+++ b/examples/webpack/src/components/Input.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import isFunction from "lodash/isFunction";
+import { isFunction } from "lodash-es";
 
 class Input extends React.PureComponent {
 	/**

--- a/examples/webpack/src/redux/utils/configureEnhancers.js
+++ b/examples/webpack/src/redux/utils/configureEnhancers.js
@@ -1,7 +1,7 @@
 // External dependencies.
 import { applyMiddleware } from "redux";
 import thunk from "redux-thunk";
-import flowRight from "lodash/flowRight";
+import { flowRight } from "lodash-es";
 
 /**
  * Configures the Redux store enhancers.

--- a/examples/wordRelevance/index.js
+++ b/examples/wordRelevance/index.js
@@ -24,8 +24,8 @@ var formatNumber = function ( number ) {
 };
 var getWords = require( "../../js/stringProcessing/getWords" );
 
-var map = require( "lodash/map" );
-var forEach = require( "lodash/forEach" );
+import { map } from "lodash-es";
+import { forEach } from "lodash-es";
 
 var fs = require( "fs" );
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "htmlparser2": "^3.9.2",
     "jed": "^1.1.0",
     "jest": "^23.0.0",
-    "lodash": "^4.14.1",
     "node-sass": "^4.7.2",
     "sassdash": "0.9.0",
     "tokenizer2": "^2.0.0"
@@ -87,6 +86,9 @@
       "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",
       "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
+    "transformIgnorePatterns": [
+      "<rootDir>/node_modules/(?!lodash-es/.*)"
+    ],
     "testRegex": "/spec/.*\\.(ts|tsx|js)$",
     "testEnvironment": "jsdom",
     "moduleDirectories": [

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "htmlparser2": "^3.9.2",
     "jed": "^1.1.0",
+    "lodash-es": "^4.17.10",
     "sassdash": "0.9.0",
     "tokenizer2": "^2.0.1"
   },

--- a/spec/contentAssessorSpec.js
+++ b/spec/contentAssessorSpec.js
@@ -3,7 +3,7 @@ var AssessmentResult = require( "../js/values/AssessmentResult.js" );
 var Factory = require( "./helpers/factory.js" );
 var Paper = require( "../js/values/Paper.js" );
 
-var forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 var i18n = Factory.buildJed();
 

--- a/spec/cornerstone/contentAssessorSpec.js
+++ b/spec/cornerstone/contentAssessorSpec.js
@@ -2,7 +2,7 @@ let ContentAssessor = require( "../../js/cornerstone/contentAssessor.js" );
 let AssessmentResult = require( "../../js/values/AssessmentResult.js" );
 let Factory = require( "../helpers/factory.js" );
 let Paper = require( "../../js/values/Paper.js" );
-let forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 let i18n = Factory.buildJed();
 
 describe( "A content assessor", function() {

--- a/spec/stringProcessing/getSentencesSpec.js
+++ b/spec/stringProcessing/getSentencesSpec.js
@@ -1,6 +1,6 @@
 var getSentences = require( "../../js/stringProcessing/getSentences.js" );
 
-var forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 /**
  * Helper to test sentence detection.

--- a/spec/stringProcessing/syllables/countDutchSpec.js
+++ b/spec/stringProcessing/syllables/countDutchSpec.js
@@ -1,5 +1,5 @@
 let countSyllableFunction = require( "../../../js/stringProcessing/syllables/count.js" );
-let forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 /**
  * Helper to tests syllable count.

--- a/spec/stringProcessing/syllables/countFrenchSpec.js
+++ b/spec/stringProcessing/syllables/countFrenchSpec.js
@@ -1,5 +1,5 @@
 let countSyllableFunction = require( "../../../js/stringProcessing/syllables/count.js" );
-let forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 /**
  * Helper to test syllable count.

--- a/src/app.js
+++ b/src/app.js
@@ -2,18 +2,18 @@ require( "./config/config.js" );
 
 var SnippetPreview = require( "./snippetPreview.js" );
 
-var defaultsDeep = require( "lodash/defaultsDeep" );
-var isObject = require( "lodash/isObject" );
-var isString = require( "lodash/isString" );
+import { defaultsDeep } from "lodash-es";
+import { isObject } from "lodash-es";
+import { isString } from "lodash-es";
 var MissingArgument = require( "./errors/missingArgument" );
-var isUndefined = require( "lodash/isUndefined" );
-var isEmpty = require( "lodash/isEmpty" );
-var isFunction = require( "lodash/isFunction" );
-var isArray = require( "lodash/isArray" );
-var forEach = require( "lodash/forEach" );
-var debounce = require( "lodash/debounce" );
-var throttle = require( "lodash/throttle" );
-const merge = require( "lodash/merge" );
+import { isUndefined } from "lodash-es";
+import { isEmpty } from "lodash-es";
+import { isFunction } from "lodash-es";
+import { isArray } from "lodash-es";
+import { forEach } from "lodash-es";
+import { debounce } from "lodash-es";
+import { throttle } from "lodash-es";
+import { merge } from "lodash-es";
 
 var Jed = require( "jed" );
 

--- a/src/assessmentHelpers/checkForTooLongSentences.js
+++ b/src/assessmentHelpers/checkForTooLongSentences.js
@@ -1,4 +1,4 @@
-var filter = require( "lodash/filter" );
+import { filter } from "lodash-es";
 var isSentenceTooLong = require( "../helpers/isValueTooLong" );
 
 /**

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -1,6 +1,6 @@
 let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let Assessment = require( "../../assessment.js" );
-const inRange = require( "lodash/inRange" );
+import { inRange } from "lodash-es";
 
 const getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 

--- a/src/assessments/readability/paragraphTooLongAssessment.js
+++ b/src/assessments/readability/paragraphTooLongAssessment.js
@@ -5,8 +5,8 @@ var Mark = require( "../../values/Mark.js" );
 var marker = require( "../../markers/addMark.js" );
 var inRange = require( "../../helpers/inRange.js" ).inRangeEndInclusive;
 
-var filter = require( "lodash/filter" );
-var map = require( "lodash/map" );
+import { filter } from "lodash-es";
+import { map } from "lodash-es";
 
 // 150 is the recommendedValue for the maximum paragraph length.
 var recommendedValue = 150;

--- a/src/assessments/readability/passiveVoiceAssessment.js
+++ b/src/assessments/readability/passiveVoiceAssessment.js
@@ -6,7 +6,7 @@ const stripTags = require( "../../stringProcessing/stripHTMLTags" ).stripIncompl
 const Mark = require( "../../values/Mark.js" );
 const marker = require( "../../markers/addMark.js" );
 
-const map = require( "lodash/map" );
+import { map } from "lodash-es";
 
 const getLanguageAvailability = require( "../../helpers/getLanguageAvailability.js" );
 const availableLanguages = [ "en", "de", "fr", "es", "ru", "it", "nl", "pl" ];

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -1,11 +1,11 @@
 let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let stripTags = require( "../../stringProcessing/stripHTMLTags" ).stripIncompleteTags;
 
-let partition = require( "lodash/partition" );
-let sortBy = require( "lodash/sortBy" );
-let map = require( "lodash/map" );
-let filter = require( "lodash/filter" );
-let flatten = require( "lodash/flatten" );
+import { partition } from "lodash-es";
+import { sortBy } from "lodash-es";
+import { map } from "lodash-es";
+import { filter } from "lodash-es";
+import { flatten } from "lodash-es";
 
 let Mark = require( "../../values/Mark.js" );
 let marker = require( "../../markers/addMark.js" );

--- a/src/assessments/readability/sentenceLengthInTextAssessment.js
+++ b/src/assessments/readability/sentenceLengthInTextAssessment.js
@@ -8,8 +8,8 @@ let stripTags = require( "../../stringProcessing/stripHTMLTags" ).stripIncomplet
 let Mark = require( "../../values/Mark.js" );
 let addMark = require( "../../markers/addMark.js" );
 
-let map = require( "lodash/map" );
-let merge = require( "lodash/merge" );
+import { map } from "lodash-es";
+import { merge } from "lodash-es";
 
 /**
  * Represents the assessment that will calculate the length of sentences in the text.

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -3,9 +3,9 @@ const Assessment = require( "../../assessment.js" );
 const isTextTooLong = require( "../../helpers/isValueTooLong" );
 const getSubheadings = require( "../../stringProcessing/getSubheadings.js" ).getSubheadings;
 const getWords = require( "../../stringProcessing/getWords.js" );
-const filter = require( "lodash/filter" );
-const map = require( "lodash/map" );
-const merge = require( "lodash/merge" );
+import { filter } from "lodash-es";
+import { map } from "lodash-es";
+import { merge } from "lodash-es";
 
 const Mark = require( "../../values/Mark.js" );
 const marker = require( "../../markers/addMark.js" );

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -1,6 +1,6 @@
 let AssessmentResult = require( "../../values/AssessmentResult.js" );
 let formatNumber = require( "../../helpers/formatNumber.js" );
-let map = require( "lodash/map" );
+import { map } from "lodash-es";
 let inRange = require( "../../helpers/inRange.js" ).inRangeStartInclusive;
 let stripTags = require( "../../stringProcessing/stripHTMLTags" ).stripIncompleteTags;
 

--- a/src/assessments/readability/wordComplexityAssessment.js
+++ b/src/assessments/readability/wordComplexityAssessment.js
@@ -4,11 +4,11 @@ var formatNumber = require( "../../helpers/formatNumber.js" );
 var Mark = require( "../../values/Mark.js" );
 var addMark = require( "../../markers/addMark.js" );
 
-var filter = require( "lodash/filter" );
-var flatMap = require( "lodash/flatMap" );
-var zip = require( "lodash/zip" );
-var forEach = require( "lodash/forEach" );
-var flatten = require( "lodash/flatten" );
+import { filter } from "lodash-es";
+import { flatMap } from "lodash-es";
+import { zip } from "lodash-es";
+import { forEach } from "lodash-es";
+import { flatten } from "lodash-es";
 
 // The maximum recommended value is 3 syllables. With more than 3 syllables a word is considered complex.
 var recommendedValue = 3;

--- a/src/assessments/seo/InternalLinksAssessment.js
+++ b/src/assessments/seo/InternalLinksAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/IntroductionKeywordAssessment.js
+++ b/src/assessments/seo/IntroductionKeywordAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -1,5 +1,5 @@
-const isUndefined = require( "lodash/isUndefined" );
-const merge = require( "lodash/merge" );
+import { isUndefined } from "lodash-es";
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/LargestKeywordDistanceAssessment.js
+++ b/src/assessments/seo/LargestKeywordDistanceAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/TextCompetingLinksAssessment.js
+++ b/src/assessments/seo/TextCompetingLinksAssessment.js
@@ -1,6 +1,6 @@
-const map = require( "lodash/map" );
-const merge = require( "lodash/merge" );
-const isUndefined = require( "lodash/isUndefined" );
+import { map } from "lodash-es";
+import { merge } from "lodash-es";
+import { isUndefined } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/TitleKeywordAssessment.js
+++ b/src/assessments/seo/TitleKeywordAssessment.js
@@ -1,5 +1,5 @@
-const merge = require( "lodash/merge" );
-const escape = require( "lodash/escape" );
+import { merge } from "lodash-es";
+import { escape } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/UrlKeywordAssessment.js
+++ b/src/assessments/seo/UrlKeywordAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const Assessment = require( "../../assessment" );
 const AssessmentResult = require( "../../values/AssessmentResult" );

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -1,5 +1,5 @@
-const isEmpty = require( "lodash/isEmpty" );
-const merge = require( "lodash/merge" );
+import { isEmpty } from "lodash-es";
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessments/seo/taxonomyTextLengthAssessment.js
+++ b/src/assessments/seo/taxonomyTextLengthAssessment.js
@@ -1,5 +1,5 @@
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
-const inRange = require( "lodash/inRange" );
+import { inRange } from "lodash-es";
 
 const recommendedMinimum = 150;
 /**

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -1,5 +1,5 @@
-const inRange = require( "lodash/inRange" );
-const merge = require( "lodash/merge" );
+import { inRange } from "lodash-es";
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessments/seo/urlLengthAssessment.js
+++ b/src/assessments/seo/urlLengthAssessment.js
@@ -1,4 +1,4 @@
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult.js" );
 const Assessment = require( "../../assessment.js" );

--- a/src/assessor.js
+++ b/src/assessor.js
@@ -4,13 +4,13 @@ var removeDuplicateMarks = require( "./markers/removeDuplicateMarks" );
 var AssessmentResult = require( "./values/AssessmentResult.js" );
 var showTrace = require( "./helpers/errors.js" ).showTrace;
 
-var isUndefined = require( "lodash/isUndefined" );
-var isFunction = require( "lodash/isFunction" );
-var forEach = require( "lodash/forEach" );
-var filter = require( "lodash/filter" );
-var map = require( "lodash/map" );
-var findIndex = require( "lodash/findIndex" );
-var find = require( "lodash/find" );
+import { isUndefined } from "lodash-es";
+import { isFunction } from "lodash-es";
+import { forEach } from "lodash-es";
+import { filter } from "lodash-es";
+import { map } from "lodash-es";
+import { findIndex } from "lodash-es";
+import { find } from "lodash-es";
 
 var ScoreRating = 9;
 

--- a/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/src/bundledPlugins/previouslyUsedKeywords.js
@@ -1,5 +1,5 @@
 var AssessmentResult = require( "../values/AssessmentResult.js" );
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 var MissingArgument = require( "../errors/missingArgument" );
 /**

--- a/src/config/content/combinedConfig.js
+++ b/src/config/content/combinedConfig.js
@@ -1,4 +1,4 @@
-let defaultsDeep = require( "lodash/defaultsDeep" );
+import { defaultsDeep } from "lodash-es";
 let getLanguage = require( "./../../helpers/getLanguage" );
 let defaultConfig = require( "./default" );
 let it = require( "./it" );

--- a/src/config/syllables.js
+++ b/src/config/syllables.js
@@ -1,7 +1,7 @@
 /** @module config/syllables */
 
 let getLanguage = require( "../helpers/getLanguage.js" );
-let isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 let de = require( "./syllables/de.json" );
 let en = require( './syllables/en.json' );

--- a/src/config/transliterations.js
+++ b/src/config/transliterations.js
@@ -1,5 +1,5 @@
 var getLanguage = require( "../helpers/getLanguage.js" );
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 
 var transliterations = {

--- a/src/config/transliterationsWPstyle.js
+++ b/src/config/transliterationsWPstyle.js
@@ -3,7 +3,7 @@
  */
 
 const getLanguage = require( "../helpers/getLanguage.js" );
-const isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 
 const transliterationsGeneral =	[

--- a/src/contentAssessor.js
+++ b/src/contentAssessor.js
@@ -20,8 +20,8 @@ let contentConfiguration = require( "./config/content/combinedConfig.js" );
 
 let scoreToRating = require( "./interpreters/scoreToRating" );
 
-let map = require( "lodash/map" );
-let sum = require( "lodash/sum" );
+import { map } from "lodash-es";
+import { sum } from "lodash-es";
 
 /**
  * Creates the Assessor

--- a/src/helpers/domManipulation.js
+++ b/src/helpers/domManipulation.js
@@ -1,4 +1,4 @@
-var forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 /**
  * Adds a class to an element

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -1,4 +1,4 @@
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 /**
  * Shows and error trace of the error message in the console if the console is available.

--- a/src/helpers/getLanguageAvailability.js
+++ b/src/helpers/getLanguageAvailability.js
@@ -1,4 +1,4 @@
-var indexOf = require( "lodash/indexOf" );
+import { indexOf } from "lodash-es";
 
 var getLanguage = require( "./getLanguage.js" );
 

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -23,8 +23,8 @@ var greaterThanContentRegex = /^<[^><]*$/;
 var commentRegex = /<!--(.|[\r\n])*?-->/g;
 
 var core = require( "tokenizer2/core" );
-var forEach = require( "lodash/forEach" );
-var memoize = require( "lodash/memoize" );
+import { forEach } from "lodash-es";
+import { memoize } from "lodash-es";
 
 var tokens = [];
 var htmlBlockTokenizer;

--- a/src/helpers/syllableCountIterator.js
+++ b/src/helpers/syllableCountIterator.js
@@ -1,7 +1,7 @@
 var SyllableCountStep = require( "./syllableCountStep.js" );
 
-var isUndefined = require( "lodash/isUndefined" );
-var forEach = require( "lodash/forEach" );
+import { isUndefined } from "lodash-es";
+import { forEach } from "lodash-es";
 
 /**
  * Creates a syllable count iterator.

--- a/src/helpers/syllableCountStep.js
+++ b/src/helpers/syllableCountStep.js
@@ -1,4 +1,4 @@
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 var arrayToRegex = require( "../stringProcessing/createRegexFromArray.js" );
 

--- a/src/markers/removeDuplicateMarks.js
+++ b/src/markers/removeDuplicateMarks.js
@@ -1,4 +1,4 @@
-var uniqBy = require( "lodash/uniqBy" );
+import { uniqBy } from "lodash-es";
 
 /**
  * Removes duplicate marks from an array

--- a/src/pluggable.js
+++ b/src/pluggable.js
@@ -1,8 +1,8 @@
-var isUndefined = require( "lodash/isUndefined" );
-var forEach = require( "lodash/forEach" );
-var reduce = require( "lodash/reduce" );
-var isString = require( "lodash/isString" );
-var isObject = require( "lodash/isObject" );
+import { isUndefined } from "lodash-es";
+import { forEach } from "lodash-es";
+import { reduce } from "lodash-es";
+import { isString } from "lodash-es";
+import { isObject } from "lodash-es";
 var InvalidTypeError = require( "./errors/invalidType" );
 
 /**

--- a/src/renderers/AssessorPresenter.js
+++ b/src/renderers/AssessorPresenter.js
@@ -1,8 +1,8 @@
-var forEach = require( "lodash/forEach" );
-var isNumber = require( "lodash/isNumber" );
-var isObject = require( "lodash/isObject" );
-var isUndefined = require( "lodash/isUndefined" );
-var difference = require( "lodash/difference" );
+import { forEach } from "lodash-es";
+import { isNumber } from "lodash-es";
+import { isObject } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { difference } from "lodash-es";
 var template = require( "../templates.js" ).assessmentPresenterResult;
 var scoreToRating = require( "../interpreters/scoreToRating.js" );
 var createConfig = require( "../config/presenter.js" );

--- a/src/researcher.js
+++ b/src/researcher.js
@@ -1,10 +1,10 @@
 import sentences from "./researches/sentences";
 
-var merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 var InvalidTypeError = require( "./errors/invalidType" );
 var MissingArgument = require( "./errors/missingArgument" );
-var isUndefined = require( "lodash/isUndefined" );
-var isEmpty = require( "lodash/isEmpty" );
+import { isUndefined } from "lodash-es";
+import { isEmpty } from "lodash-es";
 
 // Researches
 var wordCountInText = require( "./researches/wordCountInText.js" );

--- a/src/researches/dutch/passiveVoice/DutchParticiple.js
+++ b/src/researches/dutch/passiveVoice/DutchParticiple.js
@@ -1,4 +1,4 @@
-const includes = require( "lodash/includes" );
+import { includes } from "lodash-es";
 
 const Participle = require( "../../../values/Participle.js" );
 const checkException = require( "../../passiveVoice/periphrastic/checkException.js" );

--- a/src/researches/english/passiveVoice/EnglishParticiple.js
+++ b/src/researches/english/passiveVoice/EnglishParticiple.js
@@ -5,9 +5,9 @@ var nonVerbsEndingEd = require( "./non-verb-ending-ed.js" )();
 var directPrecedenceException = require( "../../../stringProcessing/directPrecedenceException" );
 var precedenceException = require( "../../../stringProcessing/precedenceException" );
 
-var includes = require( "lodash/includes" );
-var isEmpty = require( "lodash/isEmpty" );
-var intersection = require( "lodash/intersection" );
+import { includes } from "lodash-es";
+import { isEmpty } from "lodash-es";
+import { intersection } from "lodash-es";
 
 var irregularExclusionArray = [ "get", "gets", "getting", "got", "gotten" ];
 

--- a/src/researches/findKeywordInFirstParagraph.js
+++ b/src/researches/findKeywordInFirstParagraph.js
@@ -3,9 +3,9 @@
 const matchParagraphs = require( "../stringProcessing/matchParagraphs.js" );
 const wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
 
-const escapeRegExp = require( "lodash/escapeRegExp" );
-const reject = require( "lodash/reject" );
-const isEmpty = require( "lodash/isEmpty" );
+import { escapeRegExp } from "lodash-es";
+import { reject } from "lodash-es";
+import { isEmpty } from "lodash-es";
 
 /**
  * Counts the occurrences of the keyword in the first paragraph, returns 0 if it is not found,

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -3,7 +3,7 @@
 const wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
 const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 
-const escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Counts the occurrences of the keyword in the pagetitle. Returns the number of matches

--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -4,9 +4,9 @@ var normalizeSingleQuotes = require( "../stringProcessing/quotes.js" ).normalize
 var getTransitionWords = require( "../helpers/getTransitionWords.js" );
 var matchWordInSentence = require( "../stringProcessing/matchWordInSentence.js" ).isWordInSentence;
 
-var forEach = require( "lodash/forEach" );
-var filter = require( "lodash/filter" );
-var memoize = require( "lodash/memoize" );
+import { forEach } from "lodash-es";
+import { filter } from "lodash-es";
+import { memoize } from "lodash-es";
 
 var createRegexFromDoubleArrayCached = memoize( createRegexFromDoubleArray );
 /**

--- a/src/researches/french/passiveVoice/FrenchParticiple.js
+++ b/src/researches/french/passiveVoice/FrenchParticiple.js
@@ -8,9 +8,9 @@ var exceptionsParticiplesNounsVowel = require( "./exceptionsParticiples.js" )().
 var exceptionsParticiplesNounsConsonant = require( "./exceptionsParticiples.js" )().nounsStartingWithConsonant;
 var exceptionsParticiplesOthers = require( "./exceptionsParticiples.js" )().others;
 
-var includes = require( "lodash/includes" );
-var forEach = require( "lodash/forEach" );
-var memoize = require( "lodash/memoize" );
+import { includes } from "lodash-es";
+import { forEach } from "lodash-es";
+import { memoize } from "lodash-es";
 
 /**
  * Creates an Participle object for the French language.

--- a/src/researches/german/passiveVoice/GermanParticiple.js
+++ b/src/researches/german/passiveVoice/GermanParticiple.js
@@ -8,8 +8,8 @@ var auxiliaries = require( "./auxiliaries.js" )().participleLike;
 var exceptionsRegex =
 	/\S+(apparat|arbeit|dienst|haft|halt|keit|kraft|not|pflicht|schaft|schrift|tät|wert|zeit)($|[ \n\r\t.,'()"+-;!?:/»«‹›<>])/ig;
 
-var includes = require( "lodash/includes" );
-var map = require( "lodash/map" );
+import { includes } from "lodash-es";
+import { map } from "lodash-es";
 
 /**
  * Creates an Participle object for the German language.

--- a/src/researches/german/passiveVoice/getParticiples.js
+++ b/src/researches/german/passiveVoice/getParticiples.js
@@ -9,8 +9,8 @@ var irregularParticiples = require( "./irregulars.js" )();
 
 var GermanParticiple = require( "./GermanParticiple.js" );
 
-var forEach = require( "lodash/forEach" );
-var includes = require( "lodash/includes" );
+import { forEach } from "lodash-es";
+import { includes } from "lodash-es";
 
 /**
  * Creates GermanParticiple Objects for the participles found in a sentence.

--- a/src/researches/getLinkStatistics.js
+++ b/src/researches/getLinkStatistics.js
@@ -6,7 +6,7 @@ var getLinkType = require( "../stringProcessing/getLinkType.js" );
 var checkNofollow = require( "../stringProcessing/checkNofollow.js" );
 var urlHelper = require( "../stringProcessing/url.js" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Checks whether or not an anchor contains the passed keyword.

--- a/src/researches/getLinks.js
+++ b/src/researches/getLinks.js
@@ -2,7 +2,7 @@
 
 let getAnchors = require( "../stringProcessing/getAnchorsFromText.js" );
 
-let map = require( "lodash/map" );
+import { map } from "lodash-es";
 let url = require( "../stringProcessing/url.js" );
 
 /**

--- a/src/researches/getParagraphLength.js
+++ b/src/researches/getParagraphLength.js
@@ -1,6 +1,6 @@
 var countWords = require( "../stringProcessing/countWords.js" );
 var matchParagraphs = require( "../stringProcessing/matchParagraphs.js" );
-var filter = require( "lodash/filter" );
+import { filter } from "lodash-es";
 
 /**
  * Gets all paragraphs and their word counts from the text.

--- a/src/researches/getPassiveVoice.js
+++ b/src/researches/getPassiveVoice.js
@@ -3,7 +3,7 @@ const stripHTMLTags = require( "../stringProcessing/stripHTMLTags.js" ).stripFul
 const getLanguage = require( "../helpers/getLanguage.js" );
 const Sentence = require( "../values/Sentence.js" );
 
-const forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 const isPassiveSentencePart = require( "./passiveVoice/periphrastic/determinePassiveSentencePart.js" );
 const isPassiveSentence = require( "./passiveVoice/morphological/determinePassiveSentence.js" );

--- a/src/researches/getSentenceBeginnings.js
+++ b/src/researches/getSentenceBeginnings.js
@@ -3,9 +3,9 @@ let stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 let stripTags = require( "../stringProcessing/stripHTMLTags.js" ).stripFullTags;
 let getFirstWordExceptions = require( "../helpers/getFirstWordExceptions.js" );
 
-let isEmpty = require( "lodash/isEmpty" );
-let forEach = require( "lodash/forEach" );
-let filter = require( "lodash/filter" );
+import { isEmpty } from "lodash-es";
+import { forEach } from "lodash-es";
+import { filter } from "lodash-es";
 
 /**
  * Compares the first word of each sentence with the first word of the following sentence.

--- a/src/researches/getSubheadingTextLengths.js
+++ b/src/researches/getSubheadingTextLengths.js
@@ -1,6 +1,6 @@
 const getSubheadingTexts = require( "../stringProcessing/getSubheadingTexts" );
 const countWords = require( "../stringProcessing/countWords" );
-const forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 /**
  * Gets the subheadings from the text and returns the length of these subheading in an array.

--- a/src/researches/getWordComplexity.js
+++ b/src/researches/getWordComplexity.js
@@ -2,8 +2,8 @@ var getWords = require( "../stringProcessing/getWords.js" );
 var countSyllables = require( "../stringProcessing/syllables/count.js" );
 var getSentences = require( "../stringProcessing/getSentences.js" );
 
-var map = require( "lodash/map" );
-var forEach = require( "lodash/forEach" );
+import { map } from "lodash-es";
+import { forEach } from "lodash-es";
 
 /**
  * Gets the complexity per word, along with the index for the sentence.

--- a/src/researches/imageAltTags.js
+++ b/src/researches/imageAltTags.js
@@ -4,7 +4,7 @@ var imageInText = require( "../stringProcessing/imageInText" );
 var imageAlttag = require( "../stringProcessing/getAlttagContent" );
 var wordMatch = require( "../stringProcessing/matchTextWithWord" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Matches the alt-tags in the images found in the text.

--- a/src/researches/keywordCount.js
+++ b/src/researches/keywordCount.js
@@ -1,8 +1,8 @@
 /** @module analyses/getKeywordCount */
 
 const matchWords = require( "../stringProcessing/matchTextWithWord.js" );
-const unique = require( "lodash/uniq" );
-const escapeRegExp = require( "lodash/escapeRegExp" );
+import { uniq as unique } from "lodash-es";
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Calculates the keyword count.

--- a/src/researches/keywordCountInUrl.js
+++ b/src/researches/keywordCountInUrl.js
@@ -1,7 +1,7 @@
 /** @module researches/countKeywordInUrl */
 
 var wordMatch = require( "../stringProcessing/matchTextWithWord.js" );
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Matches the keyword in the URL. Replaces whitespaces with dashes and uses dash as wordboundary.

--- a/src/researches/largestKeywordDistance.js
+++ b/src/researches/largestKeywordDistance.js
@@ -1,4 +1,4 @@
-const sortBy = require( "lodash/sortBy" );
+import { sortBy } from "lodash-es";
 const topicCount = require( "./topicCount" );
 
 /**

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -4,7 +4,7 @@ var stripSomeTags = require( "../stringProcessing/stripNonTextTags.js" );
 var subheadingMatch = require( "../stringProcessing/subheadingsMatch.js" );
 var getSubheadingContents = require( "../stringProcessing/getSubheadings.js" ).getSubheadingContents;
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Checks if there are any subheadings like h2 in the text

--- a/src/researches/metaDescriptionKeyword.js
+++ b/src/researches/metaDescriptionKeyword.js
@@ -1,6 +1,6 @@
 var matchTextWithWord = require( "../stringProcessing/matchTextWithWord.js" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Matches the keyword in the description if a description and keyword are available.

--- a/src/researches/passiveVoice/morphological/determinePassiveSentence.js
+++ b/src/researches/passiveVoice/morphological/determinePassiveSentence.js
@@ -1,4 +1,4 @@
-const filter = require( "lodash/filter" );
+import { filter } from "lodash-es";
 const getWords = require( "../../../stringProcessing/getWords.js" );
 
 // Verb-form lists per language

--- a/src/researches/passiveVoice/periphrastic/checkException.js
+++ b/src/researches/passiveVoice/periphrastic/checkException.js
@@ -1,4 +1,4 @@
-const isEmpty = require( "lodash/isEmpty" );
+import { isEmpty } from "lodash-es";
 
 /**
  * Sets sentence part passiveness to passive if no exception rules for the participle apply.

--- a/src/researches/passiveVoice/periphrastic/determineSentencePartIsPassive.js
+++ b/src/researches/passiveVoice/periphrastic/determineSentencePartIsPassive.js
@@ -1,4 +1,4 @@
-const forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 /**
  * Checks if the participles make the sentence part passive.

--- a/src/researches/passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/nonDirectParticiplePrecedenceException.js
+++ b/src/researches/passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/nonDirectParticiplePrecedenceException.js
@@ -1,4 +1,4 @@
-const uniq = require( "lodash/uniq" );
+import { uniq } from "lodash-es";
 
 const arrayToRegex = require( "../../../../stringProcessing/createRegexFromArray.js" );
 const getWordIndices = require( "../getIndicesWithRegex.js" );

--- a/src/researches/passiveVoice/periphrastic/getParticiples.js
+++ b/src/researches/passiveVoice/periphrastic/getParticiples.js
@@ -1,4 +1,4 @@
-const forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 
 const getWords = require( "../../../stringProcessing/getWords.js" );
 const matchParticiples = require( "./matchParticiples" )();

--- a/src/researches/passiveVoice/periphrastic/getSentenceParts.js
+++ b/src/researches/passiveVoice/periphrastic/getSentenceParts.js
@@ -9,11 +9,11 @@ const getWordIndices = require( "./getIndicesWithRegex.js" );
 const includesIndex = require( "../../../stringProcessing/includesIndex" );
 const followsIndex = require( "../../../stringProcessing/followsIndex" );
 
-const filter = require( "lodash/filter" );
-const isUndefined = require( "lodash/isUndefined" );
-const includes = require( "lodash/includes" );
-const map = require( "lodash/map" );
-const forEach = require( "lodash/forEach" );
+import { filter } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { includes } from "lodash-es";
+import { map } from "lodash-es";
+import { forEach } from "lodash-es";
 
 // English-specific variables and imports.
 const SentencePartEnglish = require( "../../english/passiveVoice/SentencePart" );

--- a/src/researches/passiveVoice/periphrastic/getSentencePartsSplitOnStopwords.js
+++ b/src/researches/passiveVoice/periphrastic/getSentencePartsSplitOnStopwords.js
@@ -1,6 +1,6 @@
-const forEach = require( "lodash/forEach" );
-const isEmpty = require( "lodash/isEmpty" );
-const map = require( "lodash/map" );
+import { forEach } from "lodash-es";
+import { isEmpty } from "lodash-es";
+import { map } from "lodash-es";
 
 const arrayToRegex = require( "../../../stringProcessing/createRegexFromArray.js" );
 const stripSpaces = require( "../../../stringProcessing/stripSpaces.js" );

--- a/src/researches/passiveVoice/periphrastic/matchParticiples.js
+++ b/src/researches/passiveVoice/periphrastic/matchParticiples.js
@@ -1,8 +1,8 @@
-const find = require( "lodash/find" );
-const forEach = require( "lodash/forEach" );
-const memoize = require( "lodash/memoize" );
-const includes = require( "lodash/includes" );
-const flattenDeep = require( "lodash/flattenDeep" );
+import { find } from "lodash-es";
+import { forEach } from "lodash-es";
+import { memoize } from "lodash-es";
+import { includes } from "lodash-es";
+import { flattenDeep } from "lodash-es";
 
 const irregularsEnglish = require( "../../english/passiveVoice/irregulars" )();
 const irregularsRegularFrench = require( "../../french/passiveVoice/irregulars" )().irregularsRegular;

--- a/src/researches/stopWordsInKeyword.js
+++ b/src/researches/stopWordsInKeyword.js
@@ -2,7 +2,7 @@
 
 var stopWordsInText = require( "./stopWordsInText.js" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Checks for the amount of stop words in the keyword.

--- a/src/researches/topicCount.js
+++ b/src/researches/topicCount.js
@@ -2,8 +2,8 @@
 const matchTextWithArray = require( "../stringProcessing/matchTextWithArray.js" );
 const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 const parseSynonyms = require( "../stringProcessing/parseSynonyms" );
-const unique = require( "lodash/uniq" );
-const isEmpty = require( "lodash/isEmpty" );
+import { uniq as unique } from "lodash-es";
+import { isEmpty } from "lodash-es";
 const getSentences = require( "../stringProcessing/getSentences" );
 const arrayToRegex = require( "../stringProcessing/createRegexFromArray" );
 const addMark = require( "../markers/addMarkSingleWord" );

--- a/src/snippetPreview.js
+++ b/src/snippetPreview.js
@@ -1,10 +1,10 @@
-var isEmpty = require( "lodash/isEmpty" );
-var isElement = require( "lodash/isElement" );
-var isUndefined = require( "lodash/isUndefined" );
-var clone = require( "lodash/clone" );
-var defaultsDeep = require( "lodash/defaultsDeep" );
-var forEach = require( "lodash/forEach" );
-var debounce = require( "lodash/debounce" );
+import { isEmpty } from "lodash-es";
+import { isElement } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { clone } from "lodash-es";
+import { defaultsDeep } from "lodash-es";
+import { forEach } from "lodash-es";
+import { debounce } from "lodash-es";
 
 var createWordRegex = require( "./stringProcessing/createWordRegex.js" );
 var stripHTMLTags = require( "./stringProcessing/stripHTMLTags.js" ).stripFullTags;

--- a/src/snippetPreviewToggler.js
+++ b/src/snippetPreviewToggler.js
@@ -1,4 +1,4 @@
-var forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 var domManipulation = require( "./helpers/domManipulation.js" );
 
 var previewModes = {

--- a/src/stringProcessing/countWordOccurrences.js
+++ b/src/stringProcessing/countWordOccurrences.js
@@ -1,4 +1,4 @@
-var filter = require( "lodash/filter" );
+import { filter } from "lodash-es";
 
 var transliterate = require( "./transliterate.js" );
 var getWords = require( "./getWords.js" );

--- a/src/stringProcessing/createRegexFromArray.js
+++ b/src/stringProcessing/createRegexFromArray.js
@@ -1,7 +1,7 @@
 /** @module stringProcessing/createRegexFromArray */
 
 var addWordBoundary = require( "../stringProcessing/addWordboundary.js" );
-var map = require( "lodash/map" );
+import { map } from "lodash-es";
 
 /**
  * Creates a regex of combined strings from the input array.

--- a/src/stringProcessing/createWordRegex.js
+++ b/src/stringProcessing/createWordRegex.js
@@ -1,12 +1,10 @@
-/** @module stringProcessing/stringToRegex */
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 var replaceDiacritics = require( "../stringProcessing/replaceDiacritics.js" );
 var addWordBoundary = require( "../stringProcessing/addWordboundary.js" );
 var sanitizeString = require( "../stringProcessing/sanitizeString" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
-
-var memoize = require( "lodash/memoize" );
+import { escapeRegExp } from "lodash-es";
+import { memoize } from "lodash-es";
 
 /**
  * Creates a regex from a string so it can be matched everywhere in the same way.

--- a/src/stringProcessing/createWordRegex.js
+++ b/src/stringProcessing/createWordRegex.js
@@ -1,3 +1,4 @@
+/** @module stringProcessing/stringToRegex */
 import { isUndefined } from "lodash-es";
 var replaceDiacritics = require( "../stringProcessing/replaceDiacritics.js" );
 var addWordBoundary = require( "../stringProcessing/addWordboundary.js" );

--- a/src/stringProcessing/findKeywordInUrl.js
+++ b/src/stringProcessing/findKeywordInUrl.js
@@ -2,7 +2,7 @@
 
 var matchTextWithTransliteration = require( "./matchTextWithTransliteration.js" );
 
-var escapeRegExp = require( "lodash/escapeRegExp" );
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Matches the keyword in the URL.

--- a/src/stringProcessing/followsIndex.js
+++ b/src/stringProcessing/followsIndex.js
@@ -1,6 +1,6 @@
-var isEmpty = require( "lodash/isEmpty" );
-var forEach = require( "lodash/forEach" );
-var includes = require( "lodash/includes" );
+import { isEmpty } from "lodash-es";
+import { forEach } from "lodash-es";
+import { includes } from "lodash-es";
 
 /**
  * Checks whether a given word is followed by any word from a given list.

--- a/src/stringProcessing/getSentences.js
+++ b/src/stringProcessing/getSentences.js
@@ -1,12 +1,12 @@
-var map = require( "lodash/map" );
-var isUndefined = require( "lodash/isUndefined" );
-var forEach = require( "lodash/forEach" );
-var isNaN = require( "lodash/isNaN" );
-var filter = require( "lodash/filter" );
-var flatMap = require( "lodash/flatMap" );
-var isEmpty = require( "lodash/isEmpty" );
-var negate = require( "lodash/negate" );
-var memoize = require( "lodash/memoize" );
+import { map } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { forEach } from "lodash-es";
+import { isNaN } from "lodash-es";
+import { filter } from "lodash-es";
+import { flatMap } from "lodash-es";
+import { isEmpty } from "lodash-es";
+import { negate } from "lodash-es";
+import { memoize } from "lodash-es";
 
 var core = require( "tokenizer2/core" );
 

--- a/src/stringProcessing/getSubheadingTexts.js
+++ b/src/stringProcessing/getSubheadingTexts.js
@@ -1,4 +1,4 @@
-const isEmpty = require( "lodash/isEmpty.js" );
+import { isEmpty } from "lodash-es";
 /**
  * Returns all texts per subheading.
  * @param {string} text The text to analyze from.

--- a/src/stringProcessing/getSubheadings.js
+++ b/src/stringProcessing/getSubheadings.js
@@ -1,4 +1,4 @@
-var map = require( "lodash/map" );
+import { map } from "lodash-es";
 
 /**
  * Gets all subheadings from the text and returns these in an array.

--- a/src/stringProcessing/getWords.js
+++ b/src/stringProcessing/getWords.js
@@ -3,8 +3,8 @@
 var stripTags = require( "./stripHTMLTags.js" ).stripFullTags;
 var stripSpaces = require( "./stripSpaces.js" );
 var removePunctuation = require( "./removePunctuation.js" );
-var map = require( "lodash/map" );
-var filter = require( "lodash/filter" );
+import { map } from "lodash-es";
+import { filter } from "lodash-es";
 
 /**
  * Returns an array with words used in the text.

--- a/src/stringProcessing/htmlParser.js
+++ b/src/stringProcessing/htmlParser.js
@@ -2,7 +2,7 @@
 let htmlparser = require( "htmlparser2" );
 
 
-let includes = require( "lodash/includes" );
+import { includes } from "lodash-es";
 
 // The array containing the text parts without the blocks defined in inlineTags.
 let textArray;

--- a/src/stringProcessing/includesIndex.js
+++ b/src/stringProcessing/includesIndex.js
@@ -1,6 +1,6 @@
-var isEmpty = require( "lodash/isEmpty" );
-var forEach = require( "lodash/forEach" );
-var includes = require( "lodash/includes" );
+import { isEmpty } from "lodash-es";
+import { forEach } from "lodash-es";
+import { includes } from "lodash-es";
 
 /**
  * Checks whether a given word is directly preceded by a word from a list of words.

--- a/src/stringProcessing/indices.js
+++ b/src/stringProcessing/indices.js
@@ -1,5 +1,5 @@
-var isUndefined = require( "lodash/isUndefined" );
-var forEach = require( "lodash/forEach" );
+import { isUndefined } from "lodash-es";
+import { forEach } from "lodash-es";
 var stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 var matchWordInSentence = require( "../stringProcessing/matchWordInSentence.js" ).isWordInSentence;
 var characterInBoundary = require( "../stringProcessing/matchWordInSentence.js" ).characterInBoundary;

--- a/src/stringProcessing/matchParagraphs.js
+++ b/src/stringProcessing/matchParagraphs.js
@@ -1,6 +1,6 @@
-var map = require( "lodash/map" );
-var flatMap = require( "lodash/flatMap" );
-var filter = require( "lodash/filter" );
+import { map } from "lodash-es";
+import { flatMap } from "lodash-es";
+import { filter } from "lodash-es";
 
 var getBlocks = require( "../helpers/html" ).getBlocks;
 

--- a/src/stringProcessing/matchTextWithArray.js
+++ b/src/stringProcessing/matchTextWithArray.js
@@ -3,7 +3,7 @@
 const stripSpaces = require( "../stringProcessing/stripSpaces.js" );
 const removePunctuation = require( "../stringProcessing/removePunctuation.js" );
 const matchTextWithWord = require( "../stringProcessing/matchTextWithWord" );
-const unique = require( "lodash/uniq" );
+import { uniq as unique } from "lodash-es";
 /**
  * Matches strings from an array against a given text.
  *

--- a/src/stringProcessing/matchTextWithTransliteration.js
+++ b/src/stringProcessing/matchTextWithTransliteration.js
@@ -1,4 +1,4 @@
-var map = require( "lodash/map" );
+import { map } from "lodash-es";
 var addWordBoundary = require( "./addWordboundary.js" );
 var stripSpaces = require( "./stripSpaces.js" );
 var transliterate = require( "./transliterate.js" );

--- a/src/stringProcessing/matchTextWithWord.js
+++ b/src/stringProcessing/matchTextWithWord.js
@@ -6,7 +6,7 @@ const removePunctuation = require( "../stringProcessing/removePunctuation.js" );
 const unifyWhitespace = require( "../stringProcessing/unifyWhitespace.js" ).unifyAllSpaces;
 const matchStringWithTransliteration = require( "../stringProcessing/matchTextWithTransliteration.js" );
 const normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
-const map = require( "lodash/map" );
+import { map } from "lodash-es";
 
 /**
  * Returns the number of matches in a given string

--- a/src/stringProcessing/matchWordInSentence.js
+++ b/src/stringProcessing/matchWordInSentence.js
@@ -1,5 +1,5 @@
 var wordBoundaries = require( "../config/wordBoundaries.js" )();
-var includes = require( "lodash/includes" );
+import { includes } from "lodash-es";
 var addWordBoundary = require( "./addWordboundary.js" );
 
 /**

--- a/src/stringProcessing/precedesIndex.js
+++ b/src/stringProcessing/precedesIndex.js
@@ -1,5 +1,5 @@
-var isEmpty = require( "lodash/isEmpty" );
-var forEach = require( "lodash/forEach" );
+import { isEmpty } from "lodash-es";
+import { forEach } from "lodash-es";
 
 /**
  * Checks whether a given word precedes a participle directly or indirectly.

--- a/src/stringProcessing/relevantWords.js
+++ b/src/stringProcessing/relevantWords.js
@@ -5,16 +5,16 @@ let normalizeQuotes = require( "../stringProcessing/quotes.js" ).normalize;
 let functionWordLists = require( "../helpers/getFunctionWords.js" )();
 let getLanguage = require( "../helpers/getLanguage.js" );
 
-let filter = require( "lodash/filter" );
-let map = require( "lodash/map" );
-let forEach = require( "lodash/forEach" );
-let has = require( "lodash/has" );
-let flatMap = require( "lodash/flatMap" );
-let values = require( "lodash/values" );
-let take = require( "lodash/take" );
-let includes = require( "lodash/includes" );
-let intersection = require( "lodash/intersection" );
-let isEmpty = require( "lodash/isEmpty" );
+import { filter } from "lodash-es";
+import { map } from "lodash-es";
+import { forEach } from "lodash-es";
+import { has } from "lodash-es";
+import { flatMap } from "lodash-es";
+import { values } from "lodash-es";
+import { take } from "lodash-es";
+import { includes } from "lodash-es";
+import { intersection } from "lodash-es";
+import { isEmpty } from "lodash-es";
 
 let densityLowerLimit = 0;
 let densityUpperLimit = 0.03;

--- a/src/stringProcessing/sentencesLength.js
+++ b/src/stringProcessing/sentencesLength.js
@@ -1,5 +1,5 @@
 var wordCount = require( "./countWords.js" );
-var forEach = require( "lodash/forEach" );
+import { forEach } from "lodash-es";
 var stripHTMLTags = require( "./stripHTMLTags.js" ).stripFullTags;
 
 /**

--- a/src/stringProcessing/syllables/DeviationFragment.js
+++ b/src/stringProcessing/syllables/DeviationFragment.js
@@ -1,5 +1,5 @@
-var isUndefined = require( "lodash/isUndefined" );
-var pick = require( "lodash/pick" );
+import { isUndefined } from "lodash-es";
+import { pick } from "lodash-es";
 
 /**
  * Represents a partial deviation when counting syllables

--- a/src/stringProcessing/syllables/count.js
+++ b/src/stringProcessing/syllables/count.js
@@ -4,14 +4,14 @@ var syllableMatchers = require( "../../config/syllables.js" );
 
 var getWords = require( "../getWords.js" );
 
-var forEach = require( "lodash/forEach" );
-var filter = require( "lodash/filter" );
-var find = require( "lodash/find" );
-var isUndefined = require( "lodash/isUndefined" );
-var map = require( "lodash/map" );
-var sum = require( "lodash/sum" );
-var memoize = require( "lodash/memoize" );
-var flatMap = require( "lodash/flatMap" );
+import { forEach } from "lodash-es";
+import { filter } from "lodash-es";
+import { find } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { map } from "lodash-es";
+import { sum } from "lodash-es";
+import { memoize } from "lodash-es";
+import { flatMap } from "lodash-es";
 
 var SyllableCountIterator = require( "../../helpers/syllableCountIterator.js" );
 var DeviationFragment = require( "./DeviationFragment" );

--- a/src/values/AssessmentResult.js
+++ b/src/values/AssessmentResult.js
@@ -1,6 +1,6 @@
-const isArray = require( "lodash/isArray" );
-const isUndefined = require( "lodash/isUndefined" );
-const isNumber = require( "lodash/isNumber" );
+import { isArray } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { isNumber } from "lodash-es";
 
 const Mark = require( "./Mark" );
 

--- a/src/values/Mark.js
+++ b/src/values/Mark.js
@@ -1,4 +1,4 @@
-const defaults = require( "lodash/defaults" );
+import { defaults } from "lodash-es";
 
 /**
  * Represents a marked piece of text

--- a/src/values/Paper.js
+++ b/src/values/Paper.js
@@ -1,6 +1,6 @@
-var defaults = require( "lodash/defaults" );
-const isEmpty = require( "lodash/isEmpty" );
-const isEqual = require( "lodash/isEqual" );
+import { defaults } from "lodash-es";
+import { isEmpty } from "lodash-es";
+import { isEqual } from "lodash-es";
 
 /**
  * Default attributes to be used by the Paper if they are left undefined.

--- a/src/values/Participle.js
+++ b/src/values/Participle.js
@@ -1,8 +1,8 @@
 var getType = require( "./../helpers/types.js" ).getType;
 var isSameType = require( "./../helpers/types.js" ).isSameType;
 
-var defaults = require( "lodash/defaults" );
-var forEach = require( "lodash/forEach" );
+import { defaults } from "lodash-es";
+import { forEach } from "lodash-es";
 
 /**
  * Default attributes to be used by the Participle if they are left undefined.

--- a/src/values/WordCombination.js
+++ b/src/values/WordCombination.js
@@ -1,5 +1,5 @@
-var forEach = require( "lodash/forEach" );
-var has = require( "lodash/has" );
+import { forEach } from "lodash-es";
+import { has } from "lodash-es";
 
 /**
  * Returns whether or not the given word is a function word.

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -1,12 +1,12 @@
 // External dependencies.
 const Jed = require( "jed" );
-const forEach = require( "lodash/forEach" );
-const merge = require( "lodash/merge" );
-const pickBy = require( "lodash/pickBy" );
-const includes = require( "lodash/includes" );
-const isUndefined = require( "lodash/isUndefined" );
-const isString = require( "lodash/isString" );
-const isObject = require( "lodash/isObject" );
+import { forEach } from "lodash-es";
+import { merge } from "lodash-es";
+import { pickBy } from "lodash-es";
+import { includes } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { isString } from "lodash-es";
+import { isObject } from "lodash-es";
 
 // YoastSEO.js dependencies.
 import * as assessments from "../assessments";

--- a/src/worker/scheduler/Scheduler.js
+++ b/src/worker/scheduler/Scheduler.js
@@ -1,3 +1,4 @@
+// External dependencies.
 import { merge } from "lodash-es";
 
 // Internal dependencies.

--- a/src/worker/scheduler/Scheduler.js
+++ b/src/worker/scheduler/Scheduler.js
@@ -1,5 +1,4 @@
-// External dependencies.
-const merge = require( "lodash/merge" );
+import { merge } from "lodash-es";
 
 // Internal dependencies.
 import Task from "./Task";

--- a/src/worker/scheduler/Task.js
+++ b/src/worker/scheduler/Task.js
@@ -1,3 +1,4 @@
+// External dependencies.
 import { isFunction } from "lodash-es";
 import { isNumber } from "lodash-es";
 import { isObject } from "lodash-es";

--- a/src/worker/scheduler/Task.js
+++ b/src/worker/scheduler/Task.js
@@ -1,7 +1,6 @@
-// External dependencies.
-const isFunction = require( "lodash/isFunction" );
-const isNumber = require( "lodash/isNumber" );
-const isObject = require( "lodash/isObject" );
+import { isFunction } from "lodash-es";
+import { isNumber } from "lodash-es";
+import { isObject } from "lodash-es";
 
 class Task {
 	/**

--- a/src/worker/transporter/parse.js
+++ b/src/worker/transporter/parse.js
@@ -1,6 +1,6 @@
-const isArray = require( "lodash/isArray" );
-const isObject = require( "lodash/isObject" );
-const mapValues = require( "lodash/mapValues" );
+import { isArray } from "lodash-es";
+import { isObject } from "lodash-es";
+import { mapValues } from "lodash-es";
 
 const AssessmentResult = require( "../../values/AssessmentResult" );
 const Mark = require( "../../values/Mark" );

--- a/src/worker/transporter/serialize.js
+++ b/src/worker/transporter/serialize.js
@@ -1,6 +1,6 @@
-const isArray = require( "lodash/isArray" );
-const isObject = require( "lodash/isObject" );
-const mapValues = require( "lodash/mapValues" );
+import { isArray } from "lodash-es";
+import { isObject } from "lodash-es";
+import { mapValues } from "lodash-es";
 
 /**
  * Serializes a data structure to transfer it over a web worker message.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4155,6 +4155,10 @@ lodash-cli@^4.14.1:
     semver "5.3.0"
     uglify-js "2.7.5"
 
+lodash-es@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
+
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Change all usage of `lodash` to `lodash-es`.

## Relevant technical choices:

* This allows YoastSEO.js to be tree-shaken better.

## Test instructions

This PR can be tested by following these steps:

* Make sure all the tests still run
* Make sure the analysis works as expected.

Fixes #1736