### PR TITLE
Expose more public API required in yoast-components

### DIFF
--- a/src/stringProcessing/index.js
+++ b/src/stringProcessing/index.js
@@ -5,6 +5,8 @@ const replaceDiacritics = require( "./replaceDiacritics" );
 const imageInText = require( "./imageInText" );
 const relevantWords = require( "./relevantWords" );
 const removeHtmlBlocks = require( "./htmlParser" );
+const createWordRegex = require( "./createWordRegex" );
+const wordBoundaries = require( "../config/wordBoundaries" );
 
 export {
 	stripHTMLTags,
@@ -14,4 +16,8 @@ export {
 	imageInText,
 	relevantWords,
 	removeHtmlBlocks,
+	wordBoundaries,
+
+	// We don't want to expose this, but yoast-components needs it.
+	createWordRegex as __createWordRegex,
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Exposes word boundaries for use in other libraries or applications.

## Relevant technical choices:

* We don't want to expose `createWordRegex` but yoast-components needs it.