### PR TITLE
Fix cornerstone-specific values in KeywordSubheadings assessment

### DIFF
--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -184,9 +184,10 @@ describe( "running assessments in the assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.noMatches ).toBe( 3 );
+			expect( assessment._config.scores.tooFewMatches ).toBe( 3 );
+			expect( assessment._config.scores.tooManyMatches ).toBe( 3 );
 			expect( assessment._config.scores.oneMatch ).toBe( 6 );
-			expect( assessment._config.scores.multipleMatches ).toBe( 9 );
+			expect( assessment._config.scores.goodNumberOfMatches ).toBe( 9 );
 		} );
 
 		test( "TextImagesAssessment", () => {

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -27,6 +27,7 @@ class SubHeadingsKeywordAssessment extends Assessment {
 			},
 			scores: {
 				tooFewMatches: 3,
+				oneMatch: 9,
 				goodNumberOfMatches: 9,
 				tooManyMatches: 3,
 			},
@@ -128,7 +129,7 @@ class SubHeadingsKeywordAssessment extends Assessment {
 	calculateResult( i18n ) {
 		if ( this.hasOneOutOfOneMatch() ) {
 			return {
-				score: this._config.scores.goodNumberOfMatches,
+				score: this._config.scores.oneMatch,
 				resultText: i18n.sprintf(
 					/**
 					 * Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -48,9 +48,7 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 		new SubheadingsKeyword(
 			{
 				scores: {
-					noMatches: 3,
 					oneMatch: 6,
-					multipleMatches: 9,
 				},
 			}
 		),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an erroneously deprecated cornerstone-specific score for an assessment that checks for keyphrase in subheadings

## Relevant technical choices:

* The score for a case where the only subheading in the article contains keyphrase is put back to 6 (orange bullet) from 9 (green bullet).

## Test instructions

This PR can be tested by following these steps:

* Check that the KeywordSubheadings assessment [returns correct values](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#5-keyword-in-subheadings) for the non-cornerstone content.
* Check that the KeywordSubheadings assessment returns correct values for the cornerstone content.
* Specifically check the case where there is one subheading in the text and it has keyphrase in it.
