### PR TITLE
Refactor Polish participle direct precedence exceptions to not use Re…

### DIFF
--- a/spec/researches/polish/passiveVoice/PolishParticipleSpec.js
+++ b/spec/researches/polish/passiveVoice/PolishParticipleSpec.js
@@ -1,5 +1,6 @@
 const PolishParticiple = require( "../../../../js/researches/polish/passiveVoice/PolishParticiple.js" );
 const checkException = require( "../../../../js/researches/passiveVoice/periphrastic/checkException.js" );
+const getWords = require( "../../../../src/stringProcessing/getWords" );
 
 describe( "A test for checking the Polish participle", function() {
 	it( "checks the properties of the Polish participle object with a passive", function() {
@@ -8,31 +9,36 @@ describe( "A test for checking the Polish participle", function() {
 			type: "irregular",
 			language: "pl",
 		} );
+		const wordsInSentencePart = getWords( mockParticiple._sentencePart );
+
 		expect( mockParticiple.getParticiple() ).toBe( "napisana" );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 12, "pl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( wordsInSentencePart, 2, "pl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
 	it( "checks the properties of the Polish participle object with a direct precedence exception", function() {
 		// Direct precedence exception word: il.
-		let mockParticiple = new PolishParticiple( "znalezione", "To są nasze znalezione skarby.", {
+		const mockParticiple = new PolishParticiple( "znalezione", "To są nasze znalezione skarby.", {
 			auxiliaries: [ "są" ],
 			type: "irregular",
 			language: "pl",
 		} );
+		const wordsInSentencePart = getWords( mockParticiple._sentencePart );
+
 		expect( mockParticiple.getParticiple() ).toBe( "znalezione" );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 12, "pl" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( wordsInSentencePart, 3, "pl" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		let mockParticiple = new PolishParticiple( "napisana", "została już napisana.", {
+		const mockParticiple = new PolishParticiple( "napisana", "została już napisana.", {
 			auxiliaries: [ "została" ],
 			type: "irregular",
 			language: "pl",
 		} );
 		mockParticiple._participle = null;
 		checkException.call( mockParticiple );
+
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 } );

--- a/src/researches/polish/passiveVoice/PolishParticiple.js
+++ b/src/researches/polish/passiveVoice/PolishParticiple.js
@@ -1,6 +1,7 @@
 const Participle = require( "../../../values/Participle.js" );
 const checkException = require( "../../passiveVoice/periphrastic/checkException.js" );
-const directPrecedenceException = require( "../../../stringProcessing/directPrecedenceException" );
+const directPrecedenceException = require( "../../../stringProcessing/directPrecedenceExceptionWithoutRegex" );
+const getWords = require( "../../../stringProcessing/getWords" );
 const nonDirectPrecedenceException = require( "../../passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/nonDirectParticiplePrecedenceException" );
 
 /**
@@ -30,10 +31,11 @@ PolishParticiple.prototype.isPassive = function() {
 	const participle = this.getParticiple();
 	const auxiliaries = this.getAuxiliaries();
 
-	const participleIndex = sentencePart.indexOf( this.getParticiple() );
+	const wordsInSentencePart = getWords( sentencePart );
+	const participleIndex = wordsInSentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
-	return ! this.directPrecedenceException( sentencePart, participleIndex, language ) &&
+	return ! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
 		! this.nonDirectPrecedenceException( sentencePart, participle, auxiliaries, language );
 };
 

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -1,0 +1,36 @@
+import cannotDirectlyPrecedePassiveParticiplePolishFactory from "../researches/polish/functionWords.js";
+const cannotDirectlyPrecedePassiveParticiplePolish = cannotDirectlyPrecedePassiveParticiplePolishFactory().cannotDirectlyPrecedePassiveParticiple;
+
+/**
+ * Checks whether the participle is directly preceded by a word from the direct precedence exception list.
+ * If this is the case, the sentence part is not passive.
+ *
+ * @param {string[]} wordsInSentencePart The words in the sentence part that contains the participle.
+ * @param {number}   participleIndex     The index of the participle.
+ * @param {string}   language            The language of the participle.
+ *
+ * @returns {boolean} Returns true if a word from the direct precedence exception list is directly preceding
+ * the participle, otherwise returns false.
+ */
+export default function( wordsInSentencePart, participleIndex, language ) {
+	// If the participle is the first word, there can't be a word before that.
+	if ( participleIndex === 0 ) {
+		return false;
+	}
+	const wordPrecedingParticiple = wordsInSentencePart[ participleIndex - 1 ];
+
+	let directPrecedenceExceptions = [];
+	switch ( language ) {
+		case "pl":
+			directPrecedenceExceptions = cannotDirectlyPrecedePassiveParticiplePolish;
+			break;
+	}
+
+	for ( let i = 0; i < directPrecedenceExceptions.length; i++ ) {
+		if ( directPrecedenceExceptions[ i ].includes( wordPrecedingParticiple ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -1,5 +1,4 @@
-import cannotDirectlyPrecedePassiveParticiplePolishFactory from "../researches/polish/functionWords.js";
-const cannotDirectlyPrecedePassiveParticiplePolish = cannotDirectlyPrecedePassiveParticiplePolishFactory().cannotDirectlyPrecedePassiveParticiple;
+const cannotDirectlyPrecedePassiveParticiplePolish = require( "../researches/polish/functionWords.js" )().cannotDirectlyPrecedePassiveParticiple;
 
 /**
  * Checks whether the participle is directly preceded by a word from the direct precedence exception list.
@@ -12,7 +11,7 @@ const cannotDirectlyPrecedePassiveParticiplePolish = cannotDirectlyPrecedePassiv
  * @returns {boolean} Returns true if a word from the direct precedence exception list is directly preceding
  * the participle, otherwise returns false.
  */
-export default function( wordsInSentencePart, participleIndex, language ) {
+module.exports = function( wordsInSentencePart, participleIndex, language ) {
 	// If the participle is the first word, there can't be a word before that.
 	if ( participleIndex === 0 ) {
 		return false;
@@ -33,4 +32,4 @@ export default function( wordsInSentencePart, participleIndex, language ) {
 	}
 
 	return false;
-}
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Simplify the lookup of the Polish participle direct precedence exceptions.

## Relevant technical choices:

* Replace the giant RegExp with a for loop with includes in array check.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`.
* Combine with `wordpress-seo`.
* In Chrome on Windows, create a post with the following: `została założona` (an auxiliary followed by a participle; could be any combination that are included in the lists).

Fixes https://github.com/Yoast/wordpress-seo/issues/11011
