### PR TITLE
Reformat SEOAssessorSpec to reflect assessor names

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "testPathIgnorePatterns": [
       "/spec/helpers/factory.js",
       "/spec/specHelpers/paperChanger.js",
+      "/spec/specHelpers/getAssesorResults.js",
       "/spec/fullTextTests/testTexts"
     ],
     "coveragePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "testPathIgnorePatterns": [
       "/spec/helpers/factory.js",
       "/spec/specHelpers/paperChanger.js",
-      "/spec/specHelpers/getAssesorResults.js",
+      "/spec/specHelpers/getAssessorResults.js",
       "/spec/fullTextTests/testTexts"
     ],
     "coveragePathIgnorePatterns": [

--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -1,5 +1,6 @@
 var Assessor = require( "../js/seoAssessor.js" );
 var Paper = require( "../js/values/Paper.js" );
+import getResults from "./specHelpers/getAssessorResults";
 
 var factory = require( "./helpers/factory.js" );
 var i18n = factory.buildJed();
@@ -9,33 +10,114 @@ var assessor = new Assessor( i18n );
 describe( "running assessments in the assessor", function() {
 	it( "runs assessments without any specific requirements", function() {
 		assessor.assess( new Paper( "" ) );
-		expect( assessor.getValidResults().length ).toBe( 4 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that only require a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that require text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
 		const text = "a ".repeat( 200 );
 		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );
-		expect( assessor.getValidResults().length ).toBe( 8 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
-	it( "additionally runs assessments that require an url", function() {
+	it( "additionally runs assessments that require a text and a url", function() {
 		assessor.assess( new Paper( "text", { url: "sample url" } ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", url: "sample url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"urlKeyword",
+		] );
 	} );
 
 	// These specifications will additionally trigger the largest keyword distance assessment.
@@ -53,7 +135,19 @@ describe( "running assessments in the assessor", function() {
 			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
 			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
 			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 8 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that require a long enough text and one keyword occurrence and one synonym occurrence", function() {
@@ -70,6 +164,18 @@ describe( "running assessments in the assessor", function() {
 			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
 			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas synonym." +
 			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword", synonyms: "synonym" } ) );
-		expect( assessor.getValidResults().length ).toBe( 8 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 } );

--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -37,7 +37,7 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that only require a keyword", function() {
+	it( "additionally runs assessments only require a text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -1,3 +1,4 @@
+import getResults from "../specHelpers/getAssessorResults";
 let Assessor = require( "../../js/cornerstone/seoAssessor.js" );
 let Paper = require( "../../js/values/Paper.js" );
 let factory = require( "../helpers/factory.js" );
@@ -7,33 +8,98 @@ let assessor = new Assessor( i18n );
 describe( "running assessments in the assessor", function() {
 	it( "runs assessments without any specific requirements", function() {
 		assessor.assess( new Paper( "" ) );
-		expect( assessor.getValidResults().length ).toBe( 4 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
-	it( "additionally runs assessments that only require a keyword", function() {
+	it( "additionally runs assessments that require a text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
 		const text = "a ".repeat( 200 );
 		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );
-		expect( assessor.getValidResults().length ).toBe( 8 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
-	it( "additionally runs assessments that require text and a keyword", function() {
-		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
-	} );
-
-	it( "additionally runs assessments that require an url", function() {
+	it( "additionally runs assessments that require a text and a url", function() {
 		assessor.assess( new Paper( "text", { url: "sample url" } ) );
-		expect( assessor.getValidResults().length ).toBe( 7 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", url: "sample url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"urlKeyword",
+		] );
 	} );
 
 	// These specifications will additionally trigger the largest keyword distance assessment.
@@ -51,7 +117,19 @@ describe( "running assessments in the assessor", function() {
 			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
 			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
 			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 8 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 
 	it( "additionally runs assessments that require a long enough text and one keyword occurrence and one synonym occurrence", function() {
@@ -68,6 +146,18 @@ describe( "running assessments in the assessor", function() {
 			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
 			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas synonym." +
 			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword", synonyms: "synonym" } ) );
-		expect( assessor.getValidResults().length ).toBe( 8 );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
 	} );
 } );

--- a/spec/specHelpers/getAssessorResults.js
+++ b/spec/specHelpers/getAssessorResults.js
@@ -1,0 +1,16 @@
+/**
+ * A function to make a list of assessments that were run from a results object.
+ *
+ * @param {Array} results An array of results of all assessments that were applicable.
+ *
+ * @returns {Array} An array with names of all assessments that appeared in the results.
+ */
+export default function( results ) {
+	let assessments = [];
+
+	for ( let result of results ) {
+		assessments.push( result._identifier );
+	}
+
+	return assessments;
+}

--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -3,16 +3,7 @@ const Paper = require( "../js/values/Paper.js" );
 const factory = require( "./helpers/factory.js" );
 const i18n = factory.buildJed();
 const assessor = new Assessor( i18n );
-
-const getResults = function( Results ) {
-	let assessments = [];
-
-	for ( let Result of Results ) {
-		assessments.push( Result._identifier );
-	}
-
-	return assessments;
-};
+import getResults from "./specHelpers/getAssessorResults";
 
 describe( "running assessments in the assessor", function() {
 	it( "runs assessments without any specific requirements", function() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Reformats the SEOAssessorSpec to actually show the names of assessments that were called instead of just checking the number of assessments that applied.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`

Fixes #1599 
