### PR TITLE
Update feedback strings in TitleKeyword assessment

### DIFF
--- a/spec/assessments/TitleKeywordAssessmentSpec.js
+++ b/spec/assessments/TitleKeywordAssessmentSpec.js
@@ -17,7 +17,9 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(
-			"The focus keyword 'keyword' does not appear in the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>."
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Not all the words from your " +
+			"keyphrase \"keyword\"; appear in the SEO title. <a href='https://yoa.st/33h' target='_blank'>Try to " +
+			"write the exact match of your keyphrase in the SEO title</a>."
 		);
 	} );
 
@@ -33,8 +35,8 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe(
-			"The exact match of the focus keyphrase appears at the beginning of " +
-			"the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>, which is considered to improve rankings."
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus " +
+			"keyphrase appears at the beginning of the SEO title. Good job!"
 		);
 	} );
 
@@ -50,12 +52,13 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe(
-			"The exact match of the focus keyphrase appears in the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>, " +
-			"but not at the beginning; try and move it to the beginning."
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus " +
+			"keyphrase appears in the  SEO title, but not at the beginning. " +
+			"<a href='https://yoa.st/33h' target='_blank'>Try move it to the beginning</a>."
 		);
 	} );
 
-	it( "returns an assementresult with keyword found at start", function() {
+	it( "returns an assementresult with keyword not found at all", function() {
 		const paper = new Paper( "", {
 			keyword: "keyword",
 			title: "a non-empty title",
@@ -67,8 +70,8 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe(
-			"The <a href='https://yoa.st/2pn' target='_blank'>SEO title</a> contains " +
-			"all words from the focus keyphrase, but not its exact match."
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Does not contain the exact match. " +
+			"<a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title</a>."
 		);
 	} );
 

--- a/spec/assessments/TitleKeywordAssessmentSpec.js
+++ b/spec/assessments/TitleKeywordAssessmentSpec.js
@@ -18,8 +18,8 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(
 			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Not all the words from your " +
-			"keyphrase \"keyword\"; appear in the SEO title. <a href='https://yoa.st/33h' target='_blank'>Try to " +
-			"write the exact match of your keyphrase in the SEO title</a>."
+			"keyphrase \"keyword\" appear in the SEO title. <a href='https://yoa.st/33h' target='_blank'>Try to " +
+			"use the exact match of your keyphrase in the SEO title</a>."
 		);
 	} );
 
@@ -53,7 +53,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe(
 			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus " +
-			"keyphrase appears in the  SEO title, but not at the beginning. " +
+			"keyphrase appears in the SEO title, but not at the beginning. " +
 			"<a href='https://yoa.st/33h' target='_blank'>Try move it to the beginning</a>."
 		);
 	} );

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -98,7 +98,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 9,
-		resultText: "The exact match of the focus keyphrase appears at the beginning of the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>, which is considered to improve rankings.",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job!",
 	},
 	titleWidth: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -87,7 +87,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 6,
-		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears in the  SEO title, but not at the beginning. <a href='https://yoa.st/33h' target='_blank'>Try move it to the beginning</a>.",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears in the SEO title, but not at the beginning. <a href='https://yoa.st/33h' target='_blank'>Try move it to the beginning</a>.",
 	},
 	titleWidth: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -87,8 +87,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 6,
-		resultText: "The exact match of the focus keyphrase appears in the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>, " +
-		"but not at the beginning; try and move it to the beginning.",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears in the  SEO title, but not at the beginning. <a href='https://yoa.st/33h' target='_blank'>Try move it to the beginning</a>.",
 	},
 	titleWidth: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -81,7 +81,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 9,
-		resultText: "The exact match of the focus keyphrase appears at the beginning of the <a href='https://yoa.st/2pn' target='_blank'>SEO title</a>, which is considered to improve rankings.",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job!",
 	},
 	titleWidth: {
 		score: 9,

--- a/src/assessments/seo/TitleKeywordAssessment.js
+++ b/src/assessments/seo/TitleKeywordAssessment.js
@@ -32,7 +32,8 @@ class TitleKeywordAssessment extends Assessment {
 				okay: 6,
 				bad: 2,
 			},
-			url: "<a href='https://yoa.st/2pn' target='_blank'>",
+			urlTitle: "<a href='https://yoa.st/33g' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/33h' target='_blank'>",
 		};
 
 		this.identifier = "titleKeyword";
