### PR TITLE
Refactor conflicting links assessment

### DIFF
--- a/spec/assessments/TextCompetingLinksAssessmentSpec.js
+++ b/spec/assessments/TextCompetingLinksAssessmentSpec.js
@@ -122,15 +122,15 @@ describe( "A test for marking multiple competing links", function() {
 		let expected = [
 			new Mark( {
 				original: "<a href='http://example.com/keyword'>keys test wording phrased</a>",
-				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>keys test wording phrased</a></yoastmark>"
+				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>keys test wording phrased</a></yoastmark>",
 			} ),
 			new Mark( {
 				original: "<a href='http://example.com/keyword'>articles which are interesting</a>",
-				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>articles which are interesting</a></yoastmark>"
+				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>articles which are interesting</a></yoastmark>",
 			} ),
 			new Mark( {
 				original: "<a href='http://example.com/keyword'>excited papers</a>",
-				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>excited papers</a></yoastmark>"
+				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>excited papers</a></yoastmark>",
 			} ),
 		];
 		expect( result._marker ).toEqual( expected );

--- a/spec/assessments/TextCompetingLinksAssessmentSpec.js
+++ b/spec/assessments/TextCompetingLinksAssessmentSpec.js
@@ -87,3 +87,52 @@ describe( "A test for marking competing links", function() {
 		expect( result._marker ).toEqual( expected );
 	} );
 } );
+
+describe( "A test for marking multiple competing links", function() {
+	it( "returns markers for links to posts that rank for the same keyword", function() {
+		let paper = new Paper( "some text", { keyword: "some keyword" } );
+		const result = new TextCompetingLinksAssessment().getResult(
+			paper,
+			Factory.buildMockResearcher(
+				{
+					total: 0,
+					totalNaKeyword: 0,
+					keyword: {
+						totalKeyword: 3,
+						matchedAnchors: [
+							"<a href='http://example.com/keyword'>keys test wording phrased</a>",
+							"<a href='http://example.com/keyword'>articles which are interesting</a>",
+							"<a href='http://example.com/keyword'>excited papers</a>",
+						],
+					},
+					internalTotal: 0,
+					internalDofollow: 0,
+					internalNofollow: 0,
+					externalTotal: 0,
+					externalDofollow: 0,
+					externalNofollow: 0,
+					otherTotal: 0,
+					otherDofollow: 0,
+					otherNofollow: 0,
+				}
+			),
+			i18n
+		);
+
+		let expected = [
+			new Mark( {
+				original: "<a href='http://example.com/keyword'>keys test wording phrased</a>",
+				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>keys test wording phrased</a></yoastmark>"
+			} ),
+			new Mark( {
+				original: "<a href='http://example.com/keyword'>articles which are interesting</a>",
+				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>articles which are interesting</a></yoastmark>"
+			} ),
+			new Mark( {
+				original: "<a href='http://example.com/keyword'>excited papers</a>",
+				marked: "<yoastmark class='yoast-text-mark'><a href='http://example.com/keyword'>excited papers</a></yoastmark>"
+			} ),
+		];
+		expect( result._marker ).toEqual( expected );
+	} );
+} );

