### PR TITLE
Change feedback strings for readability assessments

### DIFF
--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -51,7 +51,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 55.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 6 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 55 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 55 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>." );
 	} );
 
 	it( "returns a 'difficult' score for a paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
@@ -59,7 +59,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 45 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 45 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a paper.", function() {
@@ -67,7 +67,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 36.6 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 36.6 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 36.6 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a 'very difficult' score and the associated feedback text for a paper.", function() {
@@ -75,7 +75,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a 'very easy' score and the associated feedback text for a Russian paper.", function() {
@@ -131,7 +131,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 6 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 45 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 45 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>." );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -139,7 +139,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 35.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 35 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 35 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -147,7 +147,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 26.6 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 26.6 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 26.6 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a 'very difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -155,7 +155,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a feedback text containing '100' for a paper with a flesch score above 100.", function() {
@@ -171,7 +171,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( -3.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>." );
 	} );
 
 	it( "returns a null result for the assessment for an Afrikaans paper with text.", function() {

--- a/spec/assessments/fleschReadingEaseSpec.js
+++ b/spec/assessments/fleschReadingEaseSpec.js
@@ -11,7 +11,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 100.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 100 in the test, which is considered very easy to read. Good job!" );
 	} );
 
 	it( "returns an 'easy' score and the associated feedback text for a paper.", function() {
@@ -19,7 +19,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 82.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 82 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 82 in the test, which is considered easy to read. Good job!" );
 	} );
 
 	it( "returns a 'fairly easy' score and the associated feedback text for a paper.", function() {
@@ -27,7 +27,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 78.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 78.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 78.9 in the test, which is considered fairly easy to read. Good job!" );
 	} );
 
 	it( "returns an 'ok' score and the associated feedback text for a paper.", function() {
@@ -35,7 +35,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 63.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 63.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 63.9 in the test, which is considered ok to read. Good job!" );
 	} );
 
 	it( "returns an 'ok' score and the associated feedback text for a paper.", function() {
@@ -43,7 +43,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 60.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 60 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 60 in the test, which is considered ok to read. Good job!" );
 	} );
 
 	it( "returns a 'fairly difficult' score and the associated feedback text for a paper.", function() {
@@ -51,7 +51,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 55.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 6 );
-		expect( result.getText() ).toBe( "The copy scores 55 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 55 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability.</a>" );
 	} );
 
 	it( "returns a 'difficult' score for a paper with the score between 40 and 50, and the associated feedback text for a paper.", function() {
@@ -59,7 +59,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 45 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 45 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a paper.", function() {
@@ -67,7 +67,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 36.6 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 36.6 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 36.6 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a 'very difficult' score and the associated feedback text for a paper.", function() {
@@ -75,7 +75,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a 'very easy' score and the associated feedback text for a Russian paper.", function() {
@@ -83,7 +83,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 100.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 100 in the test, which is considered very easy to read. Good job!" );
 	} );
 
 	it( "returns a 'very easy' score and the associated feedback text for a Russian paper.", function() {
@@ -91,7 +91,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 85 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 85 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 85 in the test, which is considered very easy to read. Good job!" );
 	} );
 
 	it( "returns an 'easy' score and the associated feedback text for a Russian paper.", function() {
@@ -99,7 +99,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 72.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 72 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 72 in the test, which is considered easy to read. Good job!" );
 	} );
 
 	it( "returns a 'fairly easy' score and the associated feedback text for a Russian paper.", function() {
@@ -107,7 +107,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 68.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 68.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 68.9 in the test, which is considered fairly easy to read. Good job!" );
 	} );
 
 	it( "returns an 'ok' score and the associated feedback text for a Russian paper.", function() {
@@ -115,7 +115,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 53.9 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 53.9 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 53.9 in the test, which is considered ok to read. Good job!" );
 	} );
 
 	it( "returns an 'ok' score and the associated feedback text for a Russian paper.", function() {
@@ -123,7 +123,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 50.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 50 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 50 in the test, which is considered ok to read. Good job!" );
 	} );
 
 	it( "returns a 'fairly difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -131,7 +131,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 45.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 6 );
-		expect( result.getText() ).toBe( "The copy scores 45 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 45 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability.</a>" );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -139,7 +139,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 35.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 35 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 35 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a 'difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -147,7 +147,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 26.6 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 26.6 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 26.6 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a 'very difficult' score and the associated feedback text for a Russian paper.", function() {
@@ -155,7 +155,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a feedback text containing '100' for a paper with a flesch score above 100.", function() {
@@ -163,7 +163,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( 103.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "The copy scores 100 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very easy to read. " );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 100 in the test, which is considered very easy to read. Good job!" );
 	} );
 
 	it( "returns a feedback text containing '0' for a paper with a flesch score under 0.", function() {
@@ -171,7 +171,7 @@ describe( "An assessment for the flesch reading", function() {
 		const result = new FleschReadingAssessment( contentConfiguration( paper.getLocale() ).fleschReading ).getResult( paper, factory.buildMockResearcher( -3.0 ), i18n );
 
 		expect( result.getScore() ).toBe( 3 );
-		expect( result.getText() ).toBe( "The copy scores 0 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0 in the test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability.</a>" );
 	} );
 
 	it( "returns a null result for the assessment for an Afrikaans paper with text.", function() {

--- a/spec/assessments/paragraphTooLongSpec.js
+++ b/spec/assessments/paragraphTooLongSpec.js
@@ -9,41 +9,41 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 	it( "scores 1 paragraph with ok length", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "None of the paragraphs are too long, which is great." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs are too long. Great job!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 	it( "scores 1 slightly too long paragraph", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 160, text: "" } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "1 of the paragraphs contains more than the recommended maximum of 150 words. " +
-			"Are you sure all information is about the same topic, and therefore belongs in one single paragraph?" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended maximum of 150 words." +
+			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "scores 1 extremely long paragraph", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 6000, text: "" } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "1 of the paragraphs contains more than the recommended maximum of 150 words. " +
-			"Are you sure all information is about the same topic, and therefore belongs in one single paragraph?" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended maximum of 150 words." +
+			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "scores 3 paragraphs with ok length", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" }, { wordCount: 71, text: "" }, { wordCount: 83, text: "" } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "None of the paragraphs are too long, which is great." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs are too long. Great job!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 	it( "scores 3 paragraphs, one of which is too long", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" }, { wordCount: 71, text: "" }, { wordCount: 183, text: "" } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "1 of the paragraphs contains more than the recommended maximum of 150 words. " +
-			"Are you sure all information is about the same topic, and therefore belongs in one single paragraph?" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended maximum of 150 words." +
+			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "scores 3 paragraphs, two of which are too long", function() {
 		var assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" }, { wordCount: 191, text: "" }, { wordCount: 183, text: "" } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "2 of the paragraphs contain more than the recommended maximum of 150 words. Are you sure " +
-			"all information within each of these paragraphs is about the same topic, and therefore belongs in a single paragraph?" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 2 of the paragraphs contain more than the recommended maximum of 150 words." +
+			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns an empty assessment result for a paper without paragraphs.", function() {

--- a/spec/assessments/passiveVoiceAssessmentSpec.js
+++ b/spec/assessments/passiveVoiceAssessmentSpec.js
@@ -9,47 +9,44 @@ describe( "An assessment for scoring passive voice.", function() {
 	it( "scores 0 passive sentences - 0%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [] } ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "0% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
-			"which is less than or equal to the recommended maximum of 10%." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!" );
 	} );
 
 	it( "scores 1 passive sentence - 5%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1 ] } ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "5% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
-			"which is less than or equal to the recommended maximum of 10%." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
 	it( "scores 2 passive sentences - 10%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2 ] } ), i18n );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "10% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
-			"which is less than or equal to the recommended maximum of 10%." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
 	it( "scores 10 passive sentence - 50%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] } ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "50% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
-			"which is more than the recommended maximum of 10%. Try to use their active counterparts." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 50% of the sentences contain passive voice, which is more than the recommended maximum of 10%. " +
+			"<a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
 	it( "scores 5 passive sentences - 25%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2, 3, 4, 5 ] } ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "25% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
-			"which is more than the recommended maximum of 10%. Try to use their active counterparts." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 25% of the sentences contain passive voice, which is more than the recommended maximum of 10%. " +
+			"<a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
 	it( "scores 5 passive sentences - 13.3%", function() {
 		var assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 30, passives: [ 1, 2, 3, 4 ] } ), i18n );
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "13.3% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, " +
-			"which is more than the recommended maximum of 10%. Try to use their active counterparts." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.3% of the sentences contain passive voice, which is more than the recommended maximum of 10%. " +
+			"<a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 } );

--- a/spec/assessments/sentenceBeginningsSpec.js
+++ b/spec/assessments/sentenceBeginningsSpec.js
@@ -10,42 +10,46 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 }, { word: "cup", count: 2 }, { word: "laptop", count: 1 },
 			{ word: "table", count: 4 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The text contains 4 consecutive sentences starting with the same word. Try to mix things up!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: The text contains 4 consecutive sentences starting with the same word." +
+			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
 	} );
 
 	it( "scores two instance with too many consecutive English sentences starting with the same word, 5 being the lowest count.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 }, { word: "banana", count: 6 }, { word: "pencil", count: 1 },
 			{ word: "bottle", count: 5 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The text contains 2 instances where 5 or more consecutive sentences start with the same word. Try to mix things up!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
+			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
 	} );
 
 	it( "scores zero instance with too many consecutive English sentences starting with the same word.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 1 }, { word: "telephone", count: 2 }, { word: "towel", count: 2 },
 			{ word: "couch", count: 1 } ] ), i18n );
-		expect( assessment.getScore() ).toBe( 0 );
-		expect( assessment.getText() ).toBe( "" );
+		expect( assessment.getScore() ).toBe( 9 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!" );
 	} );
 
 	it( "scores one instance with 4 consecutive German sentences starting with the same word.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 }, { word: "Stuhl", count: 2 }, { word: "Banane", count: 1 },
 			{ word: "Tafel", count: 4 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The text contains 4 consecutive sentences starting with the same word. Try to mix things up!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: The text contains 4 consecutive sentences starting with the same word." +
+			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
 	} );
 
 	it( "scores two instance with too many consecutive German sentences starting with the same word, 5 being the lowest count.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 }, { word: "Banane", count: 6 }, { word: "Blatt", count: 1 },
 			{ word: "Schloss", count: 5 } ] ), i18n );
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "The text contains 2 instances where 5 or more consecutive sentences start with the same word. Try to mix things up!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
+			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
 	} );
 
 	it( "scores zero instance with too many consecutive German sentences starting with the same word.", function() {
 		var assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 1 }, { word: "Telefon", count: 2 }, { word: "Hund", count: 2 },
 			{ word: "Haus", count: 1 } ] ), i18n );
