### PR TITLE
Make sure that common OS files (like .DS_Store) are not tracked.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,10 @@ coverage/
 dist/
 .tscache/
 
+# Ignore common OS files
+[Tt]humbs.db
+[Dd]esktop.ini
+*.DS_store
+.DS_store?
+
 /examples/browserified/example-browserified.js


### PR DESCRIPTION
## Summary

Adds some pesky little OS files to the `.gitignore` so that they are not tracked by the repository.
These are files that are automatically created by Mac and/or Windows for e.g. showing thumbnails in the finder or explorer.