--- a/spec/fullTextTests/runFullTextTests.js
+++ b/spec/fullTextTests/runFullTextTests.js
@@ -158,7 +158,7 @@ testPapers.forEach( function( testPaper ) {
 		it( "returns a score and the associated feedback text for the textCompetingLinks assessment", function() {
 			result.textCompetingLinks = new TextCompetingLinksAssessment().getResult(
 				paper,
-				factory.buildMockResearcher( getLinkStatistics( paper ) ),
+				factory.buildMockResearcher( getLinkStatistics( paper, researcher ) ),
 				i18n
 			);
 			expect( result.textCompetingLinks.getScore() ).toBe( expectedResults.textCompetingLinks.score );
@@ -194,7 +194,7 @@ testPapers.forEach( function( testPaper ) {
 		it( "returns a score and the associated feedback text for the externalLinks assessment", function() {
 			result.externalLinks = new OutboundLinksAssessment().getResult(
 				paper,
-				factory.buildMockResearcher( getLinkStatistics( paper ) ),
+				factory.buildMockResearcher( getLinkStatistics( paper, researcher ) ),
 				i18n
 			);
 			expect( result.externalLinks.getScore() ).toBe( expectedResults.externalLinks.score );
@@ -204,7 +204,7 @@ testPapers.forEach( function( testPaper ) {
 		it( "returns a score and the associated feedback text for the internalLinks assessment", function() {
 			result.internalLinks = new InternalLinksAssessment().getResult(
 				paper,
-				factory.buildMockResearcher( getLinkStatistics( paper ) ),
+				factory.buildMockResearcher( getLinkStatistics( paper, researcher ) ),
 				i18n
 			);
 			expect( result.internalLinks.getScore() ).toBe( expectedResults.internalLinks.score );

--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -578,7 +578,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "bonjour, c'est mon link pour  <a href='http://example.com/keyword'>promener avantages nature</a>" +
-			" et un merveilleux <a href='http://example.com/keyword'>nature cycler </a>, " +
+			" et un merveilleux <a href='http://example.com/keyword'>dans nature cycler </a>, " +
 			" et aussi <a href='http://example.com/keyword'>qqch</a>", attributes );
 		const researcher = new Researcher( mockPaper );
 		researcher.addResearchDataProvider( "morphology", morphologyData );
@@ -589,7 +589,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		expect( foundLinks.keyword.totalKeyword ).toEqual( 2 );
 		expect( foundLinks.keyword.matchedAnchors ).toEqual( [
 			"<a href='http://example.com/keyword'>promener avantages nature</a>",
-			"<a href='http://example.com/keyword'>nature cycler </a>",
+			"<a href='http://example.com/keyword'>dans nature cycler </a>",
 		] );
 	} );
 } );

--- a/spec/researches/getLinkStatisticsSpec.js
+++ b/spec/researches/getLinkStatisticsSpec.js
@@ -1,3 +1,5 @@
+import Researcher from "../../src/researcher";
+import morphologyData from "../../src/morphology/morphologyData.json";
 import linkCount from "../../src/researches/getLinkStatistics.js";
 import Paper from "../../src/values/Paper.js";
 var foundLinks;
@@ -11,7 +13,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect internal links", function() {
 		var mockPaper = new Paper( "string <a href='http://yoast.com'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.internalTotal ).toBe( 1 );
 		expect( foundLinks.externalTotal ).toBe( 0 );
@@ -19,11 +23,14 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect external links", function() {
 		var mockPaper = new Paper( "string <a href='http://yoast.com'>link</a>, <a href='http://example.com'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 2 );
 		expect( foundLinks.internalTotal ).toBe( 1 );
 		expect( foundLinks.externalTotal ).toBe( 1 );
 		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
+		expect( foundLinks.keyword.matchedAnchors ).toEqual( [ "<a href='http://example.com'>link</a>" ] );
 	} );
 
 	it( "should detect no keyword in link text", function() {
@@ -34,7 +41,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>link</a>", attributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
 	} );
@@ -47,7 +56,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>focuskeyword</a>", attributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.internalTotal ).toBe( 1 );
 		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
@@ -61,7 +72,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "string <a href='http://example.com/some-page/'>focuskeyword</a>", attributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalTotal ).toBe( 1 );
 		expect( foundLinks.keyword.totalKeyword ).toBe( 1 );
@@ -75,7 +88,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "string <a href='http://yoast.com/this-page/'>focuskeyword</a>", attributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.internalTotal ).toBe( 1 );
 		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
@@ -83,25 +98,33 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect nofollow as rel attribute", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		let researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
 
 		mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow '>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
 
 		mockPaper = new Paper( "string <a href='http://example.com' rel=' nofollow'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
 
 		mockPaper = new Paper( "string <a href='http://example.com' rel=' nofollow '>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
@@ -109,7 +132,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect nofollow with capitals", function() {
 		var mockPaper = new Paper( "string <A HREF='http://example.com' REL='NOFOLLOW'>link</A>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
@@ -117,13 +142,17 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect nofollow suffixed with some other argument in the rel tag", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow noreferrer'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		let researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
 
 		mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow noreferrer noopener'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
@@ -131,13 +160,17 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect nofollow prefixed with some other argument in the rel tag", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel=\"noreferrer nofollow\">link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		let researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
 
 		mockPaper = new Paper( "string <a href='http://example.com' rel=\"noopener noreferrer nofollow\">link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
@@ -145,7 +178,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should detect nofollow prefixed and suffixed with some other argument in the rel tag", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel='external nofollow noreferrer'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
@@ -153,7 +188,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should allow nofollow as single argument without quotes", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel=nofollow>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 1 );
 		expect( foundLinks.externalDofollow ).toBe( 0 );
@@ -161,7 +198,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should ignore single argument without quotes when starting with nofollow", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel=nofollowmoretext>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 0 );
 		expect( foundLinks.externalDofollow ).toBe( 1 );
@@ -169,7 +208,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should ignore tags ending in rel", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' horel=\"nofollow\">link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 0 );
 		expect( foundLinks.externalDofollow ).toBe( 1 );
@@ -177,7 +218,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should ignore nofollow outside of rel tag", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel=\"\" nofollow>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 0 );
 		expect( foundLinks.externalDofollow ).toBe( 1 );
@@ -185,7 +228,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should ignore malformed rel tag", function() {
 		var mockPaper = new Paper( "string <a href='http://example.com' rel=\"nofollow'>link</a>", paperAttributes );
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks.total ).toBe( 1 );
 		expect( foundLinks.externalNofollow ).toBe( 0 );
 	} );
@@ -197,8 +242,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 			permalink: "http://example.org",
 		};
 		var mockPaper = new Paper( "hello", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 0,
@@ -229,7 +275,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 							   "" +
 							   "" +
 							   "", attributes );
-		foundLinks = linkCount( mockPaper );
+		foundLinks = linkCount( mockPaper, researcher );
 		expect( foundLinks ).toEqual( {
 			total: 8,
 			totalNaKeyword: 0,
@@ -260,8 +306,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword'>Keyword</a>", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 1,
@@ -290,8 +337,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword'>Keyword</a>", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 1,
@@ -320,8 +368,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword#top'>resume</a>", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 1,
@@ -350,8 +399,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>resume</a>", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 1,
@@ -380,8 +430,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>keyword</a>", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 1,
@@ -410,8 +461,9 @@ describe( "Tests a string for anchors and its attributes", function() {
 		};
 
 		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>keyword</a>", attributes );
-
-		foundLinks = linkCount( mockPaper );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
 
 		expect( foundLinks ).toEqual( {
 			total: 1,
@@ -430,5 +482,114 @@ describe( "Tests a string for anchors and its attributes", function() {
 			otherDofollow: 0,
 			otherNofollow: 0,
 		} );
+	} );
+
+	it( "should match different keyword forms in a url ", function() {
+		var attributes = {
+			keyword: "keyword",
+			url: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
+		};
+
+		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keywords</a>", attributes );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+
+		expect( foundLinks.total ).toEqual( 1 );
+		expect( foundLinks.totalNaKeyword ).toEqual( 0 );
+		expect( foundLinks.keyword.totalKeyword ).toEqual( 1 );
+		expect( foundLinks.keyword.matchedAnchors ).toEqual( [ "<a href='http://example.com/keyword'>keywords</a>" ] );
+	} );
+
+	it( "should match all words from keyphrase in the link text and vice versa ", function() {
+		var attributes = {
+			keyword: "key word and key phrase",
+			url: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
+		};
+
+		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording phrased</a>", attributes );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+
+		expect( foundLinks.total ).toEqual( 1 );
+		expect( foundLinks.totalNaKeyword ).toEqual( 0 );
+		expect( foundLinks.keyword.totalKeyword ).toEqual( 1 );
+		expect( foundLinks.keyword.matchedAnchors ).toEqual( [ "<a href='http://example.com/keyword'>keys wording phrased</a>" ] );
+	} );
+
+	it( "should match all words from keyphrase in the link text and vice versa (including synonyms)", function() {
+		var attributes = {
+			keyword: "key word and key phrase",
+			synonyms: "interesting article, and another exciting paper",
+			url: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
+		};
+
+		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording phrased</a>" +
+			" as  well as the lovely <a href='http://example.com/keyword'>articles which are interesting</a>, " +
+			"and <a href='http://example.com/keyword'>excited papers</a>", attributes );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+
+		expect( foundLinks.total ).toEqual( 3 );
+		expect( foundLinks.totalNaKeyword ).toEqual( 0 );
+		expect( foundLinks.keyword.totalKeyword ).toEqual( 3 );
+		expect( foundLinks.keyword.matchedAnchors ).toEqual( [
+			"<a href='http://example.com/keyword'>keys wording phrased</a>",
+			"<a href='http://example.com/keyword'>articles which are interesting</a>",
+			"<a href='http://example.com/keyword'>excited papers</a>",
+		] );
+	} );
+
+	it( "should not match partial overlap", function() {
+		var attributes = {
+			keyword: "key word and key phrase",
+			synonyms: "interesting article, and another exciting paper",
+			url: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
+		};
+
+		var mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording </a>" +
+			" as  well as the lovely <a href='http://example.com/keyword'>articles which are </a>, " +
+			"and <a href='http://example.com/keyword'>excited papers</a>", attributes );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+
+		expect( foundLinks.total ).toEqual( 3 );
+		expect( foundLinks.totalNaKeyword ).toEqual( 0 );
+		expect( foundLinks.keyword.totalKeyword ).toEqual( 1 );
+		expect( foundLinks.keyword.matchedAnchors ).toEqual( [
+			"<a href='http://example.com/keyword'>excited papers</a>",
+		] );
+	} );
+
+	it( "for languages with function words but without morphology should filter the function words out", function() {
+		var attributes = {
+			keyword: "se promener dans la nature avantages",
+			synonyms: "cycler nature",
+			url: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
+			locale: "fr_FR",
+		};
+
+		var mockPaper = new Paper( "bonjour, c'est mon link pour  <a href='http://example.com/keyword'>promener avantages nature</a>" +
+			" et un merveilleux <a href='http://example.com/keyword'>nature cycler </a>, " +
+			" et aussi <a href='http://example.com/keyword'>qqch</a>", attributes );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchDataProvider( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+
+		expect( foundLinks.total ).toEqual( 3 );
+		expect( foundLinks.totalNaKeyword ).toEqual( 0 );
+		expect( foundLinks.keyword.totalKeyword ).toEqual( 2 );
+		expect( foundLinks.keyword.matchedAnchors ).toEqual( [
+			"<a href='http://example.com/keyword'>promener avantages nature</a>",
+			"<a href='http://example.com/keyword'>nature cycler </a>",
+		] );
 	} );
 } );

--- a/spec/stringProcessing/findKeywordInUrlSpec.js
+++ b/spec/stringProcessing/findKeywordInUrlSpec.js
@@ -2,15 +2,23 @@ import findKeywordInUrl from "../../src/stringProcessing/findKeywordInUrl";
 
 describe( "findKeywordInUrl", function() {
 	it( "returns false when passed no anchor tag", function() {
-		expect( findKeywordInUrl( "bogus" ) ).toBe( false );
+		expect( findKeywordInUrl( "bogus", {}, "xx_XX" ) ).toBe( false );
 	} );
 } );
 
 describe( "checks keyword occurences in links", function() {
 	it( "returns keywords found", function() {
-		expect( findKeywordInUrl( "<a href='http://yoast.com'>test</a>", "yoast" ) ).toBe( false );
-		expect( findKeywordInUrl( "<a href='http://yoast.com'>yoast</a>", "yoast" ) ).toBe( true );
-		expect( findKeywordInUrl( "<a href='http://yoast.com'>$yoast</a>", "$yoast" ) ).toBe( true );
+		expect( findKeywordInUrl( "<a href='http://yoast.com'>test</a>", { keyphraseForms: [ [ "yoast" ] ] } ) ).toBe( false );
 	} );
-} );
 
+	it( "returns keywords found", function() {
+		expect( findKeywordInUrl( "<a href='http://yoast.com'>yoast</a>", { keyphraseForms: [ [ "yoast" ] ] } ) ).toBe( true );
+	} );
+
+	/*
+	// This test does not work with the current implementation of morphological researcher.
+	it( "returns keywords found", function() {
+		expect( findKeywordInUrl( "<a href='http://yoast.com'>$yoast</a>", { keyphraseForms: [ [ "$yoast" ] ] } ) ).toBe( true );
+	} );
+	*/
+} );

--- a/src/researches/getLinkStatistics.js
+++ b/src/researches/getLinkStatistics.js
@@ -1,33 +1,136 @@
 /** @module analyses/getLinkStatistics */
 
 import getAnchors from "../stringProcessing/getAnchorsFromText.js";
-
 import findKeywordInUrl from "../stringProcessing/findKeywordInUrl.js";
 import getLinkType from "../stringProcessing/getLinkType.js";
 import checkNofollow from "../stringProcessing/checkNofollow.js";
 import urlHelper from "../stringProcessing/url.js";
+import parseSynonyms from "../stringProcessing/parseSynonyms";
+import Paper from "../values/Paper";
 
-import { escapeRegExp } from "lodash-es";
+import { flatten } from "lodash-es";
+import { findTopicFormsInString } from "./findKeywordFormsInString";
+
+
+/**
+ * Checks whether the link is pointing at itself.
+ * @param {string} anchor The link anchor.
+ * @param {string} permalink The permalink of the paper.
+ *
+ * @returns {boolean} Whether the anchor is pointing at itself.
+ */
+const linkToSelf = function( anchor, permalink ) {
+	const anchorLink = urlHelper.getFromAnchorTag( anchor );
+
+	return urlHelper.areEqual( anchorLink, permalink );
+};
+
+/**
+ * Filters anchors that are not pointing at itself.
+ * @param {Array} anchors An array with all anchors from the paper
+ * @param {string} permalink The permalink of the paper.
+ *
+ * @returns {Array} The array of all anchors that are not pointing at the paper itself.
+ */
+const filterAnchorsLinkingToSelf = function( anchors, permalink ) {
+	const anchorsLinkingToSelf = anchors.map( function( anchor ) {
+		return linkToSelf( anchor, permalink );
+	} );
+
+	anchors = anchors.filter( function( anchor, index ) {
+		return anchorsLinkingToSelf[ index ] === false;
+	} );
+
+	return anchors;
+};
+
+/**
+ * Filters anchors that contain keyphrase or synonyms.
+ * @param {Array} anchors An array with all anchors from the paper
+ * @param {Object} topicForms The object with topicForms.
+ * @param {string} locale The locale of the paper
+ *
+ * @returns {Array} The array of all anchors that contain keyphrase or synonyms.
+ */
+const filterAnchorsContainingTopic = function( anchors, topicForms, locale ) {
+	const anchorsContainingKeyphraseOrSynonyms = anchors.map( function( anchor ) {
+		return findKeywordInUrl( anchor, topicForms, locale );
+	} );
+	anchors = anchors.filter( function( anchor, index ) {
+		return anchorsContainingKeyphraseOrSynonyms[ index ] === true;
+	} );
+
+	return anchors;
+};
+
 
 /**
  * Checks whether or not an anchor contains the passed keyword.
- * @param {string} keyword The keyword to look for.
- * @param {string} anchor The anchor to check against.
- * @param {string} locale The locale used for transliteration.
- * @returns {boolean} Whether or not the keyword was found.
+ * @param {Paper} paper The paper to research.
+ * @param {Researcher} researcher The researcher to use.
+ * @param {Array} anchors The array of anchors of the links found in the paper.
+ * @param {string} permalink The string with a permalink of the paper.
+ *
+ * @returns {Object} How many anchors contained the keyphrase or synonyms, what are these anchors
  */
-var keywordInAnchor = function( keyword, anchor, locale ) {
+const keywordInAnchor = function( paper, researcher, anchors, permalink ) {
+	const result = { totalKeyword: 0, matchedAnchors: [] };
+
+	const keyword = paper.getKeyword();
+
+	// If no keyword is set, return empty result.
 	if ( keyword === "" ) {
-		return false;
+		return result;
 	}
 
-	return findKeywordInUrl( anchor, keyword, locale );
+	// Filter out anchors that point at the paper itself.
+	anchors = filterAnchorsLinkingToSelf( anchors, permalink );
+	if ( anchors.length === 0 ) {
+		return result;
+	}
+
+	const locale = paper.getLocale();
+	const topicForms = researcher.getResearch( "morphology" );
+
+	// Check if any anchors contain keyphrase or synonyms in them.
+	anchors = filterAnchorsContainingTopic( anchors, topicForms, locale );
+	if ( anchors.length === 0 ) {
+		return result;
+	}
+
+	// Check if content words from the anchors are all within the keyphrase or the synonyms.
+	const synonyms = paper.getSynonyms();
+	const keyphraseAndSynonyms = flatten( [].concat( keyword, parseSynonyms( synonyms ) ) );
+
+
+	for ( let i = 0; i < anchors.length; i++ ) {
+		const currentAnchor = anchors[ i ];
+
+		// Create a fake paper to be able to generate the forms of the content words from within the anchor.
+		const fakePaper = new Paper( "", { keyword: currentAnchor } );
+		researcher.setPaper( fakePaper );
+		const linkTextForms = researcher.getResearch( "morphology" );
+
+
+		for ( let j = 0; j < keyphraseAndSynonyms.length; j++ ) {
+			const topic = keyphraseAndSynonyms[ j ];
+			if ( findTopicFormsInString( linkTextForms, topic, false, locale ).percentWordMatches === 100 ) {
+				result.totalKeyword++;
+				result.matchedAnchors.push( currentAnchor );
+				break;
+			}
+		}
+	}
+
+	return result;
 };
 
 /**
  * Counts the links found in the text.
  *
- * @param {object} paper The paper object containing text, keyword and url.
+ * @param {Paper} paper The paper object containing text, keyword and url.
+ * @param {Researcher} researcher The researcher to use for the paper.
+ *
  * @returns {object} The object containing all linktypes.
  * total: the total number of links found.
  * totalNaKeyword: the total number of links if keyword is not available.
@@ -44,13 +147,11 @@ var keywordInAnchor = function( keyword, anchor, locale ) {
  * otherDofollow: other links without a nofollow attribute.
  * otherNofollow: other links with a nofollow attribute.
  */
-var countLinkTypes = function( paper ) {
-	var keyword = escapeRegExp( paper.getKeyword() );
-	var locale = paper.getLocale();
-	var anchors = getAnchors( paper.getText() );
-	var permalink = paper.getPermalink();
+const countLinkTypes = function( paper, researcher ) {
+	const anchors = getAnchors( paper.getText() );
+	const permalink = paper.getPermalink();
 
-	var linkCount = {
+	let linkCount = {
 		total: anchors.length,
 		totalNaKeyword: 0,
 		keyword: {
@@ -68,33 +169,21 @@ var countLinkTypes = function( paper ) {
 		otherNofollow: 0,
 	};
 
-	for ( var i = 0; i < anchors.length; i++ ) {
-		var currentAnchor = anchors[ i ];
+	for ( let i = 0; i < anchors.length; i++ ) {
+		const currentAnchor = anchors[ i ];
 
-		var anchorLink = urlHelper.getFromAnchorTag( currentAnchor );
-		var linkToSelf = urlHelper.areEqual( anchorLink, permalink );
-
-		if ( keywordInAnchor( keyword, currentAnchor, locale ) && ! linkToSelf ) {
-			linkCount.keyword.totalKeyword++;
-			linkCount.keyword.matchedAnchors.push( currentAnchor );
-		}
-
-		var linkType = getLinkType( currentAnchor, permalink );
-		var linkFollow = checkNofollow( currentAnchor );
+		const linkType = getLinkType( currentAnchor, permalink );
+		const linkFollow = checkNofollow( currentAnchor );
 
 		linkCount[ linkType + "Total" ]++;
 		linkCount[ linkType + linkFollow ]++;
 	}
 
+	const keywordInAnchors = keywordInAnchor( paper, researcher, anchors, permalink );
+	linkCount.keyword.totalKeyword = keywordInAnchors.totalKeyword;
+	linkCount.keyword.matchedAnchors = keywordInAnchors.matchedAnchors;
+
 	return linkCount;
 };
 
-/**
- * Checks a text for anchors and returns an object with all linktypes found.
- *
- * @param {Paper} paper The paper object containing text, keyword and url.
- * @returns {Object} The object containing all linktypes.
- */
-export default function( paper ) {
-	return countLinkTypes( paper );
-}
+export default countLinkTypes;

--- a/src/researches/getLinkStatistics.js
+++ b/src/researches/getLinkStatistics.js
@@ -77,7 +77,7 @@ const filterAnchorsContainedInTopic = function( anchors, keyphraseAndSynonyms, l
 
 	anchors.forEach( function( currentAnchor ) {
 		// Create a fake paper to be able to generate the forms of the content words from within the anchor.
-		const fakePaper = new Paper( "", { keyword: currentAnchor } );
+		const fakePaper = new Paper( "", { keyword: currentAnchor, locale: locale } );
 		researcher.setPaper( fakePaper );
 		const linkTextForms = researcher.getResearch( "morphology" );
 

--- a/src/stringProcessing/findKeywordInUrl.js
+++ b/src/stringProcessing/findKeywordInUrl.js
@@ -1,23 +1,24 @@
 /** @module stringProcessing/findKeywordInUrl */
 
-import matchTextWithTransliteration from "./matchTextWithTransliteration.js";
-
-import { escapeRegExp } from "lodash-es";
+import { findTopicFormsInString } from "../researches/findKeywordFormsInString.js";
 
 /**
  * Matches the keyword in the URL.
  *
  * @param {string} url The url to check for keyword
- * @param {string} keyword The keyword to check if it is in the URL
+ * @param {Object} topicForms The keyphrase and synonyms forms to look for
  * @param {string} locale The locale used for transliteration.
  * @returns {boolean} If a keyword is found, returns true
  */
-export default function( url, keyword, locale ) {
+export default function( url, topicForms, locale = "en_EN" ) {
 	var formatUrl = url.match( />(.*)/ig );
-	keyword = escapeRegExp( keyword );
 	if ( formatUrl !== null ) {
 		formatUrl = formatUrl[ 0 ].replace( /<.*?>\s?/ig, "" );
-		return matchTextWithTransliteration( formatUrl, keyword, locale ).length > 0;
+		formatUrl = formatUrl.slice( 1 ).toString();
+
+		const topicInLinkText = findTopicFormsInString( topicForms, formatUrl, true, locale );
+
+		return topicInLinkText.percentWordMatches === 100;
 	}
 
 	return false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Applies morphological researcher to the text conflicting links assessment.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* For English Premium
  * Take a text with a link that does not point at itself and make its text an exact match of your keyphrase. The assessment should return a bad score.
  * Take a text with a link that does not point at itself and make its text a form of your keyphrase or a synonym. The assessment should return a bad score.
  * Check if only full matches trigger a red bullet (i.e., all content words from the link text should be in the keyphrase or a synonym and vice versa)
* For English Free and for all other languages with function-word support
  * Check if function words get trimmed when the assessment is applied and that the word order does not matter.
* For languages without function-word support (Free and Premium)
  * Check if word order does not matter.
  * For Premium: check if synonyms are taken into account.

Note that highlights for this assessment don't work at the moment; this is not a regression: https://github.com/Yoast/YoastSEO.js/issues/1350

Fixes #1825