-		expect( assessment.getScore() ).toBe( 0 );
-		expect( assessment.getText() ).toBe( "" );
+		expect( assessment.getScore() ).toBe( 9 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!" );
 	} );
 
 	it( "is not applicable for a paper without text.", function() {

--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -21,8 +21,7 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is less than or equal to the recommended maximum of 25%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -35,8 +34,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "50% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"50% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -48,8 +48,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -64,8 +65,7 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "25% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is less than or equal to the recommended maximum of 25%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -86,8 +86,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "30% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"30% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -101,8 +102,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 15 words</a>, " +
-			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -116,8 +118,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
-			"which is more than the recommended maximum of 25%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -132,8 +135,7 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 25 words</a>, " +
-			"which is less than or equal to the recommended maximum of 25%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -148,8 +150,7 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "0% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is less than or equal to the recommended maximum of 15%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -163,8 +164,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "100% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 15%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -187,8 +189,7 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "10% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is less than or equal to the recommended maximum of 15%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -205,12 +206,13 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "25% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 15%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"25% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 15% long sentences in Polish", function() {
+	it( "returns the score for 20% long sentences in Polish", function() {
 		mockPaper = new Paper( "text", { locale: "pl_PL" } );
 		let sentenceLengthInTextAssessmentPolish = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
 
@@ -239,8 +241,9 @@ describe( "An assessment for sentence length", function() {
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "20% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, " +
-			"which is more than the recommended maximum of 15%. Try to shorten the sentences." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"20% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 

--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -19,7 +19,8 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "You are not using any <a href='https://yoa.st/headings' target='_blank'>subheadings</a>, but your text is short enough and probably doesn't need them." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+			"You are not using any subheadings, but your text is short enough and probably doesn't need them." );
 	} );
 
 	it( "Scores a short text (<300 words), which has subheadings.", function() {
@@ -29,7 +30,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "Great job with using <a href='https://yoa.st/headings' target='_blank'>subheadings</a>!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
 	} );
 
 	it( "Scores a long text (>300 words), which does not have subheadings.", function() {
@@ -39,7 +40,8 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 2 );
-		expect( assessment.getText() ).toBe( "You are not using any subheadings, although your text is rather long. Try and add  some <a href='https://yoa.st/headings' target='_blank'>subheadings</a>." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+			"You are not using any subheadings, although your text is rather long. <a href='https://yoa.st/34y' target='_blank'>Try and add some subheadings</a>." );
 	} );
 
 	it( "Scores a long text (>300 words), which has subheadings and all sections of the text are <300 words.", function() {
@@ -49,7 +51,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "Great job with using <a href='https://yoa.st/headings' target='_blank'>subheadings</a>!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
 	} );
 
 	it( "Scores a long text (>300 words), which has subheadings and all sections of the text are <300 words, except for one, which is between 300 and 350 words long.", function() {
@@ -59,7 +61,9 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "1 section of your text is longer than 300 words and is not separated by any subheadings. Add <a href='https://yoa.st/headings' target='_blank'>subheadings</a> to improve readability." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+			"1 section of your text is longer than 300 words and is not separated by any subheadings." +
+			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
 	} );
 
 	it( "Scores a long text (>300 words), which has subheadings and all sections of the text are <300 words, except for two, which are between 300 and 350 words long.", function() {
@@ -69,7 +73,9 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "2 sections of your text are longer than 300 words and are not separated by any subheadings. Add <a href='https://yoa.st/headings' target='_blank'>subheadings</a> to improve readability." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+			"2 sections of your text are longer than 300 words and are not separated by any subheadings." +
+			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
 	} );
 
 	it( "Scores a long text (>300 words), which has subheadings and all sections of the text are <300 words, except for one, which is above 350 words long.", function() {
@@ -79,7 +85,9 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "1 section of your text is longer than 300 words and is not separated by any subheadings. Add <a href='https://yoa.st/headings' target='_blank'>subheadings</a> to improve readability." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+			"1 section of your text is longer than 300 words and is not separated by any subheadings." +
+			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
 	} );
 
 	it( "Scores a long text (>300 words), which has subheadings and some sections of the text are above 350 words long.", function() {
@@ -89,7 +97,9 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "2 sections of your text are longer than 300 words and are not separated by any subheadings. Add <a href='https://yoa.st/headings' target='_blank'>subheadings</a> to improve readability." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+			"2 sections of your text are longer than 300 words and are not separated by any subheadings." +
+			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
 	} );
 
 

--- a/spec/assessments/textPresenceSpec.js
+++ b/spec/assessments/textPresenceSpec.js
@@ -9,7 +9,8 @@ describe( "Assesses presence of text", function() {
 		var assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "You have far too little content, please add some content to enable a good analysis." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/35h' target='_blank'>Not enough content</a>:" +
+			" <a href='https://yoa.st/35i' target='_blank'>Please add some content to enable a good analysis</a>." );
 	} );
 
 	it( "returns a score of 0 and an empty feedback string for a text over 50 words", function() {

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -13,8 +13,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 0%" +
-			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"None of the sentences contain transition words. <a href='https://yoa.st/35a' target='_blank'>Use some</a>." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -24,8 +24,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 0%" +
-			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"None of the sentences contain transition words. <a href='https://yoa.st/35a' target='_blank'>Use some</a>." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -35,8 +35,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 10%" +
-			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"Only 10% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 20.0% of the sentences with transition words", function() {
@@ -45,8 +45,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20%" +
-			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"Only 20% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 25.0% of the sentences with transition words", function() {
@@ -55,8 +55,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25%" +
-			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"Only 25% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 35.0% of the sentences with transition words", function() {

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -13,8 +13,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "0% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 0%" +
+			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -24,8 +24,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "0% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 0%" +
+			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -35,8 +35,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "10% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 10%" +
+			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 20.0% of the sentences with transition words", function() {
@@ -45,8 +45,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "20% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20%" +
+			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 25.0% of the sentences with transition words", function() {
@@ -55,8 +55,8 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "25% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is less than the recommended minimum of 30%." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25%" +
+			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 35.0% of the sentences with transition words", function() {
@@ -64,8 +64,7 @@ describe( "An assessment for transition word percentage", function() {
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 20,
 			transitionWordSentences: 7 } ), i18n );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "35% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is great." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 40% sentences with transition words", function() {
@@ -73,8 +72,7 @@ describe( "An assessment for transition word percentage", function() {
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
 			transitionWordSentences: 4 } ), i18n );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "40% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is great." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -83,8 +81,7 @@ describe( "An assessment for transition word percentage", function() {
 		assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 100,
 			transitionWordSentences: 47 } ), i18n );
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "47% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is great." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
@@ -94,8 +91,7 @@ describe( "An assessment for transition word percentage", function() {
 			transitionWordSentences: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "66.7% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> " +
-			"or phrase, which is great." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 

--- a/spec/assessments/transitionWordsSpec.js
+++ b/spec/assessments/transitionWordsSpec.js
@@ -14,7 +14,7 @@ describe( "An assessment for transition word percentage", function() {
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 0%" +
-			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -25,7 +25,7 @@ describe( "An assessment for transition word percentage", function() {
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 0%" +
-			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
@@ -36,7 +36,7 @@ describe( "An assessment for transition word percentage", function() {
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 10%" +
-			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 20.0% of the sentences with transition words", function() {
@@ -46,7 +46,7 @@ describe( "An assessment for transition word percentage", function() {
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20%" +
-			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 25.0% of the sentences with transition words", function() {
@@ -56,7 +56,7 @@ describe( "An assessment for transition word percentage", function() {
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25%" +
-			" of the sentences contain them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
+			" of the sentences contain them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns the score for 35.0% of the sentences with transition words", function() {

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -142,8 +142,7 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 28.6% of the sentences contain" +
-		" them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 28.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -133,7 +133,8 @@ const expectedResults = {
 	},
 	textParagraphTooLong: {
 		score: 3,
-		resultText: "1 of the paragraphs contains more than the recommended maximum of 150 words. Are you sure all information is about the same topic, and therefore belongs in one single paragraph?",
+		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended maximum of 150 words." +
+		" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		score: 9,
@@ -145,15 +146,15 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		score: 9,
-		resultText: "7.1% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, which is less than or equal to the recommended maximum of 10%.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
 	},
 	textPresence: {
 		score: 0,
 		resultText: "",
 	},
 	sentenceBeginnings: {
-		score: 0,
-		resultText: "",
+		score: 9,
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
 	},
 };
 

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -143,7 +143,7 @@ const expectedResults = {
 	textTransitionWords: {
 		score: 6,
 		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 28.6% of the sentences contain" +
-		" them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>.",
+		" them. This is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>.",
 	},
 	passiveVoice: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -129,7 +129,7 @@ const expectedResults = {
 	},
 	subheadingsTooLong: {
 		score: 9,
-		resultText: "Great job with using <a href='https://yoa.st/headings' target='_blank'>subheadings</a>!",
+		resultText: "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!",
 	},
 	textParagraphTooLong: {
 		score: 3,
@@ -138,11 +138,12 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		score: 9,
-		resultText: "4.8% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, which is less than or equal to the recommended maximum of 25%.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		score: 6,
-		resultText: "28.6% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> or phrase, which is less than the recommended minimum of 30%.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 28.6% of the sentences contain" +
+		" them, this is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more transition words</a>.",
 	},
 	passiveVoice: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -125,7 +125,7 @@ const expectedResults = {
 	},
 	fleschReadingEase: {
 		score: 9,
-		resultText: "The copy scores 78.7 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. ",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 78.7 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -118,7 +118,9 @@ const expectedResults = {
 	},
 	subheadingsTooLong: {
 		score: 3,
-		resultText: "2 sections of your text are longer than 300 words and are not separated by any subheadings. Add <a href='https://yoa.st/headings' target='_blank'>subheadings</a> to improve readability.",
+		resultText: "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+		"2 sections of your text are longer than 300 words and are not separated by any subheadings." +
+		" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>.",
 	},
 	textParagraphTooLong: {
 		score: 9,
@@ -126,11 +128,11 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		score: 9,
-		resultText: "15.8% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, which is less than or equal to the recommended maximum of 25%.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		score: 9,
-		resultText: "42.2% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> or phrase, which is great.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -114,7 +114,7 @@ const expectedResults = {
 	},
 	fleschReadingEase: {
 		score: 9,
-		resultText: "The copy scores 75.1 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered fairly easy to read. ",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 75.1 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		score: 3,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -122,7 +122,7 @@ const expectedResults = {
 	},
 	textParagraphTooLong: {
 		score: 9,
-		resultText: "None of the paragraphs are too long, which is great.",
+		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs are too long. Great job!",
 	},
 	textSentenceLength: {
 		score: 9,
@@ -134,15 +134,15 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		score: 9,
-		resultText: "0% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, which is less than or equal to the recommended maximum of 10%.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
 	},
 	textPresence: {
 		score: 0,
 		resultText: "",
 	},
 	sentenceBeginnings: {
-		score: 0,
-		resultText: "",
+		score: 9,
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
 	},
 };
 

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -118,7 +118,7 @@ const expectedResults = {
 	},
 	textParagraphTooLong: {
 		score: 9,
-		resultText: "None of the paragraphs are too long, which is great.",
+		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs are too long. Great job!",
 	},
 	textSentenceLength: {
 		score: 9,
@@ -130,15 +130,15 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		score: 9,
-		resultText: "4.8% of the sentences contain <a href='https://yoa.st/passive-voice' target='_blank'>passive voice</a>, which is less than or equal to the recommended maximum of 10%.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
 	},
 	textPresence: {
 		score: 0,
 		resultText: "",
 	},
 	sentenceBeginnings: {
-		score: 0,
-		resultText: "",
+		score: 9,
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
 	},
 };
 

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -110,7 +110,7 @@ const expectedResults = {
 
 	fleschReadingEase: {
 		score: 9,
-		resultText: "The copy scores 63.8 in the <a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a> test, which is considered ok to read. ",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 63.8 in the test, which is considered ok to read. Good job!",
 	},
 	subheadingsTooLong: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -114,7 +114,7 @@ const expectedResults = {
 	},
 	subheadingsTooLong: {
 		score: 9,
-		resultText: "Great job with using <a href='https://yoa.st/headings' target='_blank'>subheadings</a>!",
+		resultText: "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!",
 	},
 	textParagraphTooLong: {
 		score: 9,
@@ -122,11 +122,11 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		score: 9,
-		resultText: "17.9% of the sentences contain <a href='https://yoa.st/short-sentences' target='_blank'>more than 20 words</a>, which is less than or equal to the recommended maximum of 25%.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		score: 9,
-		resultText: "40.5% of the sentences contain a <a href='https://yoa.st/transition-words' target='_blank'>transition word</a> or phrase, which is great.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		score: 9,

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -1,6 +1,7 @@
 import AssessmentResult from "../../values/AssessmentResult.js";
 import Assessment from "../../assessment.js";
 import { inRange } from "lodash-es";
+import { merge } from "lodash-es";
 
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
 
@@ -16,8 +17,13 @@ class FleschReadingEaseAssessment extends Assessment {
 	constructor( config ) {
 		super();
 
+		const defaultConfig = {
+			urlTitle: "<a href='https://yoa.st/34r' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34s' target='_blank'>",
+		};
+
 		this.identifier = "fleschReadingEase";
-		this._config = config;
+		this._config = merge( defaultConfig, config );
 	}
 
 	/**
@@ -59,22 +65,19 @@ class FleschReadingEaseAssessment extends Assessment {
 			this.fleschReadingResult = 100;
 		}
 
-		/* Translators: %1$s expands to the numeric Flesch reading ease score,
-		%2$s to a link to a Yoast.com article about Flesch reading ease score,
-		%3$s to the easyness of reading,
-		%4$s expands to a note about the flesch reading score. */
+		/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s and %7$s expand to the anchor end tag,
+		 %3$s expands to the numeric Flesch reading ease score, %4$s to the easiness of reading */
 		let text = i18n.dgettext(
 			"js-text-analysis",
-			"The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s"
+			"%1$sFlesch Reading Ease%2$s: The copy scores %3$s in the test, which is considered %4$s to read. %5$s%6$s%7$s"
 		);
-
-		const url = "<a href='https://yoa.st/flesch-reading' target='_blank'>Flesch Reading Ease</a>";
+		const noteGoodJob = i18n.dgettext( "js-text-analysis", "Good job!" );
 
 		if ( this.fleschReadingResult > this._config.borders.veryEasy ) {
 			const feedback = i18n.dgettext( "js-text-analysis", "very easy" );
 			return {
 				score: this._config.scores.veryEasy,
-				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback, "", noteGoodJob, "" ),
 			};
 		}
 
@@ -82,7 +85,7 @@ class FleschReadingEaseAssessment extends Assessment {
 			const feedback = i18n.dgettext( "js-text-analysis", "easy" );
 			return {
 				score: this._config.scores.easy,
-				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback, "", noteGoodJob, "" ),
 			};
 		}
 
@@ -90,7 +93,7 @@ class FleschReadingEaseAssessment extends Assessment {
 			const feedback = i18n.dgettext( "js-text-analysis", "fairly easy" );
 			return {
 				score: this._config.scores.fairlyEasy,
-				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback, "", noteGoodJob, "" ),
 			};
 		}
 
@@ -98,7 +101,7 @@ class FleschReadingEaseAssessment extends Assessment {
 			const feedback = i18n.dgettext( "js-text-analysis", "ok" );
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, "" ),
+				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback, "", noteGoodJob, "" ),
 			};
 		}
 
@@ -107,7 +110,8 @@ class FleschReadingEaseAssessment extends Assessment {
 			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences to improve readability." );
 			return {
 				score: this._config.scores.fairlyDifficult,
-				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, note ),
+				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback,
+					this._config.urlCallToAction, note, "</a>"  ),
 			};
 		}
 
@@ -116,7 +120,8 @@ class FleschReadingEaseAssessment extends Assessment {
 			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." );
 			return {
 				score: this._config.scores.difficult,
-				resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, note ),
+				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback,
+					this._config.urlCallToAction, note, "</a>" ),
 			};
 		}
 
@@ -124,7 +129,8 @@ class FleschReadingEaseAssessment extends Assessment {
 		const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." );
 		return {
 			score: this._config.scores.veryDifficult,
-			resultText: i18n.sprintf( text, this.fleschReadingResult, url, feedback, note ),
+			resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback,
+				this._config.urlCallToAction, note, "</a>" ),
 		};
 	}
 

--- a/src/assessments/readability/fleschReadingEaseAssessment.js
+++ b/src/assessments/readability/fleschReadingEaseAssessment.js
@@ -65,8 +65,12 @@ class FleschReadingEaseAssessment extends Assessment {
 			this.fleschReadingResult = 100;
 		}
 
-		/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s and %7$s expand to the anchor end tag,
-		 %3$s expands to the numeric Flesch reading ease score, %4$s to the easiness of reading */
+		/* Translators: %1$s and %5$s expand to a link on yoast.com,
+		%2$s to the anchor end tag,
+		%7$s expands to the anchor end tag and a full stop,
+		%3$s expands to the numeric Flesch reading ease score,
+		%4$s to the easiness of reading,
+		%6$s expands to a call to action based on the score */
 		let text = i18n.dgettext(
 			"js-text-analysis",
 			"%1$sFlesch Reading Ease%2$s: The copy scores %3$s in the test, which is considered %4$s to read. %5$s%6$s%7$s"
@@ -107,30 +111,30 @@ class FleschReadingEaseAssessment extends Assessment {
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.fairlyDifficult, this._config.borders.okay ) ) {
 			const feedback = i18n.dgettext( "js-text-analysis", "fairly difficult" );
-			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences to improve readability." );
+			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences to improve readability" );
 			return {
 				score: this._config.scores.fairlyDifficult,
 				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback,
-					this._config.urlCallToAction, note, "</a>"  ),
+					this._config.urlCallToAction, note, "</a>."  ),
 			};
 		}
 
 		if ( inRange( this.fleschReadingResult, this._config.borders.difficult, this._config.borders.fairlyDifficult ) ) {
 			const feedback = i18n.dgettext( "js-text-analysis", "difficult" );
-			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." );
+			const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability" );
 			return {
 				score: this._config.scores.difficult,
 				resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback,
-					this._config.urlCallToAction, note, "</a>" ),
+					this._config.urlCallToAction, note, "</a>." ),
 			};
 		}
 
 		const feedback = i18n.dgettext( "js-text-analysis", "very difficult" );
-		const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability." );
+		const note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability" );
 		return {
 			score: this._config.scores.veryDifficult,
 			resultText: i18n.sprintf( text, this._config.urlTitle, "</a>", this.fleschReadingResult, feedback,
-				this._config.urlCallToAction, note, "</a>" ),
+				this._config.urlCallToAction, note, "</a>." ),
 		};
 	}
 

--- a/src/assessments/readability/paragraphTooLongAssessment.js
+++ b/src/assessments/readability/paragraphTooLongAssessment.js
@@ -9,14 +9,14 @@ import { filter } from "lodash-es";
 import { map } from "lodash-es";
 
 // 150 is the recommendedValue for the maximum paragraph length.
-var recommendedValue = 150;
+const recommendedValue = 150;
 
 /**
  * Returns an array containing only the paragraphs longer than the recommended length.
  * @param {array} paragraphsLength The array containing the lengths of individual paragraphs.
  * @returns {number} The number of too long paragraphs.
  */
-var getTooLongParagraphs = function( paragraphsLength  ) {
+const getTooLongParagraphs = function( paragraphsLength  ) {
 	return filter( paragraphsLength, function( paragraph ) {
 		return isParagraphTooLong( recommendedValue, paragraph.wordCount );
 	} );
@@ -29,14 +29,16 @@ var getTooLongParagraphs = function( paragraphsLength  ) {
  * @param {object} i18n The i18n object used for translations.
  * @returns {{score: number, text: string }} the assessmentResult.
  */
-var calculateParagraphLengthResult = function( paragraphsLength, tooLongParagraphs, i18n ) {
-	var score;
+let calculateParagraphLengthResult = function( paragraphsLength, tooLongParagraphs, i18n ) {
+	let score;
+	let urlTitle = "<a href='https://yoa.st/35d' target='_blank'>";
+	let urlCallToAction = "<a href='https://yoa.st/35e' target='_blank'>";
 
 	if ( paragraphsLength.length === 0 ) {
 		return {};
 	}
 
-	var longestParagraphLength = paragraphsLength[ 0 ].wordCount;
+	let longestParagraphLength = paragraphsLength[ 0 ].wordCount;
 
 	if ( longestParagraphLength <= 150 ) {
 		// Green indicator.
@@ -57,21 +59,35 @@ var calculateParagraphLengthResult = function( paragraphsLength, tooLongParagrap
 		return {
 			score: score,
 			hasMarks: false,
-			text: i18n.dgettext( "js-text-analysis", "None of the paragraphs are too long, which is great." ),
+
+			// Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+			text: i18n.sprintf(
+				i18n.dgettext( "js-text-analysis",
+					"%1$sParagraph length%2$s: None of the paragraphs are too long. Great job!" ),
+				urlTitle,
+				"</a>"
+			),
 		};
 	}
 	return {
 		score: score,
 		hasMarks: true,
 
-		// Translators: %1$d expands to the number of paragraphs, %2$d expands to the recommended value
-		text: i18n.sprintf( i18n.dngettext(
-			"js-text-analysis",
-			"%1$d of the paragraphs contains more than the recommended maximum " +
-			"of %2$d words. Are you sure all information is about the same topic, and therefore belongs in one single paragraph?",
-			"%1$d of the paragraphs contain more than the recommended maximum of %2$d words. Are you sure all information within each of" +
-			" these paragraphs is about the same topic, and therefore belongs in a single paragraph?", tooLongParagraphs.length
-		), tooLongParagraphs.length, recommendedValue ),
+		/** Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag, %3$d expands to the
+		 * number of paragraphs over the recommended word limit, %4$d expands to the word limit
+		 */
+
+		text: i18n.sprintf(
+			i18n.dngettext( "js-text-analysis",
+				"%1$sParagraph length%2$s: %3$d of the paragraphs contains more than the recommended maximum of %4$d words." +
+				" %5$sShorten your paragraphs%2$s!", "%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the " +
+				"recommended maximum of %4$d words. %5$sShorten your paragraphs%2$s!", tooLongParagraphs.length ),
+			urlTitle,
+			"</a>",
+			tooLongParagraphs.length,
+			recommendedValue,
+			urlCallToAction
+		),
 	};
 };
 

--- a/src/assessments/readability/paragraphTooLongAssessment.js
+++ b/src/assessments/readability/paragraphTooLongAssessment.js
@@ -60,8 +60,8 @@ let calculateParagraphLengthResult = function( paragraphsLength, tooLongParagrap
 			score: score,
 			hasMarks: false,
 
-			// Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 			text: i18n.sprintf(
+				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis",
 					"%1$sParagraph length%2$s: None of the paragraphs are too long. Great job!" ),
 				urlTitle,
@@ -72,12 +72,9 @@ let calculateParagraphLengthResult = function( paragraphsLength, tooLongParagrap
 	return {
 		score: score,
 		hasMarks: true,
-
-		/** Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag, %3$d expands to the
-		 * number of paragraphs over the recommended word limit, %4$d expands to the word limit
-		 */
-
 		text: i18n.sprintf(
+			/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag, %3$d expands to the
+			number of paragraphs over the recommended word limit, %4$d expands to the word limit */
 			i18n.dngettext( "js-text-analysis",
 				"%1$sParagraph length%2$s: %3$d of the paragraphs contains more than the recommended maximum of %4$d words." +
 				" %5$sShorten your paragraphs%2$s!", "%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the " +

--- a/src/assessments/readability/passiveVoiceAssessment.js
+++ b/src/assessments/readability/passiveVoiceAssessment.js
@@ -51,10 +51,9 @@ let calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 			score: score,
 			hasMarks: hasMarks,
 			text: i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 				i18n.dgettext(
 					"js-text-analysis",
-
-					// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.
 					"%1$sPassive voice%2$s: You're using enough active voice. That's great!" ),
 				urlTitle,
 				"</a>"
@@ -65,12 +64,10 @@ let calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 		score: score,
 		hasMarks: hasMarks,
 		text: i18n.sprintf(
+			/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
+			%3$s expands to the percentage of sentences in passive voice, %4$s expands to the recommended value. */
 			i18n.dgettext(
 				"js-text-analysis",
-
-				/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
-				   %3$s expands to the percentage of sentences in passive voice, %4$s expands to the recommended value.
-				*/
 				"%1$sPassive voice%2$s: %3$s of the sentences contain passive voice, which is more than the recommended maximum of %4$s. " +
 				"%5$sTry to use their active counterparts%2$s."
 

--- a/src/assessments/readability/passiveVoiceAssessment.js
+++ b/src/assessments/readability/passiveVoiceAssessment.js
@@ -20,7 +20,8 @@ let calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 	let score;
 	let percentage = 0;
 	let recommendedValue = 10;
-	let passiveVoiceURL = "<a href='https://yoa.st/passive-voice' target='_blank'>";
+	let urlTitle = "<a href='https://yoa.st/34t' target='_blank'>";
+	let urlCallToAction = "<a href='https://yoa.st/34u' target='_blank'>";
 	let hasMarks;
 
 	// Prevent division by zero errors.
@@ -53,14 +54,10 @@ let calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 				i18n.dgettext(
 					"js-text-analysis",
 
-					// Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
-					// %3$s expands to the anchor end tag, %4$s expands to the recommended value.
-					"%1$s of the sentences contain %2$spassive voice%3$s, " +
-						"which is less than or equal to the recommended maximum of %4$s." ),
-				percentage + "%",
-				passiveVoiceURL,
-				"</a>",
-				recommendedValue + "%"
+					// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.
+					"%1$sPassive voice%2$s: You're using enough active voice. That's great!" ),
+				urlTitle,
+				"</a>"
 			),
 		};
 	}
@@ -71,15 +68,18 @@ let calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 			i18n.dgettext(
 				"js-text-analysis",
 
-				// Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
-				// %3$s expands to the anchor end tag, %4$s expands to the recommended value.
-				"%1$s of the sentences contain %2$spassive voice%3$s, " +
-				"which is more than the recommended maximum of %4$s. Try to use their active counterparts."
+				/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
+				   %3$s expands to the percentage of sentences in passive voice, %4$s expands to the recommended value.
+				*/
+				"%1$sPassive voice%2$s: %3$s of the sentences contain passive voice, which is more than the recommended maximum of %4$s. " +
+				"%5$sTry to use their active counterparts%2$s."
+
 			),
-			percentage + "%",
-			passiveVoiceURL,
+			urlTitle,
 			"</a>",
-			recommendedValue + "%"
+			percentage + "%",
+			recommendedValue + "%",
+			urlCallToAction
 		),
 	};
 };

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -43,19 +43,12 @@ let groupSentenceBeginnings = function( sentenceBeginnings ) {
  * @returns {{score: number, text: string, hasMarks: boolean}} result object with score and text.
  */
 let calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i18n ) {
-	let score;
 	let urlTitle = "<a href='https://yoa.st/35f' target='_blank'>";
 	let urlCallToAction = "<a href='https://yoa.st/35g' target='_blank'>";
 
 	if ( groupedSentenceBeginnings.total > 0 ) {
-		score = 3;
-	} else {
-		score = 9;
-	}
-
-	if ( score === 3 ) {
 		return {
-			score: score,
+			score: 3,
 			hasMarks: true,
 			text: i18n.sprintf(
 				/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
@@ -77,9 +70,8 @@ let calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i18
 		};
 	}
 	return {
-		score: score,
+		score: 9,
 		hasMarks: false,
-
 		text: i18n.sprintf(
 			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 			i18n.dgettext( "js-text-analysis",

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -58,13 +58,11 @@ let calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i18
 			score: score,
 			hasMarks: true,
 			text: i18n.sprintf(
+				/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
+				%3$d expands to the number of consecutive sentences starting with the same word,
+				%4$d expands to the number of instances where 3 or more consecutive sentences start with the same word. */
 				i18n.dngettext(
 					"js-text-analysis",
-
-					// Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
-					// %3$d expands to the number of consecutive sentences starting with the same word,
-					// %4$d expands to the number of instances where 3 or more consecutive sentences start with the same word.
-
 					"%1$sConsecutive sentences%2$s: The text contains %3$d consecutive sentences starting with the same word." +
 					" %5$sTry to mix things up%2$s!", "%1$sConsecutive sentences%2$s: The text contains %4$d instances where" +
 					" %3$d or more consecutive sentences start with the same word. %5$sTry to mix things up%2$s!",
@@ -82,9 +80,8 @@ let calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i18
 		score: score,
 		hasMarks: false,
 
-		// Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag
-
 		text: i18n.sprintf(
+			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 			i18n.dgettext( "js-text-analysis",
 				"%1$sConsecutive sentences%2$s: There is enough variety in your sentences. That's great!" ),
 			urlTitle,

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -40,28 +40,57 @@ let groupSentenceBeginnings = function( sentenceBeginnings ) {
  * Calculates the score based on sentence beginnings.
  * @param {object} groupedSentenceBeginnings The object with grouped sentence beginnings.
  * @param {object} i18n The object used for translations.
- * @returns {{score: number, text: string, hasMarks: boolean}} resultobject with score and text.
+ * @returns {{score: number, text: string, hasMarks: boolean}} result object with score and text.
  */
 let calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i18n ) {
+	let score;
+	let urlTitle = "<a href='https://yoa.st/35f' target='_blank'>";
+	let urlCallToAction = "<a href='https://yoa.st/35g' target='_blank'>";
+
 	if ( groupedSentenceBeginnings.total > 0 ) {
+		score = 3;
+	} else {
+		score = 9;
+	}
+
+	if ( score === 3 ) {
 		return {
-			score: 3,
+			score: score,
 			hasMarks: true,
 			text: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
 
-					// Translators: %1$d expands to the number of instances where 3 or more consecutive sentences start with the same word.
-					// %2$d expands to the number of consecutive sentences starting with the same word.
-					"The text contains %2$d consecutive sentences starting with the same word. Try to mix things up!",
-					"The text contains %1$d instances where %2$d or more consecutive sentences start with the same word. " +
-					"Try to mix things up!",
+					// Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
+					// %3$d expands to the number of consecutive sentences starting with the same word,
+					// %4$d expands to the number of instances where 3 or more consecutive sentences start with the same word.
+
+					"%1$sConsecutive sentences%2$s: The text contains %3$d consecutive sentences starting with the same word." +
+					" %5$sTry to mix things up%2$s!", "%1$sConsecutive sentences%2$s: The text contains %4$d instances where" +
+					" %3$d or more consecutive sentences start with the same word. %5$sTry to mix things up%2$s!",
 					groupedSentenceBeginnings.total
 				),
-				groupedSentenceBeginnings.total, groupedSentenceBeginnings.lowestCount ),
+				urlTitle,
+				"</a>",
+				groupedSentenceBeginnings.lowestCount,
+				groupedSentenceBeginnings.total,
+				urlCallToAction
+			),
 		};
 	}
-	return {};
+	return {
+		score: score,
+		hasMarks: false,
+
+		// Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag
+
+		text: i18n.sprintf(
+			i18n.dgettext( "js-text-analysis",
+				"%1$sConsecutive sentences%2$s: There is enough variety in your sentences. That's great!" ),
+			urlTitle,
+			"</a>"
+		),
+	};
 };
 
 /**

--- a/src/assessments/readability/sentenceLengthInTextAssessment.js
+++ b/src/assessments/readability/sentenceLengthInTextAssessment.js
@@ -103,8 +103,8 @@ class SentenceLengthInTextAssessment extends Assessment {
 			return i18n.sprintf( i18n.dgettext( "js-text-analysis",
 				// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag
 				"%1$sSentence length%2$s: Great!" ),
-				urlTitle,
-				"</a>"
+			urlTitle,
+			"</a>"
 			);
 		}
 
@@ -112,14 +112,14 @@ class SentenceLengthInTextAssessment extends Assessment {
 			// Translators: %1$s and %6$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
 			// %3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
 			// %5$s expands to the recommended maximum percentage.
-			"%1$sSentence length%2$s: %3$d of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
+			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
 			" %6$sTry to shorten the sentences%2$s." ),
-			urlTitle,
-			"</a>",
-			percentage + "%",
-			this._config.recommendedWordCount,
-			this._config.slightlyTooMany + "%",
-			urlCallToAction
+		urlTitle,
+		"</a>",
+		percentage + "%",
+		this._config.recommendedWordCount,
+		this._config.slightlyTooMany + "%",
+		urlCallToAction
 		);
 	}
 

--- a/src/assessments/readability/sentenceLengthInTextAssessment.js
+++ b/src/assessments/readability/sentenceLengthInTextAssessment.js
@@ -100,18 +100,20 @@ class SentenceLengthInTextAssessment extends Assessment {
 		let urlTitle = "<a href='https://yoa.st/34v' target='_blank'>";
 		let urlCallToAction = "<a href='https://yoa.st/34w' target='_blank'>";
 		if ( score >= 7 ) {
-			return i18n.sprintf( i18n.dgettext( "js-text-analysis",
-				// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag
+			return i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis",
 				"%1$sSentence length%2$s: Great!" ),
 			urlTitle,
 			"</a>"
 			);
 		}
 
-		return i18n.sprintf( i18n.dgettext( "js-text-analysis",
-			// Translators: %1$s and %6$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
-			// %3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
-			// %5$s expands to the recommended maximum percentage.
+		return i18n.sprintf(
+			/* Translators: %1$s and %6$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
+			%3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
+			%5$s expands to the recommended maximum percentage. */
+			i18n.dgettext( "js-text-analysis",
 			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
 			" %6$sTry to shorten the sentences%2$s." ),
 		urlTitle,

--- a/src/assessments/readability/sentenceLengthInTextAssessment.js
+++ b/src/assessments/readability/sentenceLengthInTextAssessment.js
@@ -103,9 +103,9 @@ class SentenceLengthInTextAssessment extends Assessment {
 			return i18n.sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis",
-				"%1$sSentence length%2$s: Great!" ),
-			urlTitle,
-			"</a>"
+					"%1$sSentence length%2$s: Great!" ),
+				urlTitle,
+				"</a>"
 			);
 		}
 
@@ -114,14 +114,14 @@ class SentenceLengthInTextAssessment extends Assessment {
 			%3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
 			%5$s expands to the recommended maximum percentage. */
 			i18n.dgettext( "js-text-analysis",
-			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
+				"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
 			" %6$sTry to shorten the sentences%2$s." ),
-		urlTitle,
-		"</a>",
-		percentage + "%",
-		this._config.recommendedWordCount,
-		this._config.slightlyTooMany + "%",
-		urlCallToAction
+			urlTitle,
+			"</a>",
+			percentage + "%",
+			this._config.recommendedWordCount,
+			this._config.slightlyTooMany + "%",
+			urlCallToAction
 		);
 	}
 

--- a/src/assessments/readability/sentenceLengthInTextAssessment.js
+++ b/src/assessments/readability/sentenceLengthInTextAssessment.js
@@ -97,24 +97,30 @@ class SentenceLengthInTextAssessment extends Assessment {
 	 * @returns {string} A string.
 	 */
 	translateScore( score, percentage,  i18n ) {
-		let sentenceLengthURL = "<a href='https://yoa.st/short-sentences' target='_blank'>";
+		let urlTitle = "<a href='https://yoa.st/34v' target='_blank'>";
+		let urlCallToAction = "<a href='https://yoa.st/34w' target='_blank'>";
 		if ( score >= 7 ) {
 			return i18n.sprintf( i18n.dgettext( "js-text-analysis",
-				// Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
-				// %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
-				// %5$s expands to the recommended maximum percentage.
-				"%1$s of the sentences contain %2$smore than %3$s words%4$s, which is less than or equal to the recommended maximum of %5$s."
-			), percentage + "%", sentenceLengthURL, this._config.recommendedWordCount, "</a>", this._config.slightlyTooMany + "%"
+				// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag
+				"%1$sSentence length%2$s: Great!" ),
+				urlTitle,
+				"</a>"
 			);
 		}
 
 		return i18n.sprintf( i18n.dgettext( "js-text-analysis",
-			// Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
-			// %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
+			// Translators: %1$s and %6$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
+			// %3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
 			// %5$s expands to the recommended maximum percentage.
-			"%1$s of the sentences contain %2$smore than %3$s words%4$s, which is more than the recommended maximum of %5$s. " +
-			"Try to shorten the sentences."
-		), percentage + "%", sentenceLengthURL, this._config.recommendedWordCount, "</a>", this._config.slightlyTooMany + "%" );
+			"%1$sSentence length%2$s: %3$d of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
+			" %6$sTry to shorten the sentences%2$s." ),
+			urlTitle,
+			"</a>",
+			percentage + "%",
+			this._config.recommendedWordCount,
+			this._config.slightlyTooMany + "%",
+			urlCallToAction
+		);
 	}
 
 	/**

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -31,7 +31,8 @@ class SubheadingsDistributionTooLong extends Assessment {
 				slightlyTooMany: 300,
 				farTooMany: 350,
 			},
-			url: "<a href='https://yoa.st/headings' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/34x' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34y' target='_blank'>",
 			scores: {
 				goodShortTextNoSubheadings: 9,
 				goodSubheadings: 9,
@@ -151,9 +152,9 @@ class SubheadingsDistributionTooLong extends Assessment {
 							// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
 							i18n.dgettext(
 								"js-text-analysis",
-								"Great job with using %1$ssubheadings%2$s!"
+								"%1$sSubheading distribution%2$s: Great job!"
 							),
-							this._config.url,
+							this._config.urlTitle,
 							"</a>"
 						),
 					};
@@ -165,21 +166,22 @@ class SubheadingsDistributionTooLong extends Assessment {
 						score: this._config.scores.okSubheadings,
 						resultText: i18n.sprintf(
 							/*
-							 * Translators: %1$d expands to the number of subheadings, %2$d expands to the recommended number
-							 * of words following a subheading, %3$s expands to a link to https://yoa.st/headings,
-							 * %4$s expands to the link closing tag.
+							 * Translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
+							 * not separated by subheadings, %4$d expands to the recommended number of words following a
+							 * subheading, %2$s expands to the link closing tag.
 							 */
 							i18n.dngettext(
 								"js-text-analysis",
-								"%1$d section of your text is longer than %2$d words and is not separated by any subheadings. " +
-								"Add %3$ssubheadings%4$s to improve readability.",
-								"%1$d sections of your text are longer than %2$d words and are not separated by any subheadings. " +
-								"Add %3$ssubheadings%4$s to improve readability.",
+								"%1$sSubheading distribution%2$s: %3$d section of your text is longer than %4$d words and" +
+								" is not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
+								"%1$sSubheading distribution%2$s: %3$d sections of your text are longer than %4$d words " +
+								"and are not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
 								this._tooLongTextsNumber ),
+							this._config.urlTitle,
+							"</a>",
 							this._tooLongTextsNumber,
 							this._config.parameters.recommendedMaximumWordCount,
-							this._config.url,
-							"</a>"
+							this._config.urlCallToAction,
 						),
 					};
 				}
