### PR TITLE
Fix config key

### DIFF
--- a/src/cornerstone/contentAssessor.js
+++ b/src/cornerstone/contentAssessor.js
@@ -36,13 +36,13 @@ let CornerStoneContentAssessor = function( i18n, options = {} ) {
 	this._assessments = [
 
 		new FleschReadingEase( contentConfiguration( locale ).fleschReading ),
-		new SubheadingDistributionTooLong(
-			{
+		new SubheadingDistributionTooLong( {
+			parameters:	{
 				slightlyTooMany: 250,
 				farTooMany: 300,
 				recommendedMaximumWordCount: 250,
-			}
-		),
+			},
+		} ),
 		paragraphTooLong,
 		new SentenceLengthInText(
 			{

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -452,7 +452,9 @@ export default class AnalysisWebWorker {
 		// Prefix the name with the pluginName so the test name is always unique.
 		const combinedName = pluginName + "-" + name;
 
-		this._seoAssessor.addAssessment( combinedName, assessment );
+		if ( this._seoAssessor !== null ) {
+			this._seoAssessor.addAssessment( combinedName, assessment );
+		}
 		this._registeredAssessments.push( { combinedName, assessment } );
 
 		this.refreshAssessment( name, pluginName );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the readability analysis would not show the correct scores for cornerstone content.

## Relevant technical choices:

* The worker initialize did not create a content assessor again.
* The subheadings distribution too long assessment did not pass the config along properly.
* Added safety check for the seo assessor within the register assessment.

## Test instructions

This PR can be tested by following these steps:

* Combine with release/8.2 branch.
* Check if the cornerstone affected scores update properly when switching cornerstone:
  - [Subheadings distribution too long](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-readability-analysis#1-subheading-presence--distribution-subheadingsdistributiontoolong)
  - [Sentence length in text](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-readability-analysis#3-sentence-length-sentencelengthintextassessment)
* Check the configuration possibilities:
  - Switch seo analysis on/off
  - Switch readability analysis on/off
* Go to a category page and check if the seo analysis functions properly.
* In Premium check whether the keyword distribution assessment appears.
* Change your language in WordPress and check if that affects the analyses messages.

Fixes #1786
