### PR TITLE
Rewritten index.js to use ES6 module import/export statements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,20 @@ export {
 	AnalysisWebWorker,
 	AnalysisWorkerWrapper,
 	createWorker,
+
+	assessments,
+	bundledPlugins,
+	config,
+	helpers,
+	markers,
+	string,
+	interpreters,
 };
 
+/**
+ * Used for backwards compatibility reasons.
+ * For new exports, please add it as a named dependency above instead.
+ **/
 export default {
 	assessments,
 	bundledPlugins,

--- a/index.js
+++ b/index.js
@@ -42,11 +42,26 @@ export {
 	interpreters,
 };
 
-/**
+/*
  * Used for backwards compatibility reasons.
  * For new exports, please add it as a named dependency above instead.
- **/
+ */
 export default {
+	App,
+	Assessor,
+	ContentAssessor,
+	TaxonomyAssessor,
+	Pluggable,
+	Researcher,
+	SnippetPreview,
+
+	Paper,
+	AssessmentResult,
+
+	AnalysisWebWorker,
+	AnalysisWorkerWrapper,
+	createWorker,
+
 	assessments,
 	bundledPlugins,
 	config,

--- a/index.js
+++ b/index.js
@@ -7,28 +7,39 @@ import * as string from "./src/stringProcessing";
 import * as interpreters from "./src/interpreters";
 import * as config from "./src/config";
 
-module.exports = {
-	Assessor: require( "./src/assessor" ),
-	SEOAssessor: require( "./src/seoAssessor" ),
-	ContentAssessor: require( "./src/contentAssessor" ),
-	TaxonomyAssessor: require( "./src/taxonomyAssessor" ),
-	App: require( "./src/app" ),
-	Pluggable: require( "./src/pluggable" ),
-	Researcher: require( "./src/researcher" ),
-	SnippetPreview: require( "./src/snippetPreview" ),
+import App from "./src/app";
+import Assessor from "./src/assessor";
+import ContentAssessor from "./src/contentAssessor";
+import TaxonomyAssessor from "./src/taxonomyAssessor";
+import Pluggable from "./src/pluggable";
+import Researcher from "./src/researcher";
+import SnippetPreview from "./src/snippetPreview";
+import Paper from "./src/values/Paper";
+import AssessmentResult from "./src/values/AssessmentResult";
 
-	Paper: require( "./src/values/Paper" ),
-	AssessmentResult: require( "./src/values/AssessmentResult" ),
+export {
+	App,
+	Assessor,
+	ContentAssessor,
+	TaxonomyAssessor,
+	Pluggable,
+	Researcher,
+	SnippetPreview,
+
+	Paper,
+	AssessmentResult,
 
 	AnalysisWebWorker,
 	AnalysisWorkerWrapper,
 	createWorker,
+};
 
+export default {
 	assessments,
 	bundledPlugins,
+	config,
 	helpers,
 	markers,
 	string,
 	interpreters,
-	config,
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* `index.js` has been rewritten to use ES6 Module import and export logic, instead of Node's `require` logic.

## Relevant technical choices:

* I defined the export statements as such to not break any existing import statements in the Wordpress SEO plugin. 
    * I did, however, need to rewrite a function import in `mapResults`, which was inconsistent with another import of the same function. I will make an issue and PR in the Wordpress SEO repo.

## Test instructions

This PR can be tested by following these steps:

**Note**: only for testing, until this is fixed in `wordpress-seo`:
In your local `wordpress-seo/src/components/contentAnalysis/mapResults.js`, change (at the top):
```js
import analysis from "yoastseo";
import { colors } from "yoast-components";
const { scoreToRating } = analysis.helpers;
```
to
```js
import { helpers } from "yoastseo";
import { colors } from "yoast-components";
const { scoreToRating } = helpers;
```

1. Make sure that your local clone of `wordpress-seo` is linked to your local clone of this repo.
2. Start your VVV.
3. Make sure that Yoast SEO is activated.
3. Make a new post or open an existing one.
4. Check if the content analysis tab is correctly loaded.

Fixes #1794 .
