### PR TITLE
Fix memoized of two part transitionwords regex

### DIFF
--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -6,9 +6,27 @@ var matchWordInSentence = require( "../stringProcessing/matchWordInSentence.js" 
 
 var forEach = require( "lodash/forEach" );
 var filter = require( "lodash/filter" );
-var memoize = require( "lodash/memoize" );
+var flattenDeep = require( "lodash/flattenDeep" );
 
-var createRegexFromDoubleArrayCached = memoize( createRegexFromDoubleArray );
+let regexFromDoubleArray = null;
+let regexFromDoubleArrayCacheKey = "";
+
+/**
+ * Memoizes the createRegexFromDoubleArray with the twoPartTransitionWords.
+ *
+ * @param {Array} twoPartTransitionWords The array containing two-part transition words.
+ *
+ * @returns {RegExp} The RegExp to match text with a double array.
+ */
+function getRegexFromDoubleArray( twoPartTransitionWords ) {
+	const cacheKey = flattenDeep( twoPartTransitionWords ).join( "" );
+	if ( regexFromDoubleArrayCacheKey !== cacheKey || regexFromDoubleArray === null ) {
+		regexFromDoubleArrayCacheKey = cacheKey;
+		regexFromDoubleArray = createRegexFromDoubleArray( twoPartTransitionWords );
+	}
+	return regexFromDoubleArray;
+}
+
 /**
  * Matches the sentence against two part transition words.
  *
@@ -18,7 +36,7 @@ var createRegexFromDoubleArrayCached = memoize( createRegexFromDoubleArray );
  */
 var matchTwoPartTransitionWords = function( sentence, twoPartTransitionWords ) {
 	sentence = normalizeSingleQuotes( sentence );
-	var twoPartTransitionWordsRegex = createRegexFromDoubleArrayCached( twoPartTransitionWords );
+	var twoPartTransitionWordsRegex = getRegexFromDoubleArray( twoPartTransitionWords );
 	return sentence.match( twoPartTransitionWordsRegex );
 };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the browser would crash because of a memory leak in the analysis.

## Relevant technical choices:

* Use the `twoPartTransitionsWords` as key for the cache instead of the array memory address that always changes.

## Test instructions

This PR can be tested by following these steps:

* Link to wordpress-seo 8.1.1 tag.
* Go to a post.
* Open the memory in your console and take note of the 2nd JavaScript VM instance (the worker) and how much memory it uses.
* Take a heap snapshot to save the current state.
* Give the post a lot of text and generally change things. Note the memory again.
* Take a heap snapshot and compare to the previous. There should now no longer be a huge discrepancy between the two snapshots where before it could rack up to 200mb or more.

Fixes https://github.com/Yoast/wordpress-seo/issues/10903