### PR TITLE
Refactor subheadings keyword assessment

### DIFF
--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -1,5 +1,5 @@
 import SubheadingsKeywordAssessment from "../../src/assessments/seo/subheadingsKeywordAssessment";
-import Paper from "../../src/values/paper";
+import Paper from "../../src/values/Paper";
 import Factory from "../specHelpers/factory.js";
 const i18n = Factory.buildJed();
 

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -1,38 +1,74 @@
-import SubheadingsKeywordAssessment from "../../src/assessments/seo/subheadingsKeywordAssessment.js";
-import Paper from "../../src/values/Paper.js";
+import SubheadingsKeywordAssessment from "../../src/assessments/seo/subheadingsKeywordAssessment";
+import Paper from "../../src/values/paper"
 import Factory from "../specHelpers/factory.js";
-var i18n = Factory.buildJed();
+const i18n = Factory.buildJed();
 
 let matchKeywordAssessment = new SubheadingsKeywordAssessment();
 
 describe( "An assessment for matching keywords in subheadings", function() {
-	it( "assesses a string without subheadings", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 0 } ), i18n );
+	it( "returns a bad score and appropriate feedback when none of the subheadings contain the keyword", function() {
+		const mockPaper = new Paper();
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
 
-		expect( assessment.hasScore() ).toBe( false );
-		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual( "" );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "You have not used the focus keyword in any " +
+			"<a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2)." );
 	} );
-	it( "assesses a string with subheadings without keywords", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
 
-		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "You have not used the focus keyword in any <a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2) in your copy." );
+	it( "returns a bad score and appropriate feedback when there are too few subheadings containing the keyword", function() {
+		const mockPaper = new Paper();
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 4, matches: 1 } ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears only in 1 out of 4 " +
+			"<a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. Try to use it in more subheadings." );
 	} );
-	it( "assesses a string with subheadings and keywords", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
+
+	it( "returns a good score and appropriate feedback when there is a sufficient number of subheadings containing the keyword", function() {
+		const mockPaper = new Paper();
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 4, matches: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 1) <a href='https://yoa.st/2ph' target='_blank'>subheadings</a> in your copy." );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears in 2 out of 4 " +
+			"<a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That's great." );
 	} );
-	it( "assesses a string with subheadings and keywords", function() {
-		var mockPaper = new Paper();
-		var assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 10, matches: 1 } ), i18n );
+
+	it( "returns a good score and appropriate feedback when there is only one subheading and that subheading contains the keyword", function() {
+		const mockPaper = new Paper();
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 (out of 10) <a href='https://yoa.st/2ph' target='_blank'>subheadings</a> in your copy." );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 out of 1 " +
+			"<a href='https://yoa.st/2ph' target='_blank'>subheading</a>. That's great." );
+	} );
+
+	it( "returns a bad score and appropriate feedback when there are too many subheadings containing the keyword", function() {
+		const mockPaper = new Paper();
+		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 4, matches: 4 } ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "The focus keyword appears in 4 out of 4 " +
+			"<a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That might sound a bit repetitive. " +
+			"Try to change some of those subheadings to make the flow of your text sound more natural." );
+	} );
+
+	it( "checks isApplicable for a paper without text", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "checks isApplicable for a paper without keyword", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "<p>some text</p><h2>heading</h2><p>some more text</p>", { keyword: "" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "checks isApplicable for a paper without subheadings", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "<p>some text</p><p>some more text</p>", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "checks isApplicable for a paper with text and keyword", function() {
+		const isApplicableResult = new SubheadingsKeywordAssessment().isApplicable( new Paper( "<p>some text</p><h2>heading</h2><p>some more text</p>", { keyword: "some keyword" } ) );
+		expect( isApplicableResult ).toBe( true );
 	} );
 } );

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -8,48 +8,77 @@ let matchKeywordAssessment = new SubheadingsKeywordAssessment();
 describe( "An assessment for matching keywords in subheadings", function() {
 	it( "returns a bad score and appropriate feedback when none of the subheadings contain the keyword", function() {
 		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 0 } ), i18n );
+		const assessment = matchKeywordAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { count: 1, matches: 0, percentReflectingTopic: 0 } ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "You have not used the focus keyword in any " +
-			"<a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2)." );
+		expect( assessment.getText() ).toEqual(
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>" +
+			"Use more keywords or synonyms in your subheadings!</a>"
+		);
 	} );
 
 	it( "returns a bad score and appropriate feedback when there are too few subheadings containing the keyword", function() {
 		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 4, matches: 1 } ), i18n );
+		const assessment = matchKeywordAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { count: 4, matches: 1, percentReflectingTopic: 25 } ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears only in 1 out of 4 " +
-			"<a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. Try to use it in more subheadings." );
+		expect( assessment.getText() ).toEqual(
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>" +
+			"Use more keywords or synonyms in your subheadings!</a>"
+		);
 	} );
 
 	it( "returns a good score and appropriate feedback when there is a sufficient number of subheadings containing the keyword", function() {
 		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 4, matches: 2 } ), i18n );
+		const assessment = matchKeywordAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { count: 4, matches: 2, percentReflectingTopic: 50 } ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 2 out of 4 " +
-			"<a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That's great." );
+		expect( assessment.getText() ).toEqual(
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
+			"50% of your subheadings reflect the topic of your copy. Good job!" );
 	} );
 
 	it( "returns a good score and appropriate feedback when there is only one subheading and that subheading contains the keyword", function() {
 		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, matches: 1 } ), i18n );
+		const assessment = matchKeywordAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { count: 1, matches: 1, percentReflectingTopic: 100 } ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 1 out of 1 " +
-			"<a href='https://yoa.st/2ph' target='_blank'>subheading</a>. That's great." );
+		expect( assessment.getText() ).toEqual(
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
+			"Your subheading reflects the topic of your copy. Good job!"
+		);
 	} );
 
 	it( "returns a bad score and appropriate feedback when there are too many subheadings containing the keyword", function() {
 		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 4, matches: 4 } ), i18n );
+		const assessment = matchKeywordAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { count: 4, matches: 4, percentReflectingTopic: 100 } ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "The focus keyword appears in 4 out of 4 " +
-			"<a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That might sound a bit repetitive. " +
-			"Try to change some of those subheadings to make the flow of your text sound more natural." );
+		expect( assessment.getText() ).toEqual(
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
+			"More than 75% of your subheadings reflect the topic of your copy. That's too much. " +
+			"<a href='https://yoa.st/33n' target='_blank'>Don't over-optimize!</a>"
+		);
 	} );
 
 	it( "checks isApplicable for a paper without text", function() {

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -17,7 +17,7 @@ describe( "An assessment for matching keywords in subheadings", function() {
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
 			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>" +
-			"Use more keywords or synonyms in your subheadings!</a>"
+			"Use more keywords or synonyms in your subheadings</a>!"
 		);
 	} );
 
@@ -32,7 +32,7 @@ describe( "An assessment for matching keywords in subheadings", function() {
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
 			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>" +
-			"Use more keywords or synonyms in your subheadings!</a>"
+			"Use more keywords or synonyms in your subheadings</a>!"
 		);
 	} );
 
@@ -77,7 +77,7 @@ describe( "An assessment for matching keywords in subheadings", function() {
 		expect( assessment.getText() ).toEqual(
 			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
 			"More than 75% of your subheadings reflect the topic of your copy. That's too much. " +
-			"<a href='https://yoa.st/33n' target='_blank'>Don't over-optimize!</a>"
+			"<a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!"
 		);
 	} );
 

--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -1,5 +1,5 @@
 import SubheadingsKeywordAssessment from "../../src/assessments/seo/subheadingsKeywordAssessment";
-import Paper from "../../src/values/paper"
+import Paper from "../../src/values/paper";
 import Factory from "../specHelpers/factory.js";
 const i18n = Factory.buildJed();
 

--- a/spec/fullTextTests/runFullTextTests.js
+++ b/spec/fullTextTests/runFullTextTests.js
@@ -148,7 +148,7 @@ testPapers.forEach( function( testPaper ) {
 		it( "returns a score and the associated feedback text for the subheadingsKeyword assessment", function() {
 			result.subheadingsKeyword = new SubheadingsKeywordAssessment().getResult(
 				paper,
-				factory.buildMockResearcher( matchKeywordInSubheadings( paper ) ),
+				factory.buildMockResearcher( matchKeywordInSubheadings( paper, researcher ) ),
 				i18n
 			);
 			expect( result.subheadingsKeyword.getScore() ).toBe( expectedResults.subheadingsKeyword.score );

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -76,8 +76,8 @@ const expectedResults = {
 		resultText: "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> is over 156 characters. Reducing the length will ensure the entire description will be visible.",
 	},
 	subheadingsKeyword: {
-		score: 6,
-		resultText: "You have not used the focus keyword in any <a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2) in your copy.",
+		score: 3,
+		resultText: "You have not used the focus keyword in any <a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2).",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -77,7 +77,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keywords or synonyms in your subheadings!</a>",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keywords or synonyms in your subheadings</a>!",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -77,7 +77,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 3,
-		resultText: "You have not used the focus keyword in any <a href='https://yoa.st/2ph' target='_blank'>subheading</a> (such as an H2).",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keywords or synonyms in your subheadings!</a>",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -66,7 +66,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 9,
-		resultText: "The focus keyword appears in 1 (out of 3) <a href='https://yoa.st/2ph' target='_blank'>subheadings</a> in your copy.",
+		resultText: "The focus keyword appears in 1 out of 3 <a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That's great.",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -66,7 +66,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 9,
-		resultText: "The focus keyword appears in 1 out of 3 <a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That's great.",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 33.3% of your subheadings reflect the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -61,7 +61,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 3,
-		resultText: "The focus keyword appears in 4 out of 4 <a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That might sound a bit repetitive. Try to change some of those subheadings to make the flow of your text sound more natural.",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize!</a>",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -61,7 +61,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize!</a>",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -60,8 +60,8 @@ const expectedResults = {
 		resultText: "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has a nice length.",
 	},
 	subheadingsKeyword: {
-		score: 9,
-		resultText: "The focus keyword appears in 1 (out of 4) <a href='https://yoa.st/2ph' target='_blank'>subheadings</a> in your copy.",
+		score: 3,
+		resultText: "The focus keyword appears in 4 out of 4 <a href='https://yoa.st/2ph' target='_blank'>subheadings</a>. That might sound a bit repetitive. Try to change some of those subheadings to make the flow of your text sound more natural.",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/researches/matchKeywordInSubheadingsSpec.js
+++ b/spec/researches/matchKeywordInSubheadingsSpec.js
@@ -1,13 +1,12 @@
 import subheadingFunction from "../../src/researches/matchKeywordInSubheadings.js";
 import Paper from "../../src/values/Paper.js";
-import Researcher from "../../src/researcher";
 import Factory from "../specHelpers/factory";
 
 describe( "a test for matching subheadings", function() {
 	it( "returns the number of subheadings in the text", function() {
 		let mockPaper = new Paper( "<h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
-		let mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'keyword' ] ], synonymsForms: [ ],
+		const mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ "keyword" ] ], synonymsForms: [ ],
 		} );
 		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 1 );
@@ -20,11 +19,11 @@ describe( "a test for matching subheadings", function() {
 
 describe( "A test for matching keywords in subheadings", function() {
 	it( "returns the number of matches in a subheading", function() {
-		let mockPaper = new Paper( "<h2>Lorem ipsum $keyword</h2>", { keyword: "$keyword" } );
+		const mockPaper = new Paper( "<h2>Lorem ipsum $keyword</h2>", { keyword: "$keyword" } );
 		const mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ '\\$keyword' ] ], synonymsForms: [ ],
+			keyphraseForms: [ [ "\\$keyword" ] ], synonymsForms: [ ],
 		} );
-		let result = subheadingFunction( mockPaper, mockResearcher );
+		const result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 	} );
 } );
@@ -33,7 +32,7 @@ describe( "a test for matching keywords in subheadings", function() {
 	it( "returns the number of matches in the subheadings", function() {
 		let mockPaper = new Paper( "<h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
 		let mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'keyword' ] ], synonymsForms: [ ],
+			keyphraseForms: [ [ "keyword" ] ], synonymsForms: [ ],
 		} );
 		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 1 );
@@ -55,54 +54,54 @@ describe( "a test for matching keywords in subheadings", function() {
 
 		mockPaper = new Paper( "<h2>this is a heading with a dashed key-word</h2>", { keyword: "key-word" } );
 		mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'key-word', 'key-words' ] ], synonymsForms: [ ],
+			keyphraseForms: [ [ "key-word", "key-words" ] ], synonymsForms: [ ],
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 
 		mockPaper = new Paper( "<h2>this is a heading with an underscored key_word</h2>", { keyword: "key_word" } );
 		mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'key_word', 'key_words' ] ], synonymsForms: [ ],
+			keyphraseForms: [ [ "key_word", "key_words" ] ], synonymsForms: [ ],
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 
 		mockPaper = new Paper( "<h2>this is a heading with a dashed key-word</h2>", { keyword: "key word" } );
 		mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'key', 'keys' ], [ 'word', 'words' ] ], synonymsForms: [ ],
+			keyphraseForms: [ [ "key", "keys" ], [ "word", "words" ] ], synonymsForms: [ ],
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 
 		mockPaper = new Paper( "<h2>this is a heading with an underscored key_word</h2>", { keyword: "key word" } );
 		mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'key', 'keys' ], [ 'word', 'words' ] ], synonymsForms: [ ],
+			keyphraseForms: [ [ "key", "keys" ], [ "word", "words" ] ], synonymsForms: [ ],
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 0 );
 	} );
 
 	it( "should not count headings when less than half of the keywords are in it", function() {
-		let mockPaper = new Paper(
+		const mockPaper = new Paper(
 			"<h1>Here are some key words: Abraham, Cats</h1><h2>Here are some more: Abraham</h2>"
 		);
-		let mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'abraham', 'abrahams' ], [ 'banner', 'banners' ], [ 'cat', 'cats' ] ], synonymsForms: [ ],
+		const mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ "abraham", "abrahams" ], [ "banner", "banners" ], [ "cat", "cats" ] ], synonymsForms: [ ],
 		} );
 		// First heading has 2/3 key words, so should match (2/3 > 1/2), second heading should not (1/2 == 1/2)
-		let result = subheadingFunction( mockPaper, mockResearcher );
+		const result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 	} );
 
 	it( "should keep synonyms into account when checking subheadings for keywords", function() {
-		let mockPaper = new Paper(
+		const mockPaper = new Paper(
 			"<h1>Here are some key words: Abraham, Cats</h1><h2>Here are some more: Abraham</h2>"
 		);
-		let mockResearcher = Factory.buildMockResearcher( {
-			keyphraseForms: [ [ 'abraham', 'abrahams' ], [ 'Darth', 'Darths' ] ], synonymsForms: [ [ [ 'cat', 'cats' ] ], [ [ 'banner', 'banners' ] ] ],
+		const mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ "abraham", "abrahams" ], [ "Darth", "Darths" ] ], synonymsForms: [ [ [ "cat", "cats" ] ], [ [ "banner", "banners" ] ] ],
 		} );
 		// First heading matches key phrase "cats" 100% in first heading, so is counted as one.
-		let result = subheadingFunction( mockPaper, mockResearcher );
+		const result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 	} );
 } );

--- a/spec/researches/matchKeywordInSubheadingsSpec.js
+++ b/spec/researches/matchKeywordInSubheadingsSpec.js
@@ -1,59 +1,108 @@
 import subheadingFunction from "../../src/researches/matchKeywordInSubheadings.js";
 import Paper from "../../src/values/Paper.js";
+import Researcher from "../../src/researcher";
+import Factory from "../specHelpers/factory";
 
 describe( "a test for matching subheadings", function() {
 	it( "returns the number of subheadings in the text", function() {
-		var mockPaper = new Paper( "<h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
-		var result = subheadingFunction( mockPaper );
+		let mockPaper = new Paper( "<h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
+		let mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'keyword' ] ], synonymsForms: [ ],
+		} );
+		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 1 );
 
-		mockPaper = new Paper( "Pellentesque sit amet justo ex. Suspendisse feugiat pulvinar leo eu consectetur" );
-		result = subheadingFunction( mockPaper );
-		expect( result.count ).toBe( 0 );
-
 		mockPaper = new Paper( "<h2>Lorem ipsum</h2><h2>Lorem ipsum</h2><h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
-		result = subheadingFunction( mockPaper );
+		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 3 );
 	} );
 } );
 
 describe( "A test for matching keywords in subheadings", function() {
 	it( "returns the number of matches in a subheading", function() {
-		var mockPaper = new Paper( "<h2>Lorem ipsum $keyword</h2>", { keyword: "$keyword" } );
-		var result = subheadingFunction( mockPaper );
+		let mockPaper = new Paper( "<h2>Lorem ipsum $keyword</h2>", { keyword: "$keyword" } );
+		const mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ '\\$keyword' ] ], synonymsForms: [ ],
+		} );
+		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 	} );
 } );
 
 describe( "a test for matching keywords in subheadings", function() {
 	it( "returns the number of matches in the subheadings", function() {
-		var mockPaper = new Paper( "<h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
-		var result = subheadingFunction( mockPaper );
+		let mockPaper = new Paper( "<h2>Lorem ipsum</h2> keyword sit amet, consectetur adipiscing elit", { keyword: "keyword" } );
+		let mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'keyword' ] ], synonymsForms: [ ],
+		} );
+		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 1 );
 		expect( result.matches ).toBe( 0 );
 
 		mockPaper = new Paper( "Pellentesque sit amet justo ex. Suspendisse feugiat pulvinar leo eu consectetur" );
-		result = subheadingFunction( mockPaper );
+		mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ ] ], synonymsForms: [ ],
+		} );
+		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 0 );
 
 		mockPaper = new Paper( "<h2>this is a heading with a diacritic keyword kapaklı </h2>", { keyword: "kapaklı" } );
-		result = subheadingFunction( mockPaper );
+		mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ "kapaklı" ] ], synonymsForms: [ ],
+		} );
+		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 
 		mockPaper = new Paper( "<h2>this is a heading with a dashed key-word</h2>", { keyword: "key-word" } );
-		result = subheadingFunction( mockPaper );
+		mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'key-word', 'key-words' ] ], synonymsForms: [ ],
+		} );
+		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 
-		mockPaper = new Paper( "<h2>this is a heading with a underscored key_word</h2>", { keyword: "key_word" } );
-		result = subheadingFunction( mockPaper );
+		mockPaper = new Paper( "<h2>this is a heading with an underscored key_word</h2>", { keyword: "key_word" } );
+		mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'key_word', 'key_words' ] ], synonymsForms: [ ],
+		} );
+		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 
-		mockPaper = new Paper( "<h2>this is a heading with a underscored key-word</h2>", { keyword: "key word" } );
-		result = subheadingFunction( mockPaper );
-		expect( result.matches ).toBe( 0 );
+		mockPaper = new Paper( "<h2>this is a heading with a dashed key-word</h2>", { keyword: "key word" } );
+		mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'key', 'keys' ], [ 'word', 'words' ] ], synonymsForms: [ ],
+		} );
+		result = subheadingFunction( mockPaper, mockResearcher );
+		expect( result.matches ).toBe( 1 );
 
-		mockPaper = new Paper( "<h2>this is a heading with a underscored key_word</h2>", { keyword: "key word" } );
-		result = subheadingFunction( mockPaper );
+		mockPaper = new Paper( "<h2>this is a heading with an underscored key_word</h2>", { keyword: "key word" } );
+		mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'key', 'keys' ], [ 'word', 'words' ] ], synonymsForms: [ ],
+		} );
+		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 0 );
+	} );
+
+	it( "should not count headings when less than half of the keywords are in it", function() {
+		let mockPaper = new Paper(
+			"<h1>Here are some key words: Abraham, Cats</h1><h2>Here are some more: Abraham</h2>"
+		);
+		let mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'abraham', 'abrahams' ], [ 'banner', 'banners' ], [ 'cat', 'cats' ] ], synonymsForms: [ ],
+		} );
+		// First heading has 2/3 key words, so should match (2/3 > 1/2), second heading should not (1/2 == 1/2)
+		let result = subheadingFunction( mockPaper, mockResearcher );
+		expect( result.matches ).toBe( 1 );
+	} );
+
+	it( "should keep synonyms into account when checking subheadings for keywords", function() {
+		let mockPaper = new Paper(
+			"<h1>Here are some key words: Abraham, Cats</h1><h2>Here are some more: Abraham</h2>"
+		);
+		let mockResearcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ 'abraham', 'abrahams' ], [ 'Darth', 'Darths' ] ], synonymsForms: [ [ [ 'cat', 'cats' ] ], [ [ 'banner', 'banners' ] ] ],
+		} );
+		// First heading has 2/3 key words, so should match (2/3 > 1/2), second heading should not (1/2 == 1/2)
+		let result = subheadingFunction( mockPaper, mockResearcher );
+		expect( result.matches ).toBe( 1 );
 	} );
 } );