@@ -54,7 +55,7 @@ class TitleKeywordAssessment extends Assessment {
 
 		const assessmentResult = new AssessmentResult();
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult( i18n, this._keyword );
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
 
@@ -78,10 +79,11 @@ class TitleKeywordAssessment extends Assessment {
 	 * from the keyphrase are in the title (in any form). Returns BAD otherwise.
 	 *
 	 * @param {Jed} i18n The object used for translations.
+	 * @param {string} keyword The keyword of the paper (to be returned in the feedback strings).
 	 *
 	 * @returns {Object} Object with score and text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult( i18n, keyword ) {
 		const exactMatch = this._keywordMatches.exactMatch;
 		const position = this._keywordMatches.position;
 		const allWordsFound = this._keywordMatches.allWordsFound;
@@ -91,15 +93,14 @@ class TitleKeywordAssessment extends Assessment {
 				return {
 					score: this._config.scores.good,
 					resultText: i18n.sprintf(
-						/* Translators: %1$s expands to the keyphrase, %2$s expands to a link on yoast.com,
-						%3$s expands to the anchor end tag. */
+						/* Translators: %1$s expands to a link on yoast.com,
+						%2$s expands to the anchor end tag. */
 						i18n.dgettext(
 							"js-text-analysis",
-							"The exact match of the focus keyphrase appears at the beginning of the %1$sSEO title%2$s, " +
-							"which is considered to improve rankings."
-
+							"%1$sKeyphrase in title%2$s: The exact match of the focus keyphrase appears at the beginning " +
+							"of the SEO title. Good job!",
 						),
-						this._config.url,
+						this._config.urlTitle,
 						"</a>"
 					),
 				};
@@ -107,14 +108,15 @@ class TitleKeywordAssessment extends Assessment {
 			return {
 				score: this._config.scores.okay,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands to the keyphrase, %2$s expands to a link on yoast.com,
+					/* Translators: %1$s and %2$s expand to a link on yoast.com,
 					%3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"The exact match of the focus keyphrase appears in the %1$sSEO title%2$s, but not at the beginning; " +
-						"try and move it to the beginning."
+						"%1$sKeyphrase in title%3$s: The exact match of the focus keyphrase appears in the  SEO title, but not " +
+						"at the beginning. %2$sTry move it to the beginning%3$s."
 					),
-					this._config.url,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -124,12 +126,15 @@ class TitleKeywordAssessment extends Assessment {
 			return {
 				score: this._config.scores.okay,
 				resultText: i18n.sprintf(
-					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+					/* Translators: %1$s and %2$s expand to a link on yoast.com,
+					%3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"The %1$sSEO title%2$s contains all words from the focus keyphrase, but not its exact match."
+						"%1$sKeyphrase in title%3$s: Does not contain the exact match. %2$sTry to write the exact match of " +
+						"your keyphrase in the SEO title%3$s."
 					),
-					this._config.url,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
 					"</a>"
 				),
 			};
@@ -138,14 +143,17 @@ class TitleKeywordAssessment extends Assessment {
 		return {
 			score: this._config.scores.bad,
 			resultText: i18n.sprintf(
-				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+				/* Translators: %1$s and %2$s expand to a link on yoast.com,
+				%3$s expands to the anchor end tag, %4$s expands to the keyword of the article.  */
 				i18n.dgettext(
 					"js-text-analysis",
-					"The focus keyword '%1$s' does not appear in the %2$sSEO title%3$s."
+					"%1$sKeyphrase in title%3$s: Not all the words from your keyphrase \"%4$s\"; appear in the SEO title. " +
+					"%2$sTry to write the exact match of your keyphrase in the SEO title%3$s."
 				),
-				this._keyword,
-				this._config.url,
-				"</a>"
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>",
+				keyword
 			),
 		};
 	}

--- a/src/assessments/seo/TitleKeywordAssessment.js
+++ b/src/assessments/seo/TitleKeywordAssessment.js
@@ -89,7 +89,7 @@ class TitleKeywordAssessment extends Assessment {
 		const allWordsFound = this._keywordMatches.allWordsFound;
 
 		if ( exactMatch === true ) {
-			if ( position === 0 )  {
+			if ( position === 0 ) {
 				return {
 					score: this._config.scores.good,
 					resultText: i18n.sprintf(
@@ -112,7 +112,7 @@ class TitleKeywordAssessment extends Assessment {
 					%3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in title%3$s: The exact match of the focus keyphrase appears in the  SEO title, but not " +
+						"%1$sKeyphrase in title%3$s: The exact match of the focus keyphrase appears in the SEO title, but not " +
 						"at the beginning. %2$sTry move it to the beginning%3$s."
 					),
 					this._config.urlTitle,
@@ -144,11 +144,11 @@ class TitleKeywordAssessment extends Assessment {
 			score: this._config.scores.bad,
 			resultText: i18n.sprintf(
 				/* Translators: %1$s and %2$s expand to a link on yoast.com,
-				%3$s expands to the anchor end tag, %4$s expands to the keyword of the article.  */
+				%3$s expands to the anchor end tag, %4$s expands to the keyword of the article. */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sKeyphrase in title%3$s: Not all the words from your keyphrase \"%4$s\"; appear in the SEO title. " +
-					"%2$sTry to write the exact match of your keyphrase in the SEO title%3$s."
+					"%1$sKeyphrase in title%3$s: Not all the words from your keyphrase \"%4$s\" appear in the SEO title. " +
+					"%2$sTry to use the exact match of your keyphrase in the SEO title%3$s."
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updates the feedback strings returned by the assessment that checks if the keyword is used in the title.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Add a paper with a title that contains your keyword in the beginning: The assessment should return a good score.
* Add more words in the beginning of the title, so that the keyword is not at the very beginning of the title anymore: The assessment should return an okay score.
* Use a multi-word keyphrase. The previous two cases should still hold.
* Add words in the title field, so that all words from the keyphrase are still in the title, but separated by some other words: The assessment should return an okay score.
* Shuffle the words in the title field, so that all words from the keyphrase are still in the title, but they are separated by some other words and do not appear in the same order as in the keyphrase: The assessment should return an okay score.
* Remove one|some|all keyphrase words from the title: The assessment should return a bad score.
* When getting an okay score, try adding function words to the keyphrase without using them in the title. The result should remain okay.
* For Premium only: When getting an okay score, try using different word forms in the keyphrase from those used in the title. The result should remain okay.

Fixes #1638 