@@ -189,21 +191,22 @@ class SubheadingsDistributionTooLong extends Assessment {
 					score: this._config.scores.badSubheadings,
 					resultText: i18n.sprintf(
 						/*
-						 * Translators: %1$d expands to the number of subheadings, %2$d expands to the recommended number
-						 * of words following a subheading, %3$s expands to a link to https://yoa.st/headings,
-						 * %4$s expands to the link closing tag.
+						 * Translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
+						 * not separated by subheadings, %4$d expands to the recommended number of words following a
+						 * subheading, %2$s expands to the link closing tag.
 						 */
 						i18n.dngettext(
 							"js-text-analysis",
-							"%1$d section of your text is longer than %2$d words and is not separated by any subheadings. " +
-							"Add %3$ssubheadings%4$s to improve readability.",
-							"%1$d sections of your text are longer than %2$d words and are not separated by any subheadings. " +
-							"Add %3$ssubheadings%4$s to improve readability.",
+							"%1$sSubheading distribution%2$s: %3$d section of your text is longer than %4$d words and" +
+							" is not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
+							"%1$sSubheading distribution%2$s: %3$d sections of your text are longer than %4$d words " +
+							"and are not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
 							this._tooLongTextsNumber ),
+						this._config.urlTitle,
+						"</a>",
 						this._tooLongTextsNumber,
 						this._config.parameters.recommendedMaximumWordCount,
-						this._config.url,
-						"</a>"
+						this._config.urlCallToAction,
 					),
 				};
 			}