--- a/spec/researches/matchKeywordInSubheadingsSpec.js
+++ b/spec/researches/matchKeywordInSubheadingsSpec.js
@@ -101,7 +101,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		let mockResearcher = Factory.buildMockResearcher( {
 			keyphraseForms: [ [ 'abraham', 'abrahams' ], [ 'Darth', 'Darths' ] ], synonymsForms: [ [ [ 'cat', 'cats' ] ], [ [ 'banner', 'banners' ] ] ],
 		} );
-		// First heading has 2/3 key words, so should match (2/3 > 1/2), second heading should not (1/2 == 1/2)
+		// First heading matches key phrase "cats" 100% in first heading, so is counted as one.
 		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
 	} );

--- a/spec/researches/matchKeywordInSubheadingsSpec.js
+++ b/spec/researches/matchKeywordInSubheadingsSpec.js
@@ -24,7 +24,9 @@ describe( "A test for matching keywords in subheadings", function() {
 			keyphraseForms: [ [ "\\$keyword" ] ], synonymsForms: [ ],
 		} );
 		const result = subheadingFunction( mockPaper, mockResearcher );
+		expect( result.count ).toBe( 1 );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 100 );
 	} );
 } );
 
@@ -37,6 +39,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		let result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 1 );
 		expect( result.matches ).toBe( 0 );
+		expect( result.percentReflectingTopic ).toBe( 0 );
 
 		mockPaper = new Paper( "Pellentesque sit amet justo ex. Suspendisse feugiat pulvinar leo eu consectetur" );
 		mockResearcher = Factory.buildMockResearcher( {
@@ -44,6 +47,8 @@ describe( "a test for matching keywords in subheadings", function() {
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.count ).toBe( 0 );
+		expect( result.matches ).toBe( 0 );
+		expect( result.percentReflectingTopic ).toBe( 0 );
 
 		mockPaper = new Paper( "<h2>this is a heading with a diacritic keyword kapaklı </h2>", { keyword: "kapaklı" } );
 		mockResearcher = Factory.buildMockResearcher( {
@@ -51,6 +56,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 100 );
 
 		mockPaper = new Paper( "<h2>this is a heading with a dashed key-word</h2>", { keyword: "key-word" } );
 		mockResearcher = Factory.buildMockResearcher( {
@@ -58,6 +64,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 100 );
 
 		mockPaper = new Paper( "<h2>this is a heading with an underscored key_word</h2>", { keyword: "key_word" } );
 		mockResearcher = Factory.buildMockResearcher( {
@@ -65,6 +72,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 100 );
 
 		mockPaper = new Paper( "<h2>this is a heading with a dashed key-word</h2>", { keyword: "key word" } );
 		mockResearcher = Factory.buildMockResearcher( {
@@ -72,6 +80,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 100 );
 
 		mockPaper = new Paper( "<h2>this is a heading with an underscored key_word</h2>", { keyword: "key word" } );
 		mockResearcher = Factory.buildMockResearcher( {
@@ -79,6 +88,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		} );
 		result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 0 );
+		expect( result.percentReflectingTopic ).toBe( 0 );
 	} );
 
 	it( "should not count headings when less than half of the keywords are in it", function() {
@@ -91,6 +101,7 @@ describe( "a test for matching keywords in subheadings", function() {
 		// First heading has 2/3 key words, so should match (2/3 > 1/2), second heading should not (1/2 == 1/2)
 		const result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 50 );
 	} );
 
 	it( "should keep synonyms into account when checking subheadings for keywords", function() {
@@ -103,5 +114,6 @@ describe( "a test for matching keywords in subheadings", function() {
 		// First heading matches key phrase "cats" 100% in first heading, so is counted as one.
 		const result = subheadingFunction( mockPaper, mockResearcher );
 		expect( result.matches ).toBe( 1 );
+		expect( result.percentReflectingTopic ).toBe( 50 );
 	} );
 } );

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -378,13 +378,14 @@ describe( "AnalysisWebWorker", () => {
 				scope.onmessage( createMessage( "analyze", { paper: paper.serialize() } ) );
 			} );
 
-			test( "researcher does not set paper again if the paper has no changes", done => {
+			test( "skips over researcher set paper and locale when there are no paper changes", done => {
 				const paper = new Paper( "This is the content." );
-				worker._researcher.setPaper = jest.fn();
+				// Using setLocale because setPaper is also used in the researcher. This makes is simpler.
+				worker.setLocale = jest.fn();
 
 				let firstRun = true;
 				worker.analyzeDone = () => {
-					expect( worker._researcher.setPaper ).toHaveBeenCalledTimes( 1 );
+					expect( worker.setLocale ).toHaveBeenCalledTimes( 1 );
 					if ( firstRun ) {
 						scope.onmessage( createMessage( "analyze", { paper: paper.serialize() } ) );
 						firstRun = false;
@@ -826,7 +827,10 @@ describe( "AnalysisWebWorker", () => {
 
 				worker.runResearchDone = ( id, result ) => {
 					expect( id ).toBe( 0 );
-					expect( isNumber( result ) ).toBe( true );
+					expect( isObject( result ) ).toBe( true );
+					expect( result.foundInOneSentence ).toBe( true );
+					expect( result.foundInParagraph ).toBe( true );
+					expect( result.keyphraseOrSynonym ).toBe( "keyphrase" );
 					done();
 				};
 

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -1,8 +1,9 @@
-const AssessmentResult = require( "../../values/AssessmentResult.js" );
-const Assessment = require( "../../assessment.js" );
-const merge = require( "lodash/merge" );
-const inRangeStartEndInclusive = require( "../../helpers/inRange.js" ).inRangeStartEndInclusive;
-const getSubheadings = require( "../../stringProcessing/getSubheadings" ).getSubheadings;
+
+import AssessmentResult from "../../values/AssessmentResult";
+import Assessment from "../../assessment";
+import { merge } from "lodash-es";
+import { inRangeStartEndInclusive } from "../../helpers";
+import { getSubheadings } from "../../stringProcessing/getSubheadings";
 
 /**
  * Represents the assessment that checks if the keyword is present in one of the subheadings.

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -1,7 +1,8 @@
-import { merge } from "lodash-es";
-
-import AssessmentResult from "../../values/AssessmentResult.js";
-import Assessment from "../../assessment.js";
+const AssessmentResult = require( "../../values/AssessmentResult.js" );
+const Assessment = require( "../../assessment.js" );
+const merge = require( "lodash/merge" );
+const inRangeStartEndInclusive = require( "../../helpers/inRange.js" ).inRangeStartEndInclusive;
+const getSubheadings = require( "../../stringProcessing/getSubheadings" ).getSubheadings;
 
 /**
  * Represents the assessment that checks if the keyword is present in one of the subheadings.
@@ -10,19 +11,25 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {Object} [config] The configuration to use.
+	 * @param {object} config The configuration to use.
 	 *
 	 * @returns {void}
 	 */
 	constructor( config = {} ) {
 		super();
 
-		let defaultConfig = {
-			scores: {
-				noMatches: 6,
-				oneMatch: 9,
-				multipleMatches: 9,
+		const defaultConfig = {
+			parameters: {
+				lowerBoundary: 0.3,
+				upperBoundary: 0.75,
 			},
+			scores: {
+				noMatches: 3,
+				tooFewMatches: 3,
+				goodNumberOfMatches: 9,
+				tooManyMatches: 3,
+			},
+			url: "<a href='https://yoa.st/2ph' target='_blank'>",
 		};
 
 		this.identifier = "subheadingsKeyword";
@@ -30,23 +37,38 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	}
 
 	/**
-	 * Runs the match keyword in subheadings module, based on this returns an assessment result with score.
+	 * Runs the matchKeywordInSubheadings research and based on this returns an assessment result.
 	 *
-	 * @param {Paper} paper The paper to use for the assessment.
-	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed} i18n The object used for translations.
+	 * @param {Paper} paper             The paper to use for the assessment.
+	 * @param {Researcher} researcher   The researcher used for calling research.
+	 * @param {Object} i18n             The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
 	getResult( paper, researcher, i18n ) {
-		let subHeadings = researcher.getResearch( "matchKeywordInSubheadings" );
-		let assessmentResult = new AssessmentResult();
-		let score = this.calculateScore( subHeadings );
+		this._subHeadings = researcher.getResearch( "matchKeywordInSubheadings" );
+		this._minNumberOfSubheadings = Math.ceil( this._subHeadings.count * this._config.parameters.lowerBoundary );
+		this._maxNumberOfSubheadings = Math.floor( this._subHeadings.count * this._config.parameters.upperBoundary );
 
-		assessmentResult.setScore( score );
-		assessmentResult.setText( this.translateScore( score, subHeadings, i18n ) );
+		let assessmentResult = new AssessmentResult();
+
+		const calculatedResult = this.calculateResult( i18n );
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
+	}
+
+	/**
+	 * Checks whether the paper has a subheadings.
+	 *
+	 * @param {Paper} paper The paper to use for the check.
+	 *
+	 * @returns {boolean} True when there is at least one subheading.
+	 */
+	hasSubheadings( paper ) {
+		const subheadings = getSubheadings( paper.getText() );
+		return subheadings.length > 0;
 	}
 
 	/**
@@ -57,63 +79,126 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	 * @returns {boolean} True when there is text and a keyword.
 	 */
 	isApplicable( paper ) {
-		return paper.hasText() && paper.hasKeyword();
+		return paper.hasText() && paper.hasKeyword() && this.hasSubheadings( paper );
 	}
 
 	/**
-	 * Returns the score for the subheadings.
+	 * Checks whether there are too few subheadings with the keyword. This is the case if the number of subheadings
+	 * with the keyword is more than 0 but less than the specified recommended minimum.
 	 *
-	 * @param {Object} subHeadings The object with all subHeadings matches.
-	 *
-	 * @returns {number|null} The calculated score.
+	 * @returns {boolean} Returns true if the keyword is included in too few subheadings.
 	 */
-	calculateScore( subHeadings ) {
-		if ( subHeadings.matches === 0 ) {
-			return this._config.scores.noMatches;
-		}
-		if ( subHeadings.matches === 1 ) {
-			return this._config.scores.oneMatch;
-		}
-
-		if ( subHeadings.matches > 1 ) {
-			return this._config.scores.multipleMatches;
-		}
-
-		return null;
+	hasTooFewMatches() {
+		return this._subHeadings.matches > 0 && this._subHeadings.matches < this._minNumberOfSubheadings;
 	}
 
 	/**
-	 * Translates the score to a message the user can understand.
+	 * Checks whether there is a good number of subheadings with the keyword. This is the case if there
+	 * is only one subheading and that subheading includes the keyword or if the number of subheadings
+	 * with the keyword is within the specified recommended range.
 	 *
-	 * @param {number} score The score for this assessment.
-	 * @param {Object} subHeadings The object with all subHeadings matches.
-	 * @param {Jed} i18n The object used for translations.
-	 *
-	 * @returns {string} The translated string.
+	 * @returns {boolean} Returns true if the keyword is included in a sufficient number of subheadings.
 	 */
-	translateScore( score, subHeadings, i18n ) {
-		const url = "<a href='https://yoa.st/2ph' target='_blank'>";
+	hasGoodNumberOfMatches() {
+		return ( this._subHeadings.count === 1 && this._subHeadings.matches === 1 ) ||
+			inRangeStartEndInclusive( this._subHeadings.matches, this._minNumberOfSubheadings, this._maxNumberOfSubheadings );
+	}
 
-		if ( score === this._config.scores.multipleMatches || score === this._config.scores.oneMatch ) {
-			return i18n.sprintf(
-				/* Translators: %1$d expands to the number of subheadings containing the keyword, %2$d expands to the
-				total number of subheadings, %3$s expands to a link on yoast.com, %4$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "The focus keyword appears in %1$d (out of %2$d) %3$ssubheadings%4$s in your copy." ),
-				subHeadings.matches, subHeadings.count, url, "</a>"
-			);
+	/**
+	 * Checks whether there are too many subheadings with the keyword.
+	 * The upper limit is only applicable if there is more than one subheading.
+	 * If there is only one subheading with the keyword this would otherwise
+	 * always lead to a 100% match rate.
+	 *
+	 * @returns {boolean} Returns true if there is more than one subheading and if
+	 * the keyword is included in less subheadings than the recommended maximum.
+	 */
+	hasTooManyMatches() {
+		return this._subHeadings.count > 1 && this._subHeadings.matches > this._maxNumberOfSubheadings;
+	}
+
+	/**
+	 * Determines the score and the Result text for the subheadings.
+	 *
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} The object with the calculated score and the result text.
+	 */
+	calculateResult( i18n ) {
+		if ( this.hasTooFewMatches() ) {
+			return {
+				score: this._config.scores.tooFewMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the total number of subheadings.
+					%2$d expands to the number of subheadings containing the keyword,
+					%3$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword appears only in %2$d out of %1$d %3$ssubheadings%4$s. " +
+						"Try to use it in more subheadings."
+					),
+					this._subHeadings.count,
+					this._subHeadings.matches,
+					this._config.url,
+					"</a>"
+				),
+			};
 		}
 
-		if ( score === this._config.scores.noMatches ) {
-			return i18n.sprintf(
-				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+		if ( this.hasGoodNumberOfMatches() ) {
+			return {
+				score: this._config.scores.goodNumberOfMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the total number of subheadings.
+					%2$d expands to the number of subheadings containing the keyword,
+					%3$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"The focus keyword appears in %2$d out of %1$d %3$ssubheading%4$s. That's great.",
+						"The focus keyword appears in %2$d out of %1$d %3$ssubheadings%4$s. That's great.",
+						this._subHeadings.count
+					),
+					this._subHeadings.count,
+					this._subHeadings.matches,
+					this._config.url,
+					"</a>"
+				),
+			};
+		}
+
+		if ( this.hasTooManyMatches() ) {
+			return {
+				score: this._config.scores.tooManyMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the total number of subheadings.
+					%2$d expands to the number of subheadings containing the keyword,
+					%3$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"The focus keyword appears in %2$d out of %1$d %3$ssubheadings%4$s. That might sound a bit repetitive. " +
+						"Try to change some of those subheadings to make the flow of your text sound more natural."
+					),
+					this._subHeadings.count,
+					this._subHeadings.matches,
+					this._config.url,
+					"</a>"
+				),
+			};
+		}
+
+		return {
+			score: this._config.scores.noMatches,
+			resultText: i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 				i18n.dgettext(
 					"js-text-analysis",
-					"You have not used the focus keyword in any %1$ssubheading%2$s (such as an H2) in your copy."
-				), url, "</a>" );
-		}
-
-		return "";
+					"You have not used the focus keyword in any %1$ssubheading%2$s (such as an H2)."
+				),
+				this._config.url,
+				"</a>"
+			),
+		};
 	}
 }
 
-export default SubHeadingsKeywordAssessment;
+module.exports = SubHeadingsKeywordAssessment;

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -176,7 +176,7 @@ class SubHeadingsKeywordAssessment extends Assessment {
 					i18n.dgettext(
 						"js-text-analysis",
 						"%1$sKeyphrase in subheading%2$s: More than %3$s of your subheadings reflect the topic of your copy. " +
-						"That's too much. %4$sDon't over-optimize!%5$s"
+						"That's too much. %4$sDon't over-optimize%5$s!"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -196,7 +196,7 @@ class SubHeadingsKeywordAssessment extends Assessment {
 				 */
 				i18n.dngettext(
 					"js-text-analysis",
-					"%1$sKeyphrase in subheading%2$s: %3$sUse more keywords or synonyms in your subheadings!%4$s"
+					"%1$sKeyphrase in subheading%2$s: %3$sUse more keywords or synonyms in your subheadings%4$s!"
 				),
 				this._config.urlTitle,
 				"</a>",

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -11,24 +11,24 @@ import matchTextWithArray from "../stringProcessing/matchTextWithArray";
  * (morphological forms included).
  *
  * @param {String} subheading the subheading to check.
- * @param {String[][]} keyphraseForms the key words and their forms to check.
+ * @param {Array<String[]>} keyphraseForms the key words and their forms to check.
  * @param {String} locale the current locale
- * @returns {boolean} if the fraction of found keywords in the subheading is bigger than 0.5.
+ * @returns {Boolean} if the fraction of found keywords in the subheading is bigger than 0.5.
  */
 const subheadingReflectsTopic = function( subheading, keyphraseForms, locale ) {
-	let keywordFormsFound = keyphraseForms.filter(
+	const keywordFormsFound = keyphraseForms.filter(
 		keywordForms => matchTextWithArray( subheading, keywordForms, locale ).count > 0
 	);
 
-	// over half the keywords should be in the subheading.
-	return (keywordFormsFound.length / keyphraseForms.length) > 0.5;
+	// Over half the keywords should be in the subheading.
+	return ( keywordFormsFound.length / keyphraseForms.length ) > 0.5;
 };
 
 /**
  * Computes the amount of subheadings reflecting the topic.
  *
  * @param {String[]} subheadings the subheadings to check.
- * @param {String[][]} keyphraseForms the key words and their forms to check.
+ * @param {Array<String[]>} keyphraseForms the key words and their forms to check.
  * @param {String} locale the current locale.
  * @returns {Number} the amount of subheadings reflecting the topic.
  */
@@ -51,10 +51,10 @@ const numberOfsubheadingsReflectingTopic = function( subheadings, keyphraseForms
 export default function( paper, researcher ) {
 	let text = paper.getText();
 	let topicForms = researcher.getResearch( "morphology" );
-	let locale = paper.getLocale();
-	let result = { count: 0 };
+	const locale = paper.getLocale();
+	const result = { count: 0 };
 	text = stripSomeTags( text );
-	let matches = getSubheadingContents( text );
+	const matches = getSubheadingContents( text );
 
 	if ( 0 !== matches.length ) {
 		result.count = matches.length;

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -8,11 +8,12 @@ import { findTopicFormsInString } from "./findKeywordFormsInString.js";
 /**
  * Computes the amount of subheadings reflecting the topic.
  *
- * @param {Object} topicForms the main key phrase and its synonyms to check.
- * @param {String[]} subheadings the subheadings to check.
- * @param {boolean} useSynonyms Whether to match synonyms or only main keyphrase.
- * @param {string} locale the current locale.
- * @returns {number} the amount of subheadings reflecting the topic.
+ * @param {Object}      topicForms      The main key phrase and its synonyms to check.
+ * @param {String[]}    subheadings     The subheadings to check.
+ * @param {boolean}     useSynonyms     Whether to match synonyms or only main keyphrase.
+ * @param {string}      locale          The current locale.
+ *
+ * @returns {number} The amount of subheadings reflecting the topic.
  */
 const numberOfSubheadingsReflectingTopic = function( topicForms, subheadings, useSynonyms, locale ) {
 	return subheadings.filter(
@@ -28,9 +29,10 @@ const numberOfSubheadingsReflectingTopic = function( topicForms, subheadings, us
  *
  * Also checks for synonyms.
  *
- * @param {Object} paper The paper object containing the text and keyword.
- * @param {Researcher} researcher The researcher object.
- * @returns {Object} the result object.
+ * @param {Object}      paper       The paper object containing the text and keyword.
+ * @param {Researcher}  researcher  The researcher object.
+ *
+ * @returns {Object} The result object.
  */
 export default function( paper, researcher ) {
 	const text = stripSomeTags( paper.getText() );

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -3,43 +3,21 @@
 import stripSomeTags from "../stringProcessing/stripNonTextTags.js";
 
 import { getSubheadingContents } from "../stringProcessing/getSubheadings.js";
-import matchTextWithArray from "../stringProcessing/matchTextWithArray";
-
-/**
- * Checks if the given subheading reflects the given topic.
- * "Reflects" is defined as a subheading having at least 50% of the content words in the key phrase
- * (morphological forms included).
- *
- * @param {String} subheading the subheading to check.
- * @param {Array<String[]>} keyphraseForms the key words and their forms to check.
- * @param {String} locale the current locale
- * @returns {Boolean} if the fraction of found keywords in the subheading is bigger than 0.5.
- */
-const subheadingReflectsTopic = function( subheading, keyphraseForms, locale ) {
-	const keywordFormsFound = keyphraseForms.filter(
-		keywordForms => matchTextWithArray( subheading, keywordForms, locale ).count > 0
-	);
-
-	// Over half the keywords should be in the subheading.
-	return ( keywordFormsFound.length / keyphraseForms.length ) > 0.5;
-};
+import { findTopicFormsInString } from "./findKeywordFormsInString.js";
 
 /**
  * Computes the amount of subheadings reflecting the topic.
  *
- * @param {String[]} subheadings the subheadings to check.
  * @param {Object} topicForms the main key phrase and its synonyms to check.
- * @param {String} locale the current locale.
- * @returns {Number} the amount of subheadings reflecting the topic.
+ * @param {String[]} subheadings the subheadings to check.
+ * @param {boolean} useSynonyms Whether to match synonyms or only main keyphrase.
+ * @param {string} locale the current locale.
+ * @returns {number} the amount of subheadings reflecting the topic.
  */
-const numberOfSubheadingsReflectingTopic = function( subheadings, topicForms, locale ) {
+const numberOfSubheadingsReflectingTopic = function( topicForms, subheadings, useSynonyms, locale ) {
 	return subheadings.filter(
 		subheading => {
-			const reflectsMainTopic = subheadingReflectsTopic( subheading, topicForms.keyphraseForms, locale );
-			const reflectsSynonym = topicForms.synonymsForms.some(
-				synonymForm => subheadingReflectsTopic( subheading, synonymForm, locale )
-			);
-			return reflectsMainTopic || reflectsSynonym;
+			return findTopicFormsInString( topicForms, subheading, useSynonyms, locale ).percentWordMatches > 50;
 		}
 	).length;
 
@@ -51,21 +29,22 @@ const numberOfSubheadingsReflectingTopic = function( subheadings, topicForms, lo
  *
  * Also checks for synonyms.
  *
- * @param {object} paper The paper object containing the text and keyword.
+ * @param {Object} paper The paper object containing the text and keyword.
  * @param {Researcher} researcher The researcher object.
- * @returns {object} the result object.
+ * @returns {Object} the result object.
  */
 export default function( paper, researcher ) {
-	let text = paper.getText();
-	let topicForms = researcher.getResearch( "morphology" );
+	const text = stripSomeTags( paper.getText() );
+	const topicForms = researcher.getResearch( "morphology" );
 	const locale = paper.getLocale();
-	const result = { count: 0 };
-	text = stripSomeTags( text );
+	const result = { count: 0, matches: 0 };
 	const subheadings = getSubheadingContents( text );
+
+	const useSynonyms = true;
 
 	if ( 0 !== subheadings.length ) {
 		result.count = subheadings.length;
-		result.matches = numberOfSubheadingsReflectingTopic( subheadings, topicForms, locale );
+		result.matches = numberOfSubheadingsReflectingTopic( topicForms, subheadings, useSynonyms, locale );
 	}
 
 	return result;

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -32,7 +32,7 @@ const subheadingReflectsTopic = function( subheading, keyphraseForms, locale ) {
  * @param {String} locale the current locale.
  * @returns {Number} the amount of subheadings reflecting the topic.
  */
-const numberOfsubheadingsReflectingTopic = function( subheadings, topicForms, locale ) {
+const numberOfSubheadingsReflectingTopic = function( subheadings, topicForms, locale ) {
 	return subheadings.filter(
 		subheading => {
 			const reflectsMainTopic = subheadingReflectsTopic( subheading, topicForms.keyphraseForms, locale );
@@ -65,7 +65,7 @@ export default function( paper, researcher ) {
 
 	if ( 0 !== subheadings.length ) {
 		result.count = subheadings.length;
-		result.matches = numberOfsubheadingsReflectingTopic( subheadings, topicForms, locale );
+		result.matches = numberOfSubheadingsReflectingTopic( subheadings, topicForms, locale );
 	}
 
 	return result;

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -20,7 +20,6 @@ const numberOfSubheadingsReflectingTopic = function( topicForms, subheadings, us
 			return findTopicFormsInString( topicForms, subheading, useSynonyms, locale ).percentWordMatches > 50;
 		}
 	).length;
-
 };
 
 /**
@@ -37,7 +36,7 @@ export default function( paper, researcher ) {
 	const text = stripSomeTags( paper.getText() );
 	const topicForms = researcher.getResearch( "morphology" );
 	const locale = paper.getLocale();
-	const result = { count: 0, matches: 0 };
+	const result = { count: 0, matches: 0, percentReflectingTopic: 0 };
 	const subheadings = getSubheadingContents( text );
 
 	const useSynonyms = true;
@@ -45,6 +44,7 @@ export default function( paper, researcher ) {
 	if ( 0 !== subheadings.length ) {
 		result.count = subheadings.length;
 		result.matches = numberOfSubheadingsReflectingTopic( topicForms, subheadings, useSynonyms, locale );
+		result.percentReflectingTopic = result.matches / result.count * 100;
 	}
 
 	return result;

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -2,29 +2,68 @@
 
 import stripSomeTags from "../stringProcessing/stripNonTextTags.js";
 
-import subheadingMatch from "../stringProcessing/subheadingsMatch.js";
 import { getSubheadingContents } from "../stringProcessing/getSubheadings.js";
+import matchTextWithArray from "../stringProcessing/matchTextWithArray";
 
-import { escapeRegExp } from "lodash-es";
+/**
+ * Checks if the given subheading reflects the given topic.
+ * "Reflects" is defined as a subheading having at least 50% of the content words in the key phrase
+ * (morphological forms included).
+ *
+ * @param {String} subheading the subheading to check.
+ * @param {String[][]} keyphraseForms the key words and their forms to check.
+ * @param {String} locale the current locale
+ * @returns {boolean} if the fraction of found keywords in the subheading is bigger than 0.5.
+ */
+const subheadingReflectsTopic = function( subheading, keyphraseForms, locale ) {
+	let keywordFormsFound = keyphraseForms.filter(
+		keywordForms => matchTextWithArray( subheading, keywordForms, locale ).count > 0
+	);
+
+	// over half the keywords should be in the subheading.
+	return (keywordFormsFound.length / keyphraseForms.length) > 0.5;
+};
+
+/**
+ * Computes the amount of subheadings reflecting the topic.
+ *
+ * @param {String[]} subheadings the subheadings to check.
+ * @param {String[][]} keyphraseForms the key words and their forms to check.
+ * @param {String} locale the current locale.
+ * @returns {Number} the amount of subheadings reflecting the topic.
+ */
+const numberOfsubheadingsReflectingTopic = function( subheadings, keyphraseForms, locale ) {
+	return subheadings.filter(
+		subheading => subheadingReflectsTopic( subheading, keyphraseForms, locale )
+	).length;
+};
 
 /**
  * Checks if there are any subheadings like h2 in the text
- * and if they have the keyword in them.
+ * and if they have the key phrase and the keywords' respective morphological forms in them.
+ *
+ * Also checks for synonyms.
  *
  * @param {object} paper The paper object containing the text and keyword.
+ * @param {Researcher} researcher The researcher object.
  * @returns {object} the result object.
  */
-export default function( paper ) {
-	var text = paper.getText();
-	var keyword = escapeRegExp( paper.getKeyword() );
-	var locale = paper.getLocale();
-	var result = { count: 0 };
+export default function( paper, researcher ) {
+	let text = paper.getText();
+	let topicForms = researcher.getResearch( "morphology" );
+	let locale = paper.getLocale();
+	let result = { count: 0 };
 	text = stripSomeTags( text );
-	var matches = getSubheadingContents( text );
+	let matches = getSubheadingContents( text );
 
 	if ( 0 !== matches.length ) {
 		result.count = matches.length;
-		result.matches = subheadingMatch( matches, keyword, locale );
+		result.matches = numberOfsubheadingsReflectingTopic( matches, topicForms.keyphraseForms, locale );
+
+		result.matches = topicForms.synonymsForms.reduce(
+			( sum, keyphraseForms ) => sum + numberOfsubheadingsReflectingTopic( matches, keyphraseForms, locale )
+			, result.matches
+		);
 	}
 
 	return result;

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -28,12 +28,11 @@ const subheadingReflectsTopic = function( subheading, keyphraseForms, locale ) {
  * Computes the amount of subheadings reflecting the topic.
  *
  * @param {String[]} subheadings the subheadings to check.
- * @param {Object} topicForms the key words and their forms to check.
+ * @param {Object} topicForms the main key phrase and its synonyms to check.
  * @param {String} locale the current locale.
  * @returns {Number} the amount of subheadings reflecting the topic.
  */
 const numberOfsubheadingsReflectingTopic = function( subheadings, topicForms, locale ) {
-	// Number of headers reflecting the main key phrase.
 	return subheadings.filter(
 		subheading => {
 			const reflectsMainTopic = subheadingReflectsTopic( subheading, topicForms.keyphraseForms, locale );
@@ -62,11 +61,11 @@ export default function( paper, researcher ) {
 	const locale = paper.getLocale();
 	const result = { count: 0 };
 	text = stripSomeTags( text );
-	const matches = getSubheadingContents( text );
+	const subheadings = getSubheadingContents( text );
 
-	if ( 0 !== matches.length ) {
-		result.count = matches.length;
-		result.matches = numberOfsubheadingsReflectingTopic( matches, topicForms, locale );
+	if ( 0 !== subheadings.length ) {
+		result.count = subheadings.length;
+		result.matches = numberOfsubheadingsReflectingTopic( subheadings, topicForms, locale );
 	}
 
 	return result;

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -28,14 +28,22 @@ const subheadingReflectsTopic = function( subheading, keyphraseForms, locale ) {
  * Computes the amount of subheadings reflecting the topic.
  *
  * @param {String[]} subheadings the subheadings to check.
- * @param {Array<String[]>} keyphraseForms the key words and their forms to check.
+ * @param {Object} topicForms the key words and their forms to check.
  * @param {String} locale the current locale.
  * @returns {Number} the amount of subheadings reflecting the topic.
  */
-const numberOfsubheadingsReflectingTopic = function( subheadings, keyphraseForms, locale ) {
+const numberOfsubheadingsReflectingTopic = function( subheadings, topicForms, locale ) {
+	// Number of headers reflecting the main key phrase.
 	return subheadings.filter(
-		subheading => subheadingReflectsTopic( subheading, keyphraseForms, locale )
+		subheading => {
+			const reflectsMainTopic = subheadingReflectsTopic( subheading, topicForms.keyphraseForms, locale );
+			const reflectsSynonym = topicForms.synonymsForms.some(
+				synonymForm => subheadingReflectsTopic( subheading, synonymForm, locale )
+			);
+			return reflectsMainTopic || reflectsSynonym;
+		}
 	).length;
+
 };
 
 /**
@@ -58,12 +66,7 @@ export default function( paper, researcher ) {
 
 	if ( 0 !== matches.length ) {
 		result.count = matches.length;
-		result.matches = numberOfsubheadingsReflectingTopic( matches, topicForms.keyphraseForms, locale );
-
-		result.matches = topicForms.synonymsForms.reduce(
-			( sum, keyphraseForms ) => sum + numberOfsubheadingsReflectingTopic( matches, keyphraseForms, locale )
-			, result.matches
-		);
+		result.matches = numberOfsubheadingsReflectingTopic( matches, topicForms, locale );
 	}
 
 	return result;

--- a/src/stringProcessing/subheadingsMatch.js
+++ b/src/stringProcessing/subheadingsMatch.js
@@ -1,17 +1,17 @@
 import replaceString from "../stringProcessing/replaceString.js";
 import removalWordsFactory from "../config/removalWords.js";
 const removalWords = removalWordsFactory();
-import matchTextWithWord from "../stringProcessing/matchTextWithWord.js";
+import matchTextWithArray from "../stringProcessing/matchTextWithArray.js";
 
 /**
  * Matches the keyword in an array of strings
  *
  * @param {Array} matches The array with the matched headings.
- * @param {String} keyword The keyword to match
+ * @param {String[]} keywordForms The array of keyword forms to match
  * @param {string} locale The locale used for transliteration.
  * @returns {number} The number of occurrences of the keyword in the headings.
  */
-export default function( matches, keyword, locale ) {
+export default function( matches, keywordForms, locale ) {
 	let foundInHeader = -1;
 
 	if ( matches !== null ) {
@@ -22,8 +22,8 @@ export default function( matches, keyword, locale ) {
 				matches[ i ], removalWords
 			);
 			if (
-				matchTextWithWord( formattedHeaders, keyword, locale ).count > 0 ||
-				matchTextWithWord( matches[ i ], keyword, locale ).count > 0
+				matchTextWithArray( formattedHeaders, keywordForms, locale ).count > 0 ||
+				matchTextWithArray( matches[ i ], keywordForms, locale ).count > 0
 			) {
 				foundInHeader++;
 			}

--- a/src/stringProcessing/subheadingsMatch.js
+++ b/src/stringProcessing/subheadingsMatch.js
@@ -17,7 +17,7 @@ export default function( matches, keywordForms, locale ) {
 	if ( matches !== null ) {
 		foundInHeader = 0;
 		for ( let i = 0; i < matches.length; i++ ) {
-			// TODO: This replaceString call seemingly doesn't work, as no replacement value is being sent to the .replace method in replaceString
+			// NOTE: This replaceString call seemingly doesn't work, as no replacement value is being sent to the .replace method in replaceString
 			const formattedHeaders = replaceString(
 				matches[ i ], removalWords
 			);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the subheadings keyword assessment to also take the morphological forms of the key words into account. Also adds limits to make sure that at least 30%, but no more than 75% of subheadings reflect the topic of an article.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Open a new post in WordPress.
* Enter four words as your keyphrase.
* Enter a text with headers (e.g. `<h1>` or `<h2>`)
* In the header:
      1. Enter two of the four keywords into the header.
          * The header should not be counted in the subheadings keyword assessment.
      2. Enter three of the four keywords into the header.
          * The header should be counted.
      3. Repeat steps 1 and 2, but now for different morphological forms of the keywords (e.g. plural or singular forms). The results should not change. 
* By `counted` the general schema of the assessment should be understood.
  * GOOD if 30-75% of subheadings reflect the topic,
  * GOOD if the only subheading in the text reflects the topic,
  * BAD if less than 30% or more than 75% of subheadings reflect the topic.

Fixes #1756 
