### PR TITLE
Remove stopwordInKeyphrase assessment from SEO assessor

### DIFF
--- a/spec/fullTextTests/runFullTextTests.js
+++ b/spec/fullTextTests/runFullTextTests.js
@@ -8,7 +8,6 @@ import Researcher from "../../src/researcher";
 import IntroductionKeywordAssessment from "../../src/assessments/seo/IntroductionKeywordAssessment";
 import KeyphraseLengthAssessment from "../../src/assessments/seo/KeyphraseLengthAssessment";
 import KeywordDensityAssessment from  "../../src/assessments/seo/KeywordDensityAssessment";
-import keywordStopWordsAssessment from "../../src/assessments/seo/keywordStopWordsAssessment";
 import MetaDescriptionKeywordAssessment from "../../src/assessments/seo/MetaDescriptionKeywordAssessment";
 import MetaDescriptionLengthAssessment from "../../src/assessments/seo/metaDescriptionLengthAssessment";
 import SubheadingsKeywordAssessment from "../../src/assessments/seo/subheadingsKeywordAssessment";
@@ -39,7 +38,6 @@ import findKeywordInFirstParagraph from "../../src/researches/findKeywordInFirst
 import keyphraseLength from "../../src/researches/keyphraseLength";
 import keywordCount from "../../src/researches/keywordCount";
 import getKeywordDensity from "../../src/researches/getKeywordDensity.js";
-import stopWordsInKeyword from "../../src/researches/stopWordsInKeyword";
 import metaDescriptionKeyword from "../../src/researches/metaDescriptionKeyword.js";
 import metaDescriptionLength from "../../src/researches/metaDescriptionLength.js";
 import matchKeywordInSubheadings from "../../src/researches/matchKeywordInSubheadings.js";
