### PR TITLE
Change feedback strings for most SEO assessments

### DIFF
--- a/spec/assessments/InternalLinksAssessmentSpec.js
+++ b/spec/assessments/InternalLinksAssessmentSpec.js
@@ -20,7 +20,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1, internalNofollow: 1, internalTotal: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: The internal links on this page are both nofollowed and normal. Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: There are both nofollowed and normal internal links on this page. Good job!" );
 	} );
 
 	it( "A paper with one internal link, which is no-follow", function() {
@@ -39,7 +39,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: " +
-			"No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>" );
+			"No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!" );
 	} );
 
 	it( "A paper without text", function() {

--- a/spec/assessments/InternalLinksAssessmentSpec.js
+++ b/spec/assessments/InternalLinksAssessmentSpec.js
@@ -11,7 +11,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1, internalNofollow: 0, internalTotal: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "This page has 1 <a href='https://yoa.st/2pm' target='_blank'>internal link(s)</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: You have enough internal links. Good job!" );
 	} );
 
 	it( "A paper with one internal link which is do-follow, and one internal link which is no-follow", function() {
@@ -20,7 +20,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1, internalNofollow: 1, internalTotal: 2 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "This page has 1 nofollowed <a href='https://yoa.st/2pm' target='_blank'>internal link(s)</a> and 1 normal internal link(s)." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: The internal links on this page are both nofollowed and normal. Good job!" );
 	} );
 
 	it( "A paper with one internal link, which is no-follow", function() {
@@ -29,7 +29,8 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 0, internalNofollow: 1, internalTotal: 1 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
-		expect( assessment.getText() ).toEqual( "This page has 1 <a href='https://yoa.st/2pm' target='_blank'>internal link(s)</a>, all nofollowed." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: " +
+			"The internal links in this page are all nofollowed. <a href='https://yoa.st/34a' target='_blank'>Add some good internal links</a>." );
 	} );
 
 	it( "A paper without internal links", function() {
@@ -37,7 +38,8 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pm' target='_blank'>internal links</a> appear in this page, consider adding some as appropriate." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: " +
+			"No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>" );
 	} );
 
 	it( "A paper without text", function() {

--- a/spec/assessments/IntroductionKeywordAssessmentSpec.js
+++ b/spec/assessments/IntroductionKeywordAssessmentSpec.js
@@ -16,7 +16,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "All topic words appear within one sentence in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!" );
 	} );
 
 	it( "returns synonym words found in one sentence of the first paragraph", function() {
@@ -30,7 +30,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "All topic words appear within one sentence in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!" );
 	} );
 
 	it( "returns keyphrase words found within the first paragraph, but not in one sentence", function() {
@@ -44,7 +44,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "All topic words appear in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy, but not within one sentence." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. <a href='https://yoa.st/33f' target='_blank'>Fix that</a>!" );
 	} );
 
 	it( "returns synonym words found within the first paragraph, but not in one sentence", function() {
@@ -58,7 +58,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "All topic words appear in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy, but not within one sentence." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. <a href='https://yoa.st/33f' target='_blank'>Fix that</a>!" );
 	} );
 
 
@@ -73,7 +73,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			i18n
 		);
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "Not all topic words appear in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy. Make sure the topic is clear immediately." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Your keyphrase or its synonyms do not appear in the first paragraph. <a href='https://yoa.st/33f' target='_blank'>Make sure the topic is clear immediately</a>." );
 	} );
 
 	it( "returns no score if no keyword is defined", function() {

--- a/spec/assessments/KeyphraseLengthAssessmentSpec.js
+++ b/spec/assessments/KeyphraseLengthAssessmentSpec.js
@@ -11,8 +11,9 @@ describe( "the keyphrase length assessment", function() {
 		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toEqual( -999 );
-		expect( result.getText() ).toEqual( "No <a href='https://yoa.st/2pdd' target='_blank'>focus keyword</a> was set for this page. " +
-		   "If you do not set a focus keyword, no score can be calculated." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"No focus keyphrase was set for this page. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Set a focus keyphrase in order to calculate your SEO score</a>." );
 	} );
 
 	it( "should assess a paper with a keyphrase that's too long as bad", function() {
@@ -22,8 +23,9 @@ describe( "the keyphrase length assessment", function() {
 		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toEqual( 3 );
-		expect( result.getText() ).toEqual( "Your <a href='https://yoa.st/2pd' target='_blank'>keyphrase</a> is 11 " +
-			"words long. That's way more than the recommended maximum of 4 words. Make the keyphrase shorter." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 11 words long. That's way more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
 	} );
 
 	it( "should assess a paper with a keyphrase that's the correct length", function() {
@@ -33,7 +35,7 @@ describe( "the keyphrase length assessment", function() {
 		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "Your <a href='https://yoa.st/2pdd' target='_blank'>keyphrase</a> has a nice length." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!" );
 	} );
 
 	it( "should assess a paper with a keyphrase that's a little longer than the correct length", function() {
@@ -43,7 +45,8 @@ describe( "the keyphrase length assessment", function() {
 		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
 
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "Your <a href='https://yoa.st/2pd' target='_blank'>keyphrase</a> is " +
-			"5 words long. That's more than the recommended maximum of 4 words. You might want to make the keyphrase a bit shorter." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 5 words long. That's more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
 	} );
 } );

--- a/spec/assessments/TextCompetingLinksAssessmentSpec.js
+++ b/spec/assessments/TextCompetingLinksAssessmentSpec.js
@@ -33,9 +33,9 @@ describe( "An assessment for competing links in the text", function() {
 		);
 
 		expect( result.getScore() ).toBe( 2 );
-		expect( result.getText() ).toBe( "You're <a href='https://yoa.st/2pi' target='_blank'>linking to another page " +
-			"with the focus keyword</a> you want this page to rank for. " +
-			"Consider changing that if you truly want this page to rank." );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34l' target='_blank'>Link focus keyphrase</a>: " +
+			"You're linking to another page with the words you want this page to rank for. " +
+			"<a href='https://yoa.st/34m' target='_blank'>Don't do that</a>!" );
 	} );
 
 	it( "is not applicable for papers without text", function() {

--- a/spec/assessments/keywordStopWordsSpec.js
+++ b/spec/assessments/keywordStopWordsSpec.js
@@ -23,7 +23,7 @@ describe( "A stop word in keyword assessment", function() {
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.hasScore() ).toEqual( true );
-		expect( assessment.getText() ).toEqual( "The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/stopwords/' target='_blank'>Learn more about the stop words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34b' target='_blank'>Stopwords</a>: The focus keyphrase contains stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/34c' target='_blank'>Learn more about stop words</a>." );
 	} );
 
 	it( "assesses multiple stop words in the keyword", function() {
@@ -33,7 +33,7 @@ describe( "A stop word in keyword assessment", function() {
 
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about", "before" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual( "The focus keyword contains 2 stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/stopwords/' target='_blank'>Learn more about the stop words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34b' target='_blank'>Stopwords</a>: The focus keyphrase contains stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/34c' target='_blank'>Learn more about stop words</a>." );
 	} );
 } );
 

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -11,7 +11,8 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has been specified. Search engines will display copy from the page instead." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>:  No meta description has been specified. " +
+			"Search engines will display copy from the page instead. <a href='https://yoa.st/34e' target='_blank'>Make sure to write one</a>!" );
 	} );
 
 	it( "assesses a short description", function() {
@@ -19,7 +20,8 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> is under 120 characters long. However, up to 156 characters are available." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
+			"The meta description is too short (under 120 characters). Up to 156 characters are available. <a href='https://yoa.st/34e' target='_blank'>Use the space!</a>" );
 	} );
 
 	it( "assesses a too long description", function() {
@@ -27,7 +29,8 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> is over 156 characters. Reducing the length will ensure the entire description will be visible." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
+			"The meta description is over 156 characters. To ensure the entire description will be visible, <a href='https://yoa.st/34e' target='_blank'>you should reduce the length!</a>" );
 	} );
 
 	it( "assesses a good description", function() {
@@ -35,6 +38,6 @@ describe( "An descriptionLength assessment", function() {
 		var assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has a nice length." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!" );
 	} );
 } );