@@ -211,14 +214,15 @@ class SubheadingsDistributionTooLong extends Assessment {
 			return {
 				score: this._config.scores.badLongTextNoSubheadings,
 				resultText: i18n.sprintf(
-					// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
+					// Translators: %1$s and %3$s expand to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
 					i18n.dgettext(
 						"js-text-analysis",
-						"You are not using any subheadings, although your text is rather long. " +
-						"Try and add  some %1$ssubheadings%2$s."
+						"%1$sSubheading distribution%2$s: You are not using any subheadings, although your text is rather long." +
+						" %3$sTry and add some subheadings%2$s."
 					),
-					this._config.url,
-					"</a>"
+					this._config.urlTitle,
+					"</a>",
+					this._config.urlCallToAction
 				),
 			};
 		}
@@ -230,9 +234,9 @@ class SubheadingsDistributionTooLong extends Assessment {
 					// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
 					i18n.dgettext(
 						"js-text-analysis",
-						"Great job with using %1$ssubheadings%2$s!"
+						"%1$sSubheading distribution%2$s: Great job!"
 					),
-					this._config.url,
+					this._config.urlTitle,
 					"</a>"
 				),
 			};
@@ -244,9 +248,10 @@ class SubheadingsDistributionTooLong extends Assessment {
 				// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
 				i18n.dgettext(
 					"js-text-analysis",
-					"You are not using any %1$ssubheadings%2$s, but your text is short enough and probably doesn't need them."
+					"%1$sSubheading distribution%2$s: You are not using any subheadings, but your text is short enough" +
+					" and probably doesn't need them."
 				),
-				this._config.url,
+				this._config.urlTitle,
 				"</a>"
 			),
 		};

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -190,11 +190,9 @@ class SubheadingsDistributionTooLong extends Assessment {
 				return {
 					score: this._config.scores.badSubheadings,
 					resultText: i18n.sprintf(
-						/*
-						 * Translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
-						 * not separated by subheadings, %4$d expands to the recommended number of words following a
-						 * subheading, %2$s expands to the link closing tag.
-						 */
+						/* Translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
+						not separated by subheadings, %4$d expands to the recommended number of words following a
+						subheading, %2$s expands to the link closing tag. */
 						i18n.dngettext(
 							"js-text-analysis",
 							"%1$sSubheading distribution%2$s: %3$d section of your text is longer than %4$d words and" +
@@ -214,7 +212,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 			return {
 				score: this._config.scores.badLongTextNoSubheadings,
 				resultText: i18n.sprintf(
-					// Translators: %1$s and %3$s expand to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
+					/* Translators: %1$s and %3$s expand to a link to https://yoa.st/headings, %2$s expands to the link closing tag. */
 					i18n.dgettext(
 						"js-text-analysis",
 						"%1$sSubheading distribution%2$s: You are not using any subheadings, although your text is rather long." +
@@ -231,7 +229,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 			return {
 				score: this._config.scores.goodSubheadings,
 				resultText: i18n.sprintf(
-					// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
+					/* Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag. */
 					i18n.dgettext(
 						"js-text-analysis",
 						"%1$sSubheading distribution%2$s: Great job!"
@@ -245,7 +243,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 		return {
 			score: this._config.scores.goodShortTextNoSubheadings,
 			resultText: i18n.sprintf(
-				// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
+				/* Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag. */
 				i18n.dgettext(
 					"js-text-analysis",
 					"%1$sSubheading distribution%2$s: You are not using any subheadings, but your text is short enough" +

--- a/src/assessments/readability/textPresenceAssessment.js
+++ b/src/assessments/readability/textPresenceAssessment.js
@@ -10,14 +10,21 @@ import AssessmentResult from "../../values/AssessmentResult";
  * @returns {AssessmentResult} The result of this assessment.
  */
 function textPresenceAssessment( paper, researcher, i18n ) {
-	var text = stripHTMLTags( paper.getText() );
+	let text = stripHTMLTags( paper.getText() );
+	let urlTitle = "<a href='https://yoa.st/35h' target='_blank'>";
+	let urlCallToAction = "<a href='https://yoa.st/35i' target='_blank'>";
 
 	if ( text.length < 50 ) {
-		var result = new AssessmentResult();
+		let result = new AssessmentResult();
 
-		result.setText( i18n.dgettext( "js-text-analysis", "You have far too little content, please add some content to enable a good analysis." ) );
+		result.setText( i18n.sprintf( i18n.dgettext( "js-text-analysis",
+
+			"%1$sNot enough content%2$s: %3$sPlease add some content to enable a good analysis%2$s." ),
+		urlTitle,
+		"</a>",
+		urlCallToAction ) );
+
 		result.setScore( 3 );
-
 		return result;
 	}
 

--- a/src/assessments/readability/textPresenceAssessment.js
+++ b/src/assessments/readability/textPresenceAssessment.js
@@ -21,10 +21,10 @@ function textPresenceAssessment( paper, researcher, i18n ) {
 			/* Translators: %1$s and %3$s expand to links to articles on Yoast.com,
 			%2$s expands to the anchor end tag*/
 			i18n.dgettext( "js-text-analysis",
-			"%1$sNot enough content%2$s: %3$sPlease add some content to enable a good analysis%2$s." ),
-		urlTitle,
-		"</a>",
-		urlCallToAction ) );
+				"%1$sNot enough content%2$s: %3$sPlease add some content to enable a good analysis%2$s." ),
+			urlTitle,
+			"</a>",
+			urlCallToAction ) );
 
 		result.setScore( 3 );
 		return result;

--- a/src/assessments/readability/textPresenceAssessment.js
+++ b/src/assessments/readability/textPresenceAssessment.js
@@ -17,8 +17,10 @@ function textPresenceAssessment( paper, researcher, i18n ) {
 	if ( text.length < 50 ) {
 		let result = new AssessmentResult();
 
-		result.setText( i18n.sprintf( i18n.dgettext( "js-text-analysis",
-
+		result.setText( i18n.sprintf(
+			/* Translators: %1$s and %3$s expand to links to articles on Yoast.com,
+			%2$s expands to the anchor end tag*/
+			i18n.dgettext( "js-text-analysis",
 			"%1$sNot enough content%2$s: %3$sPlease add some content to enable a good analysis%2$s." ),
 		urlTitle,
 		"</a>",

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -52,15 +52,30 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 		score = 9;
 	}
 
+	if ( score < 7 && percentage === 0 ) {
+		return {
+			score: formatNumber( score ),
+			hasMarks: hasMarks,
+			text: i18n.sprintf(
+				/* Translators: %1$s and %3$s expand to a link to yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis",
+					"%1$sTransition words%2$s: None of the sentences contain transition words. %3$sUse some%2$s."
+				),
+				urlTitle,
+				"</a>",
+				urlCallToAction ),
+		};
+	}
+
 	if ( score < 7 ) {
 		return {
 			score: formatNumber( score ),
 			hasMarks: hasMarks,
 			text: i18n.sprintf(
 				/* Translators: %1$s and %4$s expand to a link to yoast.com, %2$s expands to the anchor end tag,
-				%3$s expands to the percentage of sentences containing transition words, %4$s expands to the recommended value. */
+				%3$s expands to the percentage of sentences containing transition words */
 				i18n.dgettext( "js-text-analysis",
-					"%1$sTransition words%2$s: Only %3$s of the sentences contain them. This is not enough. %4$sUse more transition words%2$s."
+					"%1$sTransition words%2$s: Only %3$s of the sentences contain transition words, which is not enough. %4$sUse more of them%2$s."
 				),
 				urlTitle,
 				"</a>",

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -57,10 +57,9 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 			score: formatNumber( score ),
 			hasMarks: hasMarks,
 			text: i18n.sprintf(
+				/* Translators: %1$s and %4$s expand to a link to yoast.com, %2$s expands to the anchor end tag,
+				%3$s expands to the percentage of sentences containing transition words, %4$s expands to the recommended value. */
 				i18n.dgettext( "js-text-analysis",
-
-					// Translators: %1$s and %4$s expand to a link to yoast.com, %2$s expands to the anchor end tag,
-					// %3$s expands to the percentage of sentences containing transition words, %4$s expands to the recommended value.
 					"%1$sTransition words%2$s: Only %3$s of the sentences contain them, this is not enough. %4$sUse more transition words%2$s."
 				),
 				urlTitle,
@@ -73,9 +72,9 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 	return {
 		score: formatNumber( score ),
 		hasMarks: hasMarks,
-		text: i18n.sprintf( i18n.dgettext( "js-text-analysis",
-
-			// Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag.
+		text: i18n.sprintf(
+			/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
+			i18n.dgettext( "js-text-analysis",
 			"%1$sTransition words%2$s: Well done!"
 		),
 		urlTitle,

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -24,6 +24,29 @@ let calculateTransitionWordPercentage = function( sentences ) {
 };
 
 /**
+ * Calculates the score for the assessment based on the percentage of sentences containing transition words.
+ *
+ * @param {number} percentage The percentage of sentences containing transition words.
+ * @returns {number} The score.
+ */
+const calculateScoreFromPercentage = function( percentage ) {
+	if ( percentage < 20 ) {
+		// Red indicator.
+		return 3;
+	}
+
+	if ( inRange( percentage, 20, 30 ) ) {
+		// Orange indicator.
+		return 6;
+	}
+
+	if ( percentage >= 30 ) {
+		// Green indicator.
+		return 9;
+	}
+};
+
+/**
  * Calculates transition word result
  * @param {object} transitionWordSentences The object containing the total number of sentences and the number of sentences containing
  * a transition word.
@@ -31,26 +54,11 @@ let calculateTransitionWordPercentage = function( sentences ) {
  * @returns {object} Object containing score and text.
  */
 let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
-	let score;
 	let percentage = calculateTransitionWordPercentage( transitionWordSentences );
+	let score = calculateScoreFromPercentage( percentage );
 	let hasMarks   = ( percentage > 0 );
 	let urlTitle = "<a href='https://yoa.st/34z' target='_blank'>";
 	let urlCallToAction = "<a href='https://yoa.st/35a' target='_blank'>";
-
-	if ( percentage < 20 ) {
-		// Red indicator.
-		score = 3;
-	}
-
-	if ( inRange( percentage, 20, 30 ) ) {
-		// Orange indicator.
-		score = 6;
-	}
-
-	if ( percentage >= 30 ) {
-		// Green indicator.
-		score = 9;
-	}
 
 	if ( score < 7 && percentage === 0 ) {
 		return {

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -60,7 +60,7 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 				/* Translators: %1$s and %4$s expand to a link to yoast.com, %2$s expands to the anchor end tag,
 				%3$s expands to the percentage of sentences containing transition words, %4$s expands to the recommended value. */
 				i18n.dgettext( "js-text-analysis",
-					"%1$sTransition words%2$s: Only %3$s of the sentences contain them, this is not enough. %4$sUse more transition words%2$s."
+					"%1$sTransition words%2$s: Only %3$s of the sentences contain them. This is not enough. %4$sUse more transition words%2$s."
 				),
 				urlTitle,
 				"</a>",

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -75,10 +75,10 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 		text: i18n.sprintf(
 			/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
 			i18n.dgettext( "js-text-analysis",
-			"%1$sTransition words%2$s: Well done!"
-		),
-		urlTitle,
-		"</a>" ),
+				"%1$sTransition words%2$s: Well done!"
+			),
+			urlTitle,
+			"</a>" ),
 	};
 };
 

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -34,7 +34,8 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 	let score;
 	let percentage = calculateTransitionWordPercentage( transitionWordSentences );
 	let hasMarks   = ( percentage > 0 );
-	let transitionWordsURL = "<a href='https://yoa.st/transition-words' target='_blank'>";
+	let urlTitle = "<a href='https://yoa.st/34z' target='_blank'>";
+	let urlCallToAction = "<a href='https://yoa.st/35a' target='_blank'>";
 
 	if ( percentage < 20 ) {
 		// Red indicator.
@@ -52,18 +53,20 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 	}
 
 	if ( score < 7 ) {
-		let recommendedMinimum = 30;
 		return {
 			score: formatNumber( score ),
 			hasMarks: hasMarks,
 			text: i18n.sprintf(
 				i18n.dgettext( "js-text-analysis",
 
-					// Translators: %1$s expands to the number of sentences containing transition words, %2$s expands to a link on yoast.com,
-					// %3$s expands to the anchor end tag, %4$s expands to the recommended value.
-					"%1$s of the sentences contain a %2$stransition word%3$s or phrase, " +
-					"which is less than the recommended minimum of %4$s."
-				), percentage + "%", transitionWordsURL, "</a>", recommendedMinimum + "%" ),
+					// Translators: %1$s and %4$s expand to a link to yoast.com, %2$s expands to the anchor end tag,
+					// %3$s expands to the percentage of sentences containing transition words, %4$s expands to the recommended value.
+					"%1$sTransition words%2$s: Only %3$s of the sentences contain them, this is not enough. %4$sUse more transition words%2$s."
+				),
+				urlTitle,
+				"</a>",
+				percentage + "%",
+				urlCallToAction ),
 		};
 	}
 
@@ -72,11 +75,11 @@ let calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
 		hasMarks: hasMarks,
 		text: i18n.sprintf( i18n.dgettext( "js-text-analysis",
 
-			// Translators: %1$s expands to the number of sentences containing transition words, %2$s expands to a link on yoast.com,
-			// %3$s expands to the anchor end tag.
-			"%1$s of the sentences contain a %2$stransition word%3$s or phrase, " +
-			"which is great."
-		), percentage + "%", transitionWordsURL, "</a>" ),
+			// Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag.
+			"%1$sTransition words%2$s: Well done!"
+		),
+		urlTitle,
+		"</a>" ),
 	};
 };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the feedback strings of all readability assessments.

## Test instructions

This PR can be tested by following these steps:

* Trigger all SEO and readability assessments in all possible conditions as outlined here: https://github.com/Yoast/YoastSEO.js/wiki/Scoring-readability-analysis
* Make sure that all assessments have feedback strings according to the new format. This means:
  * In the beginning there is the assessment title with a link
  * In the end there is a call to action with a link (except when the bullet is green)

Fixes #1806 
