### PR TITLE
Make sure outbound links assessment doesn't count internal links

### DIFF
--- a/src/assessments/seo/outboundLinksAssessment.js
+++ b/src/assessments/seo/outboundLinksAssessment.js
@@ -75,7 +75,7 @@ class OutboundLinksAssessment extends Assessment {
 			return this._config.scores.noLinks;
 		}
 
-		if ( linkStatistics.externalNofollow === linkStatistics.total ) {
+		if ( linkStatistics.externalNofollow === linkStatistics.externalTotal ) {
 			return this._config.scores.allNofollowed;
 		}
 
@@ -111,7 +111,7 @@ class OutboundLinksAssessment extends Assessment {
 			);
 		}
 
-		if ( linkStatistics.externalNofollow === linkStatistics.total ) {
+		if ( linkStatistics.externalNofollow === linkStatistics.externalTotal ) {
 			return i18n.sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%3$s: " +
@@ -123,7 +123,7 @@ class OutboundLinksAssessment extends Assessment {
 			);
 		}
 
-		if ( linkStatistics.externalDofollow === linkStatistics.total ) {
+		if ( linkStatistics.externalDofollow === linkStatistics.externalTotal ) {
 			return i18n.sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%2$s: " +


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Makes sure that the outbound links analysis only counts outbound links, and not internal links.

## Test instructions

This PR can be tested by following these steps:

* Add a text with a normal outbound link. You should get the feedback `Outbound links: Good job!`
* Add a normal internal link. Make sure the outbound links assessment still displays the same feedback as before.
* Set your outbound link to `rel="nofollow"`. You sould get the feedback: `Outbound links: All 
outbound links on this page are nofollowed. Add some normal links.`
* Add a normal outbound link. You should get the feedback `Outbound links: There are both nofollowed and normal outbound links on this page. Good job!`

Fixes #1851 
