### PR TITLE
Fix faulty link statistics research

### DIFF
--- a/src/researches/getLinkStatistics.js
+++ b/src/researches/getLinkStatistics.js
@@ -69,18 +69,16 @@ const filterAnchorsContainingTopic = function( anchors, topicForms, locale ) {
  * @param {Array} anchors An array with all anchors from the paper.
  * @param {Array} keyphraseAndSynonyms An array with keyphrase and its synonyms.
  * @param {string} locale The locale of the paper.
- * @param {Researcher} researcher The morphological researcher.
+ * @param {Object} morphologyData The morphology data (regexes and exception lists) available for the language.
  *
  * @returns {Array} The array of all anchors that contain keyphrase or synonyms.
  */
-const filterAnchorsContainedInTopic = function( anchors, keyphraseAndSynonyms, locale, researcher ) {
-	const language = getLanguage( locale );
-	const morphologyData = researcher.getData( "morphology" )[ language ];
+const filterAnchorsContainedInTopic = function( anchors, keyphraseAndSynonyms, locale, morphologyData ) {
 	let anchorsContainedInTopic = [];
 
 	anchors.forEach( function( currentAnchor ) {
 		// Generate the forms of the content words from within the anchor.
-		const linkTextForms = buildForms( currentAnchor, language, morphologyData );
+		const linkTextForms = buildForms( currentAnchor, getLanguage( locale ), morphologyData );
 
 		for ( let j = 0; j < keyphraseAndSynonyms.length; j++ ) {
 			const topic = keyphraseAndSynonyms[ j ];
@@ -137,8 +135,9 @@ const keywordInAnchor = function( paper, researcher, anchors, permalink ) {
 	const synonyms = paper.getSynonyms();
 	const keyphraseAndSynonyms = flatten( [].concat( keyword, parseSynonyms( synonyms ) ) );
 
+	const morphologyData = researcher.getData( "morphology" )[ getLanguage( locale ) ] || false;
 
-	anchors = filterAnchorsContainedInTopic( anchors, keyphraseAndSynonyms, locale, researcher );
+	anchors = filterAnchorsContainedInTopic( anchors, keyphraseAndSynonyms, locale, morphologyData );
 	result.totalKeyword = anchors.length;
 	result.matchedAnchors = anchors;
 

--- a/src/researches/getLinkStatistics.js
+++ b/src/researches/getLinkStatistics.js
@@ -6,10 +6,11 @@ import getLinkType from "../stringProcessing/getLinkType.js";
 import checkNofollow from "../stringProcessing/checkNofollow.js";
 import urlHelper from "../stringProcessing/url.js";
 import parseSynonyms from "../stringProcessing/parseSynonyms";
-import Paper from "../values/Paper";
+import { buildForms } from "./buildKeywordForms";
+import getLanguage from "../helpers/getLanguage";
 
 import { flatten } from "lodash-es";
-import { findTopicFormsInString } from "./findKeywordFormsInString";
+import { findWordFormsInString } from "./findKeywordFormsInString";
 
 
 /**
@@ -73,17 +74,17 @@ const filterAnchorsContainingTopic = function( anchors, topicForms, locale ) {
  * @returns {Array} The array of all anchors that contain keyphrase or synonyms.
  */
 const filterAnchorsContainedInTopic = function( anchors, keyphraseAndSynonyms, locale, researcher ) {
+	const language = getLanguage( locale );
+	const morphologyData = researcher.getData( "morphology" )[ language ];
 	let anchorsContainedInTopic = [];
 
 	anchors.forEach( function( currentAnchor ) {
-		// Create a fake paper to be able to generate the forms of the content words from within the anchor.
-		const fakePaper = new Paper( "", { keyword: currentAnchor, locale: locale } );
-		researcher.setPaper( fakePaper );
-		const linkTextForms = researcher.getResearch( "morphology" );
+		// Generate the forms of the content words from within the anchor.
+		const linkTextForms = buildForms( currentAnchor, language, morphologyData );
 
 		for ( let j = 0; j < keyphraseAndSynonyms.length; j++ ) {
 			const topic = keyphraseAndSynonyms[ j ];
-			if ( findTopicFormsInString( linkTextForms, topic, false, locale ).percentWordMatches === 100 ) {
+			if ( findWordFormsInString( linkTextForms, topic, locale ).percentWordMatches === 100 ) {
 				anchorsContainedInTopic.push( true );
 				break;
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

* Fixes the bug where the paper would be reset to empty upon execution of the links statistics research.

## Test instructions

This PR can be tested by following these steps:

* In Free: link this branch to the `release/9.0` branch on `wordpress-seo` and check if
  * The Competing Links assessment works as expected (morphological forms are **not** matched, function words are not considered
  * The Internal Links and Outbound Links assessments work as expected (they use the same research).
  * The following assessments are correctly called and executed: TextImages, TextLength,  TitleKeywordAssessment, TitleWidth, UrlKeywordAssessment, UrlLength, urlStopWords.
* For Premium: link this branch to `trunk` on `wordpress-seo-premium` and check the same as for Free, but check also that morphological forms of words are recognized (i.e., you can use different forms of words in the keyphrase and in the link text and the Competing Links Assessment will still return a warning).

Fixes #1843 