--- a/spec/assessments/metaDescriptionLengthSpec.js
+++ b/spec/assessments/metaDescriptionLengthSpec.js
@@ -21,7 +21,7 @@ describe( "An descriptionLength assessment", function() {
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
-			"The meta description is too short (under 120 characters). Up to 156 characters are available. <a href='https://yoa.st/34e' target='_blank'>Use the space!</a>" );
+			"The meta description is too short (under 120 characters). Up to 156 characters are available. <a href='https://yoa.st/34e' target='_blank'>Use the space</a>!" );
 	} );
 
 	it( "assesses a too long description", function() {
@@ -30,7 +30,7 @@ describe( "An descriptionLength assessment", function() {
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
-			"The meta description is over 156 characters. To ensure the entire description will be visible, <a href='https://yoa.st/34e' target='_blank'>you should reduce the length!</a>" );
+			"The meta description is over 156 characters. To ensure the entire description will be visible, <a href='https://yoa.st/34e' target='_blank'>you should reduce the length</a>!" );
 	} );
 
 	it( "assesses a good description", function() {

--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -29,7 +29,7 @@ describe( "An assessor running the linkStatistics", function() {
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "This page has 0 nofollowed <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a> and 1 normal outbound link(s)." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!" );
 
 		mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
 
@@ -49,7 +49,29 @@ describe( "An assessor running the linkStatistics", function() {
 		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
-		expect( assessment.getText() ).toEqual( "This page has 1 <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a>, all nofollowed." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: All outbound links on this page are nofollowed. <a href='https://yoa.st/34g' target='_blank'>Add some normal links</a>." );
+	} );
+
+	it( "Returns the right result when there are normal as well as nofollowed outbound links", function() {
+		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
+
+		var mockResult = { externalDofollow: 1,
+			externalNofollow: 1,
+			externalTotal: 2,
+			internalDofollow: 0,
+			internalNofollow: 0,
+			internalTotal: 0,
+			otherDofollow: 0,
+			otherNofollow: 0,
+			otherTotal: 0,
+			total: 2,
+			totalKeyword: 0,
+			totalNaKeyword: 2 };
+
+		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 8 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: There are both nofollowed and normal outbound links on this page. Good job!" );
 	} );
 
 	it( "Accepts a paper and i18nobject  ", function() {
@@ -57,6 +79,6 @@ describe( "An assessor running the linkStatistics", function() {
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pl' target='_blank'>outbound links</a> appear in this page, consider adding some as appropriate." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!" );
 	} );
 } );

--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -6,11 +6,12 @@ var i18n = factory.buildJed();
 let linkStatisticAssessment = new OutboundLinksAssessment();
 
 describe( "An assessor running the linkStatistics", function() {
-	it( "Accepts a paper and i18nobject  ", function() {
-		var attributes = {
-			keyword: "keyword",
-			url: "http://example.com",
-		};
+	var attributes = {
+		keyword: "keyword",
+		url: "http://example.com",
+	};
+
+	it( "Tests a paper with some do-follow outbound links and no no-follow outbound links", function() {
 		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
 
 		var mockResult = { externalDofollow: 1,
@@ -30,8 +31,10 @@ describe( "An assessor running the linkStatistics", function() {
 
 		expect( assessment.getScore() ).toEqual( 8 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!" );
+	} );
 
-		mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
+	it( "Tests a paper with some no-folow outbound links and no do-follow outbound links", function() {
+		const mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
 
 		var mockResult = { externalDofollow: 0,
 			externalNofollow: 1,
@@ -46,7 +49,7 @@ describe( "An assessor running the linkStatistics", function() {
 			totalKeyword: 0,
 			totalNaKeyword: 0 };
 
-		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: All outbound links on this page are nofollowed. <a href='https://yoa.st/34g' target='_blank'>Add some normal links</a>." );
@@ -74,7 +77,7 @@ describe( "An assessor running the linkStatistics", function() {
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: There are both nofollowed and normal outbound links on this page. Good job!" );
 	} );
 
-	it( "Accepts a paper and i18nobject  ", function() {
+	it( "Tests a paper without outbound links", function() {
 		var mockPaper = new Paper( "" );
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
 

--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -11,34 +11,34 @@ describe( "the SEO title length assessment", function() {
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
 
 		expect( result.getScore() ).toEqual( 1 );
-		expect( result.getText() ).toEqual( "Please create an <a href='https://yoa.st/2po' target='_blank'>SEO title</a>." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: <a href='https://yoa.st/34i' target='_blank'>Please create an SEO title</a>." );
 	} );
 
 	it( "should assess a paper with a SEO title that's under the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 9 ), i18n );
 		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> is too short. Use the space to add keyword variations or create compelling call-to-action copy." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: The SEO title is too short. <a href='https://yoa.st/34i' target='_blank'>Use the space to add keyword variations or create compelling call-to-action copy</a>." );
 	} );
 
 	it( "should assess a paper with a SEO title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 450 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!" );
 	} );
 
 	it( "should assess a paper with a SEO title that's in range of the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ), i18n );
 		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!" );
 	} );
 
 	it( "should assess a paper with a SEO title that's longer than the recommended value", function() {
 		var paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );
 		expect( result.getScore() ).toEqual( 3 );
-		expect( result.getText() ).toEqual( "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> is wider than the viewable limit." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: The SEO title wider than the viewable limit. <a href='https://yoa.st/34i' target='_blank'>Try to make it shorter</a>." );
 	} );
 } );

--- a/spec/assessments/taxonomyTextLengthSpec.js
+++ b/spec/assessments/taxonomyTextLengthSpec.js
@@ -9,8 +9,8 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 1 word. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 1 word. " +
+			"This is far below the recommended minimum of 150 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses a low word count", function() {
@@ -18,8 +18,8 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 5 words. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: " +
+			"The text contains 5 words. This is far below the recommended minimum of 150 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses a medium word count", function() {
@@ -27,8 +27,8 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 90 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -10 );
-		expect( assessment.getText() ).toEqual( "The text contains 90 words. This is below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 90 words. " +
+			"This is below the recommended minimum of 150 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses a slightly higher than medium word count", function() {
@@ -36,8 +36,8 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 110 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 5 );
-		expect( assessment.getText() ).toEqual( "The text contains 110 words. This is below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: " +
+			"The text contains 110 words. This is below the recommended minimum of 150 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses an almost at the recommended amount, word count", function() {
@@ -45,8 +45,8 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 130 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 7 );
-		expect( assessment.getText() ).toEqual( "The text contains 130 words. This is slightly below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words. " +
-			"Add a bit more copy." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 130 words. " +
+			"This is slightly below the recommended minimum of 150 words. <a href='https://yoa.st/34k' target='_blank'>Add a bit more copy</a>." );
 	} );
 
 	it( "assesses high word count", function() {
@@ -54,6 +54,6 @@ describe( "A word count assessment", function() {
 		var assessment = taxonomyTextLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 175 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The text contains 175 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 150 words." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 175 words. Good job!" );
 	} );
 } );

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -12,7 +12,7 @@ describe( "An image count assessment", function() {
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "No <a href='https://yoa.st/2pj' target='_blank'>images</a> appear in this page, consider adding some as appropriate." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: No images appear on this page. <a href='https://yoa.st/33d' target='_blank'>Add some</a>!" );
 	} );
 
 	it( "assesses a single image, without a keyword and alt-tag set", function() {
@@ -26,7 +26,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page are missing alt attributes." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
 	} );
 
 	it( "assesses a single image, without a keyword, but with an alt-tag set", function() {
@@ -40,7 +40,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
@@ -56,7 +56,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page do not have alt attributes with the topic words." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword", function() {
@@ -72,7 +72,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
@@ -88,7 +88,7 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
@@ -104,6 +104,6 @@ describe( "An image count assessment", function() {
 		} ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
 	} );
 } );

--- a/spec/assessments/textLengthSpec.js
+++ b/spec/assessments/textLengthSpec.js
@@ -11,8 +11,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 1 word. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 1 word. This is far below the recommended minimum of 300 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses a low word count", function() {
@@ -20,8 +19,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -20 );
-		expect( assessment.getText() ).toEqual( "The text contains 5 words. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 5 words. This is far below the recommended minimum of 300 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses a medium word count", function() {
@@ -29,8 +27,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 150 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( -10 );
-		expect( assessment.getText() ).toEqual( "The text contains 150 words. This is far below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 150 words. This is far below the recommended minimum of 300 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses a slightly higher than medium word count", function() {
@@ -38,8 +35,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 225 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "The text contains 225 words. This is below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
-			"Add more content that is relevant for the topic." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 225 words. This is below the recommended minimum of 300 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
 	} );
 
 	it( "assesses an almost at the recommended amount, word count", function() {
@@ -47,8 +43,7 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 275 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "The text contains 275 words. This is slightly below the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words. " +
-			 "Add a bit more copy." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 275 words. This is slightly below the recommended minimum of 300 words. <a href='https://yoa.st/34o' target='_blank'>Add a bit more copy</a>." );
 	} );
 
 
@@ -57,6 +52,6 @@ describe( "A word count assessment", function() {
 		var assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 325 ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "The text contains 325 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 325 words. Good job!" );
 	} );
 } );

--- a/spec/assessments/urlLengthSpec.js
+++ b/spec/assessments/urlLengthSpec.js
@@ -11,7 +11,8 @@ describe( "An assessment for the urlLengthAssessment", function() {
 		var result = urlLengthAssessment.getResult( paper, factory.buildMockResearcher( true ), i18n );
 
 		expect( result.score ).toBe( 6 );
-		expect( result.text ).toBe( "The slug for this page is a bit long, consider shortening it." );
+		expect( result.text ).toBe( "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: " +
+			"the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!" );
 
 		var paper = new Paper();
 		var result = urlLengthAssessment.getResult( paper, factory.buildMockResearcher( false ), i18n );

--- a/spec/assessments/urlStopWordsSpec.js
+++ b/spec/assessments/urlStopWordsSpec.js
@@ -21,7 +21,7 @@ describe( "A stop word in url assessment", function() {
 
 		var assessment = stopWordsInUrlAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 5 );
-		expect( assessment.getText() ).toEqual( "The slug for this page contains a <a href='http://en.wikipedia.org/wiki/Stop_words' target='_blank'>stop word</a>, consider removing it." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!" );
 	} );
 
 	it( "assesses multiple stop words in the url", function() {
@@ -31,7 +31,7 @@ describe( "A stop word in url assessment", function() {
 
 		var assessment = stopWordsInUrlAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about", "before" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 5 );
-		expect( assessment.getText() ).toEqual( "The slug for this page contains <a href='http://en.wikipedia.org/wiki/Stop_words' target='_blank'>stop words</a>, consider removing them." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains stop words. <a href='https://yoa.st/34q' target='_blank'>Remove them</a>!" );
 	} );
 } );
 

--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -22,22 +22,25 @@ describe( "checks for keyword doubles", function() {
 
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
 		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).score ).toBe( 6 );
-		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://post?1' target='_blank'>once before</a>. " +
-			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
+		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
+			"You've used this focus keyphrase <a href='http://post?1' target='_blank'>once before</a>. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Do not use your focus keyphrase more than once</a>." );
 
 		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).score ).toBe( 1 );
-		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword' target='_blank'>2 times before</a>. " +
-			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
+		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
+			"You've used this focus keyphrase <a href='http://search?keyword' target='_blank'>2 times before</a>. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Do not use your focus keyphrase more than once</a>." );
 
 		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).score ).toBe( 9 );
-		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "You've <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>never used this focus keyword before</a>, very good." );
+		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: You've not used this focus keyphrase before, very good." );
 	} );
 
 	it( "escapes the keyword's special characters in the url", function() {
 		var paper = new Paper( "text", { keyword: "keyword/bla" } );
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
-		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "You've used this focus keyword <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. " +
-			"It’s probably a good idea to read about <a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>why you should not use your focus keyword more than once</a>." );
+		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
+			"You've used this focus keyphrase <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Do not use your focus keyphrase more than once</a>." );
 	} );
 } );
 

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -113,11 +113,11 @@ const expectedResults = {
 	},
 	urlLength: {
 		score: 6,
-		resultText: "The slug for this page is a bit long, consider shortening it.",
+		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
 	},
 	urlStopWords: {
 		score: 5,
-		resultText: "The slug for this page contains a <a href='http://en.wikipedia.org/wiki/Stop_words' target='_blank'>stop word</a>, consider removing it.",
+		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!",
 	},
 	largestKeywordDistance: {
 		score: 1,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -57,7 +57,7 @@ const expectedResults = {
 	},
 	keyphraseLength: {
 		score: 9,
-		resultText: "Your <a href='https://yoa.st/2pdd' target='_blank'>keyphrase</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!",
 	},
 	keywordDensity: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -97,7 +97,7 @@ const expectedResults = {
 	},
 	internalLinks: {
 		score: 3,
-		resultText: "No <a href='https://yoa.st/2pm' target='_blank'>internal links</a> appear in this page, consider adding some as appropriate.",
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>",
 	},
 	titleKeyword: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -53,7 +53,7 @@ const paper = new Paper( "<p>My husband &#8211; <a href='https://yoast.com/about
 const expectedResults = {
 	introductionKeyword: {
 		score: 9,
-		resultText: "All topic words appear within one sentence in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy.",
+		resultText: "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!",
 	},
 	keyphraseLength: {
 		score: 9,
@@ -85,7 +85,7 @@ const expectedResults = {
 	},
 	textImages: {
 		score: 3,
-		resultText: "No <a href='https://yoa.st/2pj' target='_blank'>images</a> appear in this page, consider adding some as appropriate.",
+		resultText: "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: No images appear on this page. <a href='https://yoa.st/33d' target='_blank'>Add some</a>!",
 	},
 	textLength: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -73,7 +73,7 @@ const expectedResults = {
 	},
 	metaDescriptionLength: {
 		score: 6,
-		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: The meta description is over 156 characters. To ensure the entire description will be visible, <a href='https://yoa.st/34e' target='_blank'>you should reduce the length!</a>",
+		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: The meta description is over 156 characters. To ensure the entire description will be visible, <a href='https://yoa.st/34e' target='_blank'>you should reduce the length</a>!",
 	},
 	subheadingsKeyword: {
 		score: 6,

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -73,7 +73,7 @@ const expectedResults = {
 	},
 	metaDescriptionLength: {
 		score: 6,
-		resultText: "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> is over 156 characters. Reducing the length will ensure the entire description will be visible.",
+		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: The meta description is over 156 characters. To ensure the entire description will be visible, <a href='https://yoa.st/34e' target='_blank'>you should reduce the length!</a>",
 	},
 	subheadingsKeyword: {
 		score: 6,
@@ -89,15 +89,15 @@ const expectedResults = {
 	},
 	textLength: {
 		score: 9,
-		resultText: "The text contains 716 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words.",
+		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 716 words. Good job!",
 	},
 	externalLinks: {
 		score: 8,
-		resultText: "This page has 0 nofollowed <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a> and 1 normal outbound link(s).",
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
 	},
 	internalLinks: {
 		score: 3,
-		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>",
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
 	},
 	titleKeyword: {
 		score: 9,
@@ -105,7 +105,7 @@ const expectedResults = {
 	},
 	titleWidth: {
 		score: 9,
-		resultText: "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!",
 	},
 	urlKeyword: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -86,7 +86,7 @@ const expectedResults = {
 	},
 	internalLinks: {
 		score: 3,
-		resultText: "No <a href='https://yoa.st/2pm' target='_blank'>internal links</a> appear in this page, consider adding some as appropriate.",
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>",
 	},
 	titleKeyword: {
 		score: 6,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -62,7 +62,7 @@ const expectedResults = {
 	},
 	metaDescriptionLength: {
 		score: 9,
-		resultText: "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!",
 	},
 	subheadingsKeyword: {
 		score: 9,
@@ -78,15 +78,15 @@ const expectedResults = {
 	},
 	textLength: {
 		score: 9,
-		resultText: "The text contains 908 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words.",
+		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 908 words. Good job!",
 	},
 	externalLinks: {
 		score: 8,
-		resultText: "This page has 0 nofollowed <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a> and 6 normal outbound link(s).",
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
 	},
 	internalLinks: {
 		score: 3,
-		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>",
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
 	},
 	titleKeyword: {
 		score: 6,
@@ -94,7 +94,7 @@ const expectedResults = {
 	},
 	titleWidth: {
 		score: 9,
-		resultText: "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!",
 	},
 	urlKeyword: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -102,11 +102,11 @@ const expectedResults = {
 	},
 	urlLength: {
 		score: 6,
-		resultText: "The slug for this page is a bit long, consider shortening it.",
+		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
 	},
 	urlStopWords: {
 		score: 5,
-		resultText: "The slug for this page contains a <a href='http://en.wikipedia.org/wiki/Stop_words' target='_blank'>stop word</a>, consider removing it.",
+		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!",
 	},
 	largestKeywordDistance: {
 		score: 1,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -46,7 +46,7 @@ const expectedResults = {
 	},
 	keyphraseLength: {
 		score: 9,
-		resultText: "Your <a href='https://yoa.st/2pdd' target='_blank'>keyphrase</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!",
 	},
 	keywordDensity: {
 		score: 4,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -42,7 +42,7 @@ const paper = new Paper( "<div class=\"content\"><p></p>\n" +
 const expectedResults = {
 	introductionKeyword: {
 		score: 6,
-		resultText: "All topic words appear in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy, but not within one sentence.",
+		resultText: "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. <a href='https://yoa.st/33f' target='_blank'>Fix that</a>!",
 	},
 	keyphraseLength: {
 		score: 9,
@@ -74,7 +74,7 @@ const expectedResults = {
 	},
 	textImages: {
 		score: 9,
-		resultText: "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page contain alt attributes with the topic words.",
+		resultText: "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!",
 	},
 	textLength: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -81,7 +81,7 @@ const expectedResults = {
 	},
 	internalLinks: {
 		score: 3,
-		resultText: "No <a href='https://yoa.st/2pm' target='_blank'>internal links</a> appear in this page, consider adding some as appropriate.",
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>",
 	},
 	titleKeyword: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -57,7 +57,7 @@ const expectedResults = {
 	},
 	metaDescriptionLength: {
 		score: 9,
-		resultText: "The <a href='https://yoa.st/2pg' target='_blank'>meta description</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!",
 	},
 	subheadingsKeyword: {
 		score: 9,
@@ -73,15 +73,15 @@ const expectedResults = {
 	},
 	textLength: {
 		score: 9,
-		resultText: "The text contains 529 words. This is more than or equal to the <a href='https://yoa.st/2pk' target='_blank'>recommended minimum</a> of 300 words.",
+		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 529 words. Good job!",
 	},
 	externalLinks: {
 		score: 8,
-		resultText: "This page has 0 nofollowed <a href='https://yoa.st/2pl' target='_blank'>outbound link(s)</a> and 1 normal outbound link(s).",
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
 	},
 	internalLinks: {
 		score: 3,
-		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some!</a>",
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
 	},
 	titleKeyword: {
 		score: 9,
@@ -89,7 +89,7 @@ const expectedResults = {
 	},
 	titleWidth: {
 		score: 9,
-		resultText: "The <a href='https://yoa.st/2po' target='_blank'>SEO title</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!",
 	},
 	urlKeyword: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -97,11 +97,11 @@ const expectedResults = {
 	},
 	urlLength: {
 		score: 6,
-		resultText: "The slug for this page is a bit long, consider shortening it.",
+		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
 	},
 	urlStopWords: {
 		score: 5,
-		resultText: "The slug for this page contains <a href='http://en.wikipedia.org/wiki/Stop_words' target='_blank'>stop words</a>, consider removing them.",
+		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains stop words. <a href='https://yoa.st/34q' target='_blank'>Remove them</a>!",
 	},
 	largestKeywordDistance: {
 		score: 1,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -37,7 +37,7 @@ const paper = new Paper( "<div class=\"content content__first\">\n" +
 const expectedResults = {
 	introductionKeyword: {
 		score: 9,
-		resultText: "All topic words appear within one sentence in the <a href='https://yoa.st/2pc' target='_blank'>first paragraph</a> of the copy.",
+		resultText: "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!",
 	},
 	keyphraseLength: {
 		score: 9,
@@ -69,7 +69,7 @@ const expectedResults = {
 	},
 	textImages: {
 		score: 6,
-		resultText: "The <a href='https://yoa.st/2pj' target='_blank'>images</a> on this page do not have alt attributes with the topic words.",
+		resultText: "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!",
 	},
 	textLength: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -41,7 +41,7 @@ const expectedResults = {
 	},
 	keyphraseLength: {
 		score: 9,
-		resultText: "Your <a href='https://yoa.st/2pdd' target='_blank'>keyphrase</a> has a nice length.",
+		resultText: "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!",
 	},
 	keywordDensity: {
 		score: 9,

--- a/src/assessments/seo/InternalLinksAssessment.js
+++ b/src/assessments/seo/InternalLinksAssessment.js
@@ -33,7 +33,8 @@ class InternalLinksAssessment extends Assessment {
 				noneInternalFollow: 7,
 				noInternal: 3,
 			},
-			url: "<a href='https://yoa.st/2pm' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/33z' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34a' target='_blank'>",
 		};
 
 		this.identifier = "internalLinks";
@@ -83,9 +84,11 @@ class InternalLinksAssessment extends Assessment {
 			return {
 				score: this._config.scores.noInternal,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "No %1$sinternal links%2$s appear in this page, consider adding some as appropriate." ),
-					this._config.url,
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sInternal links%3$s: " +
+						"No internal links appear in this page, %2$smake sure to add some!%3$s" ),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -95,11 +98,11 @@ class InternalLinksAssessment extends Assessment {
 			return {
 				score: this._config.scores.noneInternalFollow,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands the number of internal links, %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "This page has %1$s %2$sinternal link(s)%3$s, all nofollowed." ),
-					this.linkStatistics.internalNofollow,
-					this._config.url,
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sInternal links%3$s: " +
+						"The internal links in this page are all nofollowed. %2$sAdd some good internal links%3$s." ),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -109,11 +112,9 @@ class InternalLinksAssessment extends Assessment {
 			return {
 				score: this._config.scores.allInternalFollow,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands to the number of internal links, %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "This page has %1$s %2$sinternal link(s)%3$s." ),
-					this.linkStatistics.internalTotal,
-					this._config.url,
+					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sInternal links%2$s: You have enough internal links. Good job!" ),
+					this._config.urlTitle,
 					"</a>"
 				),
 			};
@@ -121,16 +122,13 @@ class InternalLinksAssessment extends Assessment {
 		return {
 			score: this._config.scores.someInternalFollow,
 			resultText: i18n.sprintf(
-				/* Translators: %1$s expands to the number of nofollow links, %2$s expands to a link on yoast.com,
-				%3$s expands to the anchor end tag, %4$s to the number of internal links */
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"This page has %1$s nofollowed %2$sinternal link(s)%3$s and %4$s normal internal link(s)."
+					"%1$sInternal links%2$s: The internal links on this page are both nofollowed and normal. Good job!"
 				),
-				this.linkStatistics.internalNofollow,
-				this._config.url,
+				this._config.urlTitle,
 				"</a>",
-				this.linkStatistics.internalDofollow
 			),
 		};
 	}

--- a/src/assessments/seo/InternalLinksAssessment.js
+++ b/src/assessments/seo/InternalLinksAssessment.js
@@ -86,7 +86,7 @@ class InternalLinksAssessment extends Assessment {
 				resultText: i18n.sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext( "js-text-analysis", "%1$sInternal links%3$s: " +
-						"No internal links appear in this page, %2$smake sure to add some!%3$s" ),
+						"No internal links appear in this page, %2$smake sure to add some%3$s!" ),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
 					"</a>"
@@ -125,7 +125,7 @@ class InternalLinksAssessment extends Assessment {
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sInternal links%2$s: The internal links on this page are both nofollowed and normal. Good job!"
+					"%1$sInternal links%2$s: There are both nofollowed and normal internal links on this page. Good job!"
 				),
 				this._config.urlTitle,
 				"</a>",

--- a/src/assessments/seo/IntroductionKeywordAssessment.js
+++ b/src/assessments/seo/IntroductionKeywordAssessment.js
@@ -27,7 +27,8 @@ class IntroductionKeywordAssessment extends Assessment {
 				okay: 6,
 				bad: 3,
 			},
-			url: "<a href='https://yoa.st/2pc' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/33e' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/33f' target='_blank'>",
 		};
 
 		this.identifier = "introductionKeyword";
@@ -81,9 +82,9 @@ class IntroductionKeywordAssessment extends Assessment {
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"All topic words appear within one sentence in the %1$sfirst paragraph%2$s of the copy."
+						"%1$sKeyphrase in introduction%2$s: Well done!"
 					),
-					this._config.url,
+					this._config.urlTitle,
 					"</a>"
 				),
 			};
@@ -93,12 +94,14 @@ class IntroductionKeywordAssessment extends Assessment {
 			return {
 				score: this._config.scores.okay,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"All topic words appear in the %1$sfirst paragraph%2$s of the copy, but not within one sentence."
+						"%1$sKeyphrase in introduction%3$s:" +
+						"Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. %2$sFix that%3$s!"
 					),
-					this._config.url,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -107,12 +110,14 @@ class IntroductionKeywordAssessment extends Assessment {
 		return {
 			score: this._config.scores.bad,
 			resultText: i18n.sprintf(
-				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag. */
 				i18n.dgettext(
 					"js-text-analysis",
-					"Not all topic words appear in the %1$sfirst paragraph%2$s of the copy. Make sure the topic is clear immediately."
+					"%1$sKeyphrase in introduction%3$s: Your keyphrase or its synonyms do not appear in the first paragraph. " +
+					"%2$sMake sure the topic is clear immediately%3$s."
 				),
-				this._config.url,
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>"
 			),
 		};

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -35,8 +35,8 @@ class KeyphraseLengthAssessment extends Assessment {
 				okay: 6,
 				good: 9,
 			},
-			urlNoOrGoodKeyword: "<a href='https://yoa.st/2pdd' target='_blank'>",
-			urlKeyphraseTooLong: "<a href='https://yoa.st/2pd' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/33i' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/33j' target='_blank'>",
 		};
 
 		this.identifier = "keyphraseLength";
@@ -78,12 +78,14 @@ class KeyphraseLengthAssessment extends Assessment {
 			return {
 				score: this._config.scores.veryBad,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext(
 						"js-text-analysis",
-						"No %1$sfocus keyword%2$s was set for this page. If you do not set a focus keyword, no score can be calculated."
+						"%1$sKeyphrase length%3$s: No focus keyphrase was set for this page. " +
+						"%2$sSet a focus keyphrase in order to calculate your SEO score%3$s."
 					),
-					this._config.urlNoOrGoodKeyword,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -96,9 +98,9 @@ class KeyphraseLengthAssessment extends Assessment {
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"Your %1$skeyphrase%2$s has a nice length."
+						"%1$sKeyphrase length%2$s: Good job!"
 					),
-					this._config.urlNoOrGoodKeyword,
+					this._config.urlTitle,
 					"</a>"
 				),
 			};
@@ -111,16 +113,17 @@ class KeyphraseLengthAssessment extends Assessment {
 					/* Translators:
 					%1$d expands to the number of words in the keyphrase,
 					%2$d expands to the recommended maximum of words in the keyphrase,
-					%3$s expands to a link on yoast.com,
-					%4$s expands to the anchor end tag. */
+					%3$s and %4$s expand to links on yoast.com,
+					%5$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"Your %3$skeyphrase%4$s is %1$d words long. That's more than the recommended maximum of %2$d words. " +
-						"You might want to make the keyphrase a bit shorter."
+						"%3$sKeyphrase length%5$s: The keyphrase is %1$d words long. That's more than the recommended maximum of %2$d words. " +
+							"%4$sMake it shorter%5$s!"
 					),
 					this._keyphraseLength,
 					this._config.parameters.recommendedMaximum,
-					this._config.urlKeyphraseTooLong,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -132,16 +135,17 @@ class KeyphraseLengthAssessment extends Assessment {
 				/* Translators:
 				%1$d expands to the number of words in the keyphrase,
 				%2$d expands to the recommended maximum of words in the keyphrase,
-				%3$s expands to a link on yoast.com,
-				%4$s expands to the anchor end tag. */
+				%3$s and %4$s expand to links on yoast.com,
+				%5$s expands to the anchor end tag. */
 				i18n.dgettext(
 					"js-text-analysis",
-					"Your %3$skeyphrase%4$s is %1$d words long. That's way more than the recommended maximum of %2$d " +
-					"words. Make the keyphrase shorter."
+					"%3$sKeyphrase length%5$s: The keyphrase is %1$d words long. That's way more than the recommended maximum of %2$d words. " +
+					"%4$sMake it shorter%5$s!"
 				),
 				this._keyphraseLength,
 				this._config.parameters.recommendedMaximum,
-				this._config.urlKeyphraseTooLong,
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>"
 			),
 		};

--- a/src/assessments/seo/TextCompetingLinksAssessment.js
+++ b/src/assessments/seo/TextCompetingLinksAssessment.js
@@ -31,7 +31,8 @@ class TextCompetingLinksAssessment extends Assessment {
 			scores: {
 				bad: 2,
 			},
-			url: "<a href='https://yoa.st/2pi' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/34l' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34m' target='_blank'>",
 		};
 
 		this.identifier = "textCompetingLinks";
@@ -89,13 +90,15 @@ class TextCompetingLinksAssessment extends Assessment {
 			return {
 				score: this._config.scores.bad,
 				resultText: i18n.sprintf(
-					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+					/* Translators:  %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext(
 						"js-text-analysis",
-						"You're %1$slinking to another page with the focus keyword%2$s you want this page to rank for. " +
-						"Consider changing that if you truly want this page to rank."
+						"%1$sLink focus keyphrase%3$s: " +
+						"You're linking to another page with the words you want this page to rank for. " +
+						"%2$sDon't do that%3$s!"
 					),
-					this._config.url,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};

--- a/src/assessments/seo/keywordStopWordsAssessment.js
+++ b/src/assessments/seo/keywordStopWordsAssessment.js
@@ -17,12 +17,10 @@ var calculateStopWordsCountResult = function( stopWordCount, i18n ) {
 			score: 0,
 			text: i18n.dngettext(
 				"js-text-analysis",
-				/* Translators: %1$s opens a link to a Yoast article about stop words, %2$s closes the link */
-				"The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. " +
-				"%1$sLearn more about the stop words%2$s.",
-				"The focus keyword contains %3$d stop words. This may or may not be wise depending on the circumstances. " +
-				"%1$sLearn more about the stop words%2$s.",
-				stopWordCount
+				/* Translators: %1$s and %2$s open links to Yoast articles, %3$s is the anchor end tag */
+				"%1$sStopwords%3$s: The focus keyphrase contains stop words. " +
+				"This may or may not be wise depending on the circumstances. " +
+				"%2$sLearn more about stop words%3$s.",
 			),
 		};
 	}
@@ -47,7 +45,8 @@ const keywordHasStopWordsAssessment = function( paper, researcher, i18n ) {
 	assessmentResult.setScore( stopWordsResult.score );
 	assessmentResult.setText( i18n.sprintf(
 		stopWordsResult.text,
-		"<a href='https://yoa.st/stopwords/' target='_blank'>",
+		"<a href='https://yoa.st/34b' target='_blank'>",
+		"<a href='https://yoa.st/34c' target='_blank'>",
 		"</a>",
 		stopWords.length
 	) );

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -123,7 +123,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 				%4$d expands to the number of characters in the meta description, %5$d expands to
 				the total available number of characters in the meta description */
 				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s: The meta description is too short (under %4$d characters). " +
-				"Up to %5$d characters are available. %2$sUse the space!%3$s" ),
+				"Up to %5$d characters are available. %2$sUse the space%3$s!" ),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>",
@@ -137,7 +137,7 @@ class MetaDescriptionLengthAssessment extends Assessment {
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
 				%4$d expands to	the total available number of characters in the meta description */
 				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s: The meta description is over %4$d characters. " +
-				"To ensure the entire description will be visible, %2$syou should reduce the length!%3$s" ),
+				"To ensure the entire description will be visible, %2$syou should reduce the length%3$s!" ),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>",

--- a/src/assessments/seo/metaDescriptionLengthAssessment.js
+++ b/src/assessments/seo/metaDescriptionLengthAssessment.js
@@ -30,6 +30,8 @@ class MetaDescriptionLengthAssessment extends Assessment {
 				tooShort: 6,
 				correctLength: 9,
 			},
+			urlTitle: "<a href='https://yoa.st/34d' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34e' target='_blank'>",
 		};
 
 		this.identifier = "metaDescriptionLength";
@@ -104,26 +106,26 @@ class MetaDescriptionLengthAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( descriptionLength, i18n ) {
-		const url = "<a href='https://yoa.st/2pg' target='_blank'>";
-
 		if ( descriptionLength === 0 ) {
 			return i18n.sprintf(
-				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "No %1$smeta description%2$s has been specified. " +
-				"Search engines will display copy from the page instead." ),
-				url,
+				/* Translators:  %1$s and %2$s expand to a links on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s:  No meta description has been specified. " +
+					"Search engines will display copy from the page instead. %2$sMake sure to write one%3$s!" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>"
 			);
 		}
 
 		if ( descriptionLength <= this._config.recommendedMaximumLength ) {
 			return i18n.sprintf(
-				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
-				%3$d expands to the number of characters in the meta description, %4$d expands to
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
+				%4$d expands to the number of characters in the meta description, %5$d expands to
 				the total available number of characters in the meta description */
-				i18n.dgettext( "js-text-analysis", "The %1$smeta description%2$s is under %3$d characters long. " +
-				"However, up to %4$d characters are available." ),
-				url,
+				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s: The meta description is too short (under %4$d characters). " +
+				"Up to %5$d characters are available. %2$sUse the space!%3$s" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>",
 				this._config.recommendedMaximumLength,
 				this._config.maximumLength
@@ -132,11 +134,12 @@ class MetaDescriptionLengthAssessment extends Assessment {
 
 		if ( descriptionLength > this._config.maximumLength ) {
 			return i18n.sprintf(
-				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
-				%3$d expands to	the total available number of characters in the meta description */
-				i18n.dgettext( "js-text-analysis", "The %1$smeta description%2$s is over %3$d characters. " +
-				"Reducing the length will ensure the entire description will be visible." ),
-				url,
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
+				%4$d expands to	the total available number of characters in the meta description */
+				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s: The meta description is over %4$d characters. " +
+				"To ensure the entire description will be visible, %2$syou should reduce the length!%3$s" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>",
 				this._config.maximumLength
 			);
@@ -145,8 +148,8 @@ class MetaDescriptionLengthAssessment extends Assessment {
 		if ( descriptionLength >= this._config.recommendedMaximumLength && descriptionLength <= this._config.maximumLength ) {
 			return i18n.sprintf(
 				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "The %1$smeta description%2$s has a nice length." ),
-				url,
+				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%2$s: Well done!" ),
+				this._config.urlTitle,
 				"</a>"
 			);
 		}

--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -25,6 +25,8 @@ class OutboundLinksAssessment extends Assessment {
 				moreNoFollowed: 8,
 				allFollowed: 9,
 			},
+			urlTitle: "<a href='https://yoa.st/34f' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34g' target='_blank'>",
 		};
 
 		this.identifier = "externalLinks";
@@ -97,45 +99,51 @@ class OutboundLinksAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( linkStatistics, i18n ) {
-		const url = "<a href='https://yoa.st/2pl' target='_blank'>";
-
 		if ( linkStatistics.externalTotal === 0 ) {
 			return i18n.sprintf(
-				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "No %1$soutbound links%2$s appear in this page, consider adding some as appropriate." ),
-				url,
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%3$s: " +
+					"No outbound links appear in this page. " +
+					"%2$sAdd some%3$s!" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>"
 			);
 		}
 
 		if ( linkStatistics.externalNofollow === linkStatistics.total ) {
 			return i18n.sprintf(
-				/* Translators: %1$s expands the number of outbound links, %2$s expands to a link on yoast.com,
-				%3$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$soutbound link(s)%3$s, all nofollowed." ),
-				linkStatistics.externalNofollow,
-				url,
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%3$s: " +
+					"All outbound links on this page are nofollowed. " +
+					"%2$sAdd some normal links%3$s." ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>"
+			);
+		}
+
+		if ( linkStatistics.externalDofollow === linkStatistics.total ) {
+			return i18n.sprintf(
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%2$s: " +
+					"Good job!" ),
+				this._config.urlTitle,
 				"</a>"
 			);
 		}
 
 		if ( linkStatistics.externalNofollow < linkStatistics.externalTotal ) {
 			return i18n.sprintf(
-				/* Translators: %1$s expands to the number of nofollow links, %2$s expands to a link on yoast.com,
-				%3$s expands to the anchor end tag, %4$s to the number of outbound links */
-				i18n.dgettext( "js-text-analysis", "This page has %1$s nofollowed %2$soutbound link(s)%3$s and %4$s normal outbound link(s)." ),
-				linkStatistics.externalNofollow,
-				url,
+				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%2$s: " +
+					"There are both nofollowed and normal outbound links on this page. " +
+					"Good job!" ),
+				this._config.urlTitle,
 				"</a>",
-				linkStatistics.externalDofollow );
+			);
 		}
 
-		if ( linkStatistics.externalDofollow === linkStatistics.total ) {
-			return i18n.sprintf(
-				/* Translators: %1$s expands to the number of outbound links, %2$s expands to a link on yoast.com,
-				%3$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "This page has %1$s %2$soutbound link(s)%3$s." ), linkStatistics.externalTotal );
-		}
 
 		return "";
 	}

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -101,7 +101,7 @@ class PageTitleWidthAssesment extends Assessment {
 	translateScore( pageTitleWidth, i18n ) {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
 			return i18n.sprintf(
-				/* Translators: %1$s and %1$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
 					"%1$sSEO title width%3$s: The SEO title is too short. " +
@@ -127,7 +127,7 @@ class PageTitleWidthAssesment extends Assessment {
 
 		if ( pageTitleWidth > this._config.maxLength ) {
 			return i18n.sprintf(
-				/* Translators: %1$s and %1$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
 					"%1$sSEO title width%3$s: The SEO title wider than the viewable limit. %2$sTry to make it shorter%3$s."
@@ -139,7 +139,7 @@ class PageTitleWidthAssesment extends Assessment {
 		}
 
 		return i18n.sprintf(
-			/* Translators: %1$s and %1$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+			/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 			i18n.dgettext( "js-text-analysis", "%1$sSEO title width%3$s: %2$sPlease create an SEO title%3$s." ),
 			this._config.urlTitle,
 			this._config.urlCallToAction,

--- a/src/assessments/seo/pageTitleWidthAssessment.js
+++ b/src/assessments/seo/pageTitleWidthAssessment.js
@@ -28,6 +28,8 @@ class PageTitleWidthAssesment extends Assessment {
 				widthTooLong: 3,
 				widthCorrect: 9,
 			},
+			urlTitle: "<a href='https://yoa.st/34h' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34i' target='_blank'>",
 		};
 
 		this.identifier = "titleWidth";
@@ -97,14 +99,18 @@ class PageTitleWidthAssesment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( pageTitleWidth, i18n ) {
-		const url = "<a href='https://yoa.st/2po' target='_blank'>";
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
 			return i18n.sprintf(
-				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				/* Translators: %1$s and %1$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"The %1$sSEO title%2$s is too short. Use the space to add keyword variations or create compelling call-to-action copy."
-				), url, "</a>" );
+					"%1$sSEO title width%3$s: The SEO title is too short. " +
+					"%2$sUse the space to add keyword variations or create compelling call-to-action copy%3$s."
+				),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>"
+			);
 		}
 
 		if ( inRange( pageTitleWidth, this._config.minLength, this._config.maxLength ) ) {
@@ -112,23 +118,32 @@ class PageTitleWidthAssesment extends Assessment {
 				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"The %1$sSEO title%2$s has a nice length."
-				), url, "</a>" );
+					"%1$sSEO title width%2$s: Good job!"
+				),
+				this._config.urlTitle,
+				"</a>"
+			);
 		}
 
 		if ( pageTitleWidth > this._config.maxLength ) {
 			return i18n.sprintf(
-				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				/* Translators: %1$s and %1$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"The %1$sSEO title%2$s is wider than the viewable limit."
-				),  url, "</a>" );
+					"%1$sSEO title width%3$s: The SEO title wider than the viewable limit. %2$sTry to make it shorter%3$s."
+				),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>"
+			);
 		}
 
 		return i18n.sprintf(
-			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-			i18n.dgettext( "js-text-analysis", "Please create an %1$sSEO title%2$s." ),
-			url, "</a>"
+			/* Translators: %1$s and %1$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+			i18n.dgettext( "js-text-analysis", "%1$sSEO title width%3$s: %2$sPlease create an SEO title%3$s." ),
+			this._config.urlTitle,
+			this._config.urlCallToAction,
+			"</a>"
 		);
 	}
 }

--- a/src/assessments/seo/taxonomyTextLengthAssessment.js
+++ b/src/assessments/seo/taxonomyTextLengthAssessment.js
@@ -37,7 +37,7 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 				i18n.dngettext(
 					"js-text-analysis",
 					/* Translators: %1$d expands to the number of words in the text,
-					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					%2$s expands to a link on yoast.com, %4$d expands to the anchor end tag. */
 					"%2$sText length%4$s: The text contains %1$d word.",
 					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
@@ -46,7 +46,7 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
 					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
 					recommendedMinimum
@@ -76,7 +76,7 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					recommendedMinimum
@@ -106,7 +106,7 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					recommendedMinimum
@@ -136,7 +136,7 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 					"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					recommendedMinimum

--- a/src/assessments/seo/taxonomyTextLengthAssessment.js
+++ b/src/assessments/seo/taxonomyTextLengthAssessment.js
@@ -9,7 +9,8 @@ const recommendedMinimum = 150;
  * @returns {object} The resulting score object.
  */
 const calculateWordCountResult = function( wordCount, i18n ) {
-	const url = "<a href='https://yoa.st/2pk' target='_blank'>";
+	const urlTitle = "<a href='https://yoa.st/34j' target='_blank'>";
+	const urlCallToAction = "<a href='https://yoa.st/34k' target='_blank'>";
 
 	if ( wordCount >= 150 ) {
 		return {
@@ -17,22 +18,14 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 			text: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text. */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
-					wordCount
-				) + " " + i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag,	%4$s expands to the recommended minimum of words. */
-					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d word.",
-					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d words.",
-					recommendedMinimum
-				),
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+					"%2$sText length%3$s: The text contains %1$d word. Good job!",
+					"%2$sText length%3$s: The text contains %1$d words. Good job!",
+					wordCount ),
 				wordCount,
-				url,
+				urlTitle,
 				"</a>",
-				recommendedMinimum
 			),
 		};
 	}
@@ -43,20 +36,24 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 			text: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text. */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
-					"This is slightly below the %2$srecommended minimum%3$s of %4$d word. Add a bit more copy.",
-					"This is slightly below the %2$srecommended minimum%3$s of %4$d words. Add a bit more copy.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
+					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
 					recommendedMinimum
 				),
 				wordCount,
-				url,
+				urlTitle,
+				urlCallToAction,
 				"</a>",
 				recommendedMinimum
 			),
@@ -69,20 +66,24 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 			text: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text. */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
-					"This is below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
-					"This is below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					recommendedMinimum
 				),
 				wordCount,
-				url,
+				urlTitle,
+				urlCallToAction,
 				"</a>",
 				recommendedMinimum
 			),
@@ -95,20 +96,24 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 			text: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text. */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
-					"This is below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
-					"This is below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					recommendedMinimum
 				),
 				wordCount,
-				url,
+				urlTitle,
+				urlCallToAction,
 				"</a>",
 				recommendedMinimum
 			),
@@ -121,20 +126,24 @@ const calculateWordCountResult = function( wordCount, i18n ) {
 			text: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text. */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag,  %4$s expands to the recommended minimum of words. */
-					"This is far below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
-					"This is far below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+					"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					recommendedMinimum
 				),
 				wordCount,
-				url,
+				urlTitle,
+				urlCallToAction,
 				"</a>",
 				recommendedMinimum
 			),

--- a/src/assessments/seo/textImagesAssessment.js
+++ b/src/assessments/seo/textImagesAssessment.js
@@ -25,7 +25,8 @@ class TextImagesAssessment extends Assessment {
 				withAlt: 6,
 				noAlt: 6,
 			},
-			url: "<a href='https://yoa.st/2pj' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/33c' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/33d' target='_blank'>",
 		};
 
 		this.identifier = "textImages";
@@ -79,9 +80,10 @@ class TextImagesAssessment extends Assessment {
 			return {
 				score: this._config.scores.noImages,
 				resultText: i18n.sprintf(
-					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "No %1$simages%2$s appear in this page, consider adding some as appropriate." ),
-					this._config.url,
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: No images appear on this page. %2$sAdd some%3$s!" ),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -93,8 +95,9 @@ class TextImagesAssessment extends Assessment {
 				score: this._config.scores.withAltKeyword,
 				resultText: i18n.sprintf(
 					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes with the topic words." ),
-					this._config.url,
+					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%2$s: " +
+						"Some images on this page contain alt attributes with words from your keyphrase! Good job!" ),
+					this._config.urlTitle,
 					"</a>"
 				),
 			};
@@ -105,8 +108,11 @@ class TextImagesAssessment extends Assessment {
 			return {
 				score: this._config.scores.withAltNonKeyword,
 				resultText: i18n.sprintf(
-					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page do not have alt attributes with the topic words." ),
-					this._config.url,
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
+						"Images on this page do not have alt attributes with words from your keyphrase. %2$sFix that%3$s!" ),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -117,8 +123,11 @@ class TextImagesAssessment extends Assessment {
 			return {
 				score: this._config.scores.withAlt,
 				resultText: i18n.sprintf(
-					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page contain alt attributes." ),
-					this._config.url,
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
+						"Images on this page do not have alt attributes with words from your keyphrase. %2$sFix that%3$s!" ),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -129,8 +138,11 @@ class TextImagesAssessment extends Assessment {
 			return {
 				score: this._config.scores.noAlt,
 				resultText: i18n.sprintf(
-					i18n.dgettext( "js-text-analysis", "The %1$simages%2$s on this page are missing alt attributes." ),
-					this._config.url,
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
+						"Images on this page do not have alt attributes with words from your keyphrase. %2$sFix that%3$s!" ),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -31,6 +31,8 @@ class TextLengthAssessment extends Assessment {
 				farBelowMinimum: -10,
 				veryFarBelowMinimum: -20,
 			},
+			urlTitle: "<a href='https://yoa.st/34n' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34o' target='_blank'>",
 		};
 
 		this.identifier = "textLength";
@@ -98,49 +100,43 @@ class TextLengthAssessment extends Assessment {
 	 * @returns {string} The translated string.
 	 */
 	translateScore( score, wordCount, i18n ) {
-		const url = "<a href='https://yoa.st/2pk' target='_blank'>";
-
 		if ( score === this._config.scores.recommendedMinimum ) {
 			return i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
-					wordCount
-				) + " " + i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag,	%4$s expands to the recommended minimum of words. */
-					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d word.",
-					"This is more than or equal to the %2$srecommended minimum%3$s of %4$d words.",
-					this._config.recommendedMinimum
-				),
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+					"%2$sText length%3$s: The text contains %1$d word. Good job!",
+					"%2$sText length%3$s: The text contains %1$d words. Good job!",
+					wordCount ),
 				wordCount,
-				url,
+				this._config.urlTitle,
 				"</a>",
-				this._config.recommendedMinimum
 			);
 		}
 
 		if ( score === this._config.scores.slightlyBelowMinimum ) {
-			return i18n.sprintf(
+			return  i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
-					"This is slightly below the %2$srecommended minimum%3$s of %4$d word. Add a bit more copy.",
-					"This is slightly below the %2$srecommended minimum%3$s of %4$d words. Add a bit more copy.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
+					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
 					this._config.recommendedMinimum
 				),
 				wordCount,
-				url,
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>",
 				this._config.recommendedMinimum
 			);
@@ -150,20 +146,24 @@ class TextLengthAssessment extends Assessment {
 			return i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag, %4$s expands to the recommended minimum of words. */
-					"This is below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
-					"This is below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					this._config.recommendedMinimum
 				),
 				wordCount,
-				url,
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>",
 				this._config.recommendedMinimum
 			);
@@ -173,20 +173,24 @@ class TextLengthAssessment extends Assessment {
 			return i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text */
-					"The text contains %1$d word.",
-					"The text contains %1$d words.",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
 					wordCount
 				) + " " + i18n.dngettext(
 					"js-text-analysis",
-					/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to a link on yoast.com,
-					%3$s expands to the anchor end tag,  %4$s expands to the recommended minimum of words. */
-					"This is far below the %2$srecommended minimum%3$s of %4$d word. Add more content that is relevant for the topic.",
-					"This is far below the %2$srecommended minimum%3$s of %4$d words. Add more content that is relevant for the topic.",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$s expands to the recommended minimum of words. */
+					"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+					"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					this._config.recommendedMinimum
 				),
 				wordCount,
-				url,
+				this._config.urlTitle,
+				this._config.urlCallToAction,
 				"</a>",
 				this._config.recommendedMinimum
 			);

--- a/src/assessments/seo/textLengthAssessment.js
+++ b/src/assessments/seo/textLengthAssessment.js
@@ -129,7 +129,7 @@ class TextLengthAssessment extends Assessment {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
 					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
 					this._config.recommendedMinimum
@@ -156,7 +156,7 @@ class TextLengthAssessment extends Assessment {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					this._config.recommendedMinimum
@@ -183,7 +183,7 @@ class TextLengthAssessment extends Assessment {
 					/* Translators: The preceding sentence is "Text length: The text contains x words.",
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
-					%5$s expands to the recommended minimum of words. */
+					%5$d expands to the recommended minimum of words. */
 					"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 					"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					this._config.recommendedMinimum

--- a/src/assessments/seo/urlLengthAssessment.js
+++ b/src/assessments/seo/urlLengthAssessment.js
@@ -21,6 +21,8 @@ class UrlLengthAssessment extends Assessment {
 			scores: {
 				tooLong: 6,
 			},
+			urlTitle: "<a href='https://yoa.st/35b' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/35c' target='_blank'>",
 		};
 
 		this.identifier = "urlLength";
@@ -82,7 +84,13 @@ class UrlLengthAssessment extends Assessment {
 	 */
 	translateScore( urlIsTooLong, i18n ) {
 		if ( urlIsTooLong ) {
-			return i18n.dgettext( "js-text-analysis", "The slug for this page is a bit long, consider shortening it." );
+			return i18n.sprintf(
+				/* Translators:  %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sSlug too long%3$s: the slug for this page is a bit long. %2$sShorten it%3$s!" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>",
+			);
 		}
 
 		return "";

--- a/src/assessments/seo/urlStopWordsAssessment.js
+++ b/src/assessments/seo/urlStopWordsAssessment.js
@@ -17,9 +17,9 @@ const calculateUrlStopWordsCountResult = function( stopWordCount, i18n ) {
 			score: 5,
 			text: i18n.dngettext(
 				"js-text-analysis",
-				/* Translators: %1$s opens a link to a wikipedia article about stop words, %2$s closes the link */
-				"The slug for this page contains a %1$sstop word%2$s, consider removing it.",
-				"The slug for this page contains %1$sstop words%2$s, consider removing them.",
+				/* Translators: %1$s and %2$s open links to an articles about stopwords, %3$s closes the links */
+				"%1$sSlug stopwords%3$s: The slug for this page contains a stop word. %2$sRemove it%3$s!",
+				"%1$sSlug stopwords%3$s: The slug for this page contains stop words. %2$sRemove them%3$s!",
 				stopWordCount
 			),
 		};
@@ -40,13 +40,16 @@ const calculateUrlStopWordsCountResult = function( stopWordCount, i18n ) {
 const urlHasStopWordsAssessment = function( paper, researcher, i18n ) {
 	const stopWords = researcher.getResearch( "stopWordsInUrl" );
 	const stopWordsResult = calculateUrlStopWordsCountResult( stopWords.length, i18n );
+	const urlTitle = "<a href='https://yoa.st/34p' target='_blank'>";
+	const urlCallToAction = "<a href='https://yoa.st/34q' target='_blank'>";
 
 	const assessmentResult = new AssessmentResult();
 	assessmentResult.setScore( stopWordsResult.score );
 	assessmentResult.setText( i18n.sprintf(
 		stopWordsResult.text,
 		/* Translators: this link is referred to in the content analysis when a slug contains one or more stop words */
-		"<a href='" + i18n.dgettext( "js-text-analysis", "http://en.wikipedia.org/wiki/Stop_words" ) + "' target='_blank'>",
+		urlTitle,
+		urlCallToAction,
 		"</a>"
 	) );
 

--- a/src/assessments/seo/urlStopWordsAssessment.js
+++ b/src/assessments/seo/urlStopWordsAssessment.js
@@ -12,15 +12,23 @@ const availableLanguages = [ "en" ];
  * @returns {Object} The resulting score object.
  */
 const calculateUrlStopWordsCountResult = function( stopWordCount, i18n ) {
+	const urlTitle = "<a href='https://yoa.st/34p' target='_blank'>";
+	const urlCallToAction = "<a href='https://yoa.st/34q' target='_blank'>";
+
 	if ( stopWordCount > 0 ) {
 		return {
 			score: 5,
-			text: i18n.dngettext(
-				"js-text-analysis",
+			text: i18n.sprintf(
 				/* Translators: %1$s and %2$s open links to an articles about stopwords, %3$s closes the links */
-				"%1$sSlug stopwords%3$s: The slug for this page contains a stop word. %2$sRemove it%3$s!",
-				"%1$sSlug stopwords%3$s: The slug for this page contains stop words. %2$sRemove them%3$s!",
-				stopWordCount
+				i18n.dngettext(
+					"js-text-analysis",
+					"%1$sSlug stopwords%3$s: The slug for this page contains a stop word. %2$sRemove it%3$s!",
+					"%1$sSlug stopwords%3$s: The slug for this page contains stop words. %2$sRemove them%3$s!",
+					stopWordCount
+				),
+				urlTitle,
+				urlCallToAction,
+				"</a>"
 			),
 		};
 	}
@@ -39,19 +47,13 @@ const calculateUrlStopWordsCountResult = function( stopWordCount, i18n ) {
  */
 const urlHasStopWordsAssessment = function( paper, researcher, i18n ) {
 	const stopWords = researcher.getResearch( "stopWordsInUrl" );
-	const stopWordsResult = calculateUrlStopWordsCountResult( stopWords.length, i18n );
-	const urlTitle = "<a href='https://yoa.st/34p' target='_blank'>";
-	const urlCallToAction = "<a href='https://yoa.st/34q' target='_blank'>";
 
 	const assessmentResult = new AssessmentResult();
+
+	const stopWordsResult = calculateUrlStopWordsCountResult( stopWords.length, i18n );
+
 	assessmentResult.setScore( stopWordsResult.score );
-	assessmentResult.setText( i18n.sprintf(
-		stopWordsResult.text,
-		/* Translators: this link is referred to in the content analysis when a slug contains one or more stop words */
-		urlTitle,
-		urlCallToAction,
-		"</a>"
-	) );
+	assessmentResult.setText( stopWordsResult.text );
 
 	return assessmentResult;
 };

--- a/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/src/bundledPlugins/previouslyUsedKeywords.js
@@ -27,6 +27,8 @@ var PreviouslyUsedKeyword = function( app, args ) {
 	this.usedKeywords = args.usedKeywords;
 	this.searchUrl = args.searchUrl;
 	this.postUrl = args.postUrl;
+	this.urlTitle = "<a href='https://yoa.st/33x' target='_blank'>";
+	this.urlCallToAction = "<a href='https://yoa.st/33y' target='_blank'>";
 };
 
 /**
@@ -68,10 +70,10 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 		return {
 			text: i18n.sprintf(
 				/* Translators:
-				%1$s expands to a link to an article on yoast.com about why you should not use a keyword more than once,
+				%1$s expands to a link to an article on yoast.com,
 				%2$s expands to an anchor tag. */
-				i18n.dgettext( "js-text-analysis", "You've %1$snever used this focus keyword before%2$s, very good." ),
-				"<a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>",
+				i18n.dgettext( "js-text-analysis", "%1$sPreviously used keyphrase%2$s: You've not used this focus keyphrase before, very good." ),
+				this.urlTitle,
 				"</a>"
 			),
 			score: 9,
@@ -81,10 +83,16 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 		var url = "<a href='" + this.postUrl.replace( "{id}", id ) + "' target='_blank'>";
 		return {
 			/* Translators: %1$s and %2$s expand to an admin link where the focus keyword is already used. %3$s and %4$s
-			expand to a link to an article on yoast.com about why you should not use a keyword more than once. */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "You've used this focus keyword %1$sonce before%2$s. " +
-				"It’s probably a good idea to read about %3$swhy you should not use your focus keyword more than once%4$s." ),
-			url, "</a>",  "<a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>", "</a>" ),
+			expand to links on yoast.com, %4$s expands to the anchor end tag. */
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%3$sPreviously used keyphrase%5$s: " +
+				"You've used this focus keyphrase %1$sonce before%2$s. " +
+				"%4$sDo not use your focus keyphrase more than once%5$s." ),
+			url,
+			"</a>",
+			this.urlTitle,
+			this.urlCallToAction,
+			"</a>"
+			),
 			score: 6,
 		};
 	}
@@ -92,11 +100,18 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 		url = "<a href='" + this.searchUrl.replace( "{keyword}", encodeURIComponent( paper.getKeyword() ) ) + "' target='_blank'>";
 		return {
 			/* Translators: %1$s and $3$s expand to the admin search page for the focus keyword, %2$d expands to the number
-			of times this focus keyword has been used before, %4$s and %5$s expand to a link to an article on yoast.com
-			about why you should not use a keyword more than once. */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "You've used this focus keyword %1$s%2$d times before%3$s. " +
-				"It’s probably a good idea to read about %4$swhy you should not use your focus keyword more than once%5$s." ),
-			url, count, "</a>", "<a href='https://yoa.st/20x' target='_blank' rel='noopener noreferrer'>", "</a>" ),
+			of times this focus keyword has been used before, %4$s and %5$s expand to links to yoast.com, %6$s expands to
+			the anchor end tag */
+			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%4$sPreviously used keyphrase%6$s: " +
+				"You've used this focus keyphrase %1$s%2$d times before%3$s. " +
+				"%5$sDo not use your focus keyphrase more than once%6$s." ),
+			url,
+			count,
+			"</a>",
+			this.urlTitle,
+			this.urlCallToAction,
+			"</a>"
+			),
 			score: 1,
 		};
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the feedback strings of SEO assessments.

## Relevant technical choices:

* Outbound links assessments: Makes sure the right feedback string is shown when there are no nofollowed links.

## Test instructions

This PR can be tested by following these steps:

* Trigger all SEO and readability assessments in all possible conditions as outlined here: https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis

* Exceptions that don't need to be tested in this PR:
  * urlKeyword
  * keywordDistribution
  * keywordDensity/largestKeywordDistance
  * subheadingsKeyword
  * metadescriptionKeyword
* Make sure that all assessments have feedback strings according to the new format. This means:
  * In the beginning there is the assessment title with a link
  * In the end there is a call to action with a link (except when the bullet is green)

Fixes #1806 