@@ -113,16 +111,6 @@ testPapers.forEach( function( testPaper ) {
 			);
 			expect( result.keywordDensity.getScore() ).toBe( expectedResults.keywordDensity.score );
 			expect( result.keywordDensity.getText() ).toBe( expectedResults.keywordDensity.resultText );
-		} );
-
-		it( "returns a score and the associated feedback text for the keywordStopWords assessment", function() {
-			result.keywordStopWords = keywordStopWordsAssessment.getResult(
-				paper,
-				factory.buildMockResearcher( stopWordsInKeyword( paper ) ),
-				i18n
-			);
-			expect( result.keywordStopWords.getScore() ).toBe( expectedResults.keywordStopWords.score );
-			expect( result.keywordStopWords.getText() ).toBe( expectedResults.keywordStopWords.resultText );
 		} );
 
 		it( "returns a score and the associated feedback text for the metaDescriptionKeyword assessment", function() {

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -63,10 +63,6 @@ const expectedResults = {
 		score: 9,
 		resultText: "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 1.3%, which is great; the focus keyword was found 9 times.",
 	},
-	keywordStopWords: {
-		score: 0,
-		resultText: "",
-	},
 	metaDescriptionKeyword: {
 		score: 9,
 		resultText: "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: Focus key phrase or synonym appear in the meta description. Well done!",

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -52,10 +52,6 @@ const expectedResults = {
 		score: 4,
 		resultText: "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.3%, which is too low; the focus keyword was found 3 times.",
 	},
-	keywordStopWords: {
-		score: 0,
-		resultText: "",
-	},
 	metaDescriptionKeyword: {
 		score: 6,
 		resultText: "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: All words of focus key phrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>.",

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -47,10 +47,6 @@ const expectedResults = {
 		score: 9,
 		resultText: "The exact-match <a href='https://yoa.st/2pe' target='_blank'>keyword density</a> is 0.8%, which is great; the focus keyword was found 4 times.",
 	},
-	keywordStopWords: {
-		score: 0,
-		resultText: "",
-	},
 	metaDescriptionKeyword: {
 		score: 9,
 		resultText: "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: Focus key phrase or synonym appear in the meta description. Well done!",

--- a/src/assessments/seo/keywordStopWordsAssessment.js
+++ b/src/assessments/seo/keywordStopWordsAssessment.js
@@ -10,6 +10,8 @@ const availableLanguages = [ "en" ];
  * @param {Jed} i18n The locale object.
  *
  * @returns {Object} The resulting score object.
+ *
+ * @deprecated
  */
 var calculateStopWordsCountResult = function( stopWordCount, i18n ) {
 	if ( stopWordCount > 0 ) {

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -10,7 +10,6 @@ import TitleKeywordAssessment from "../assessments/seo/TitleKeywordAssessment";
 import UrlKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
 import Assessor from "../assessor";
 import SEOAssessor from "../seoAssessor";
-import keywordStopWords from "../assessments/seo/keywordStopWordsAssessment";
 import MetaDescriptionLength from "../assessments/seo/metaDescriptionLengthAssessment";
 import SubheadingsKeyword from "../assessments/seo/subheadingsKeywordAssessment";
 import TextImages from "../assessments/seo/textImagesAssessment";
@@ -37,7 +36,6 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 		new IntroductionKeywordAssessment(),
 		new KeyphraseLengthAssessment(),
 		new KeywordDensityAssessment(),
-		keywordStopWords,
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLength( {
 			scores:	{

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -9,7 +9,6 @@ import InternalLinksAssessment from "./assessments/seo/InternalLinksAssessment";
 import TitleKeywordAssessment from "./assessments/seo/TitleKeywordAssessment";
 import UrlKeywordAssessment from "./assessments/seo/UrlKeywordAssessment";
 import Assessor from "./assessor";
-import keywordStopWords from "./assessments/seo/keywordStopWordsAssessment";
 import MetaDescriptionLength from "./assessments/seo/metaDescriptionLengthAssessment";
 import SubheadingsKeyword from "./assessments/seo/subheadingsKeywordAssessment";
 import TextImages from "./assessments/seo/textImagesAssessment";
@@ -35,7 +34,6 @@ const SEOAssessor = function( i18n, options ) {
 		new IntroductionKeywordAssessment(),
 		new KeyphraseLengthAssessment(),
 		new KeywordDensityAssessment(),
-		keywordStopWords,
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLength(),
 		new SubheadingsKeyword(),

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -7,7 +7,6 @@ import MetaDescriptionKeywordAssessment from "./assessments/seo/MetaDescriptionK
 import TitleKeywordAssessment from "./assessments/seo/TitleKeywordAssessment";
 import UrlKeywordAssessment from "./assessments/seo/UrlKeywordAssessment";
 import Assessor from "./assessor";
-import keywordStopWordsAssessment from "./assessments/seo/keywordStopWordsAssessment";
 import MetaDescriptionLengthAssessment from "./assessments/seo/metaDescriptionLengthAssessment";
 import taxonomyTextLengthAssessment from "./assessments/seo/taxonomyTextLengthAssessment";
 import PageTitleWidthAssessment from "./assessments/seo/pageTitleWidthAssessment";
@@ -28,7 +27,6 @@ const TaxonomyAssessor = function( i18n ) {
 		new IntroductionKeywordAssessment(),
 		new KeyphraseLengthAssessment(),
 		new KeywordDensityAssessment(),
-		keywordStopWordsAssessment,
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLengthAssessment(),
 		taxonomyTextLengthAssessment,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Deprecates the assessment that checks if stopwords were used within the keyphrase

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Make a new post in English and add a keyphrase to is that contains a stopword (e.g., `a`, `any`). A previous version of the plugin should return a grey consideration bullet. In this version no grey consideration bullet should appear.
* Check if the rest of the SEO analysis was performed correctly.
* Try adding posts in other languages to see if SEO analysis runs normally.
* Also confirm that the keyword stopword assessment has been removed for taxonomy pages.

Fixes #1833 
