### PR TITLE
Change key phrase to keyphrase in all feedback texts

### DIFF
--- a/spec/assessments/MetaDescriptionKeywordAssessmentSpec.js
+++ b/spec/assessments/MetaDescriptionKeywordAssessmentSpec.js
@@ -16,7 +16,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherNoMatches, i18n );
 
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: The meta description has been specified, but it does not contain the focus key phrase. <a href='https://yoa.st/33l' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description has been specified, but it does not contain the focus keyphrase. <a href='https://yoa.st/33l' target='_blank'>Fix that</a>!" );
 	} );
 
 	it( "returns a good result and an appropriate feedback message when at least one sentence contains every keyword term at least once in the same sentence.", function() {
@@ -24,7 +24,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherOneMatch, i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: Focus key phrase or synonym appear in the meta description. Well done!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!" );
 	} );
 
 	it( "returns a good result and an appropriate feedback message when the meta description contains the keyword two times in the same sentence", function() {
@@ -32,7 +32,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherTwoMatches, i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: Focus key phrase or synonym appear in the meta description. Well done!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!" );
 	} );
 
 	it( "returns a bad result when the meta description contains the keyword three times in the same sentence", function() {
@@ -40,7 +40,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherThreeMatches, i18n );
 
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: The meta description contains the focus keyword 3 times, which is over the advised maximum of 2 times. <a href='https://yoa.st/33l' target='_blank'>Limit that</a>!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description contains the focus keyword 3 times, which is over the advised maximum of 2 times. <a href='https://yoa.st/33l' target='_blank'>Limit that</a>!" );
 	} );
 
 	it( "returns an okay result when the meta description contains the keyword one time, but not in the same sentence", function() {
@@ -48,7 +48,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherMatchesDescription, i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: All words of focus key phrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of focus keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>." );
 	} );
 
 	it( "is not applicable when the paper doesn't have a keyword", function() {

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -66,7 +66,7 @@ const expectedResults = {
 	},
 	metaDescriptionKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: Focus key phrase or synonym appear in the meta description. Well done!",
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!",
 	},
 	metaDescriptionLength: {
 		score: 6,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -55,7 +55,7 @@ const expectedResults = {
 	},
 	metaDescriptionKeyword: {
 		score: 6,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: All words of focus key phrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>.",
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of focus keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>.",
 	},
 	metaDescriptionLength: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -49,7 +49,7 @@ const expectedResults = {
 	},
 	metaDescriptionKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Key phrase in meta description</a>: Focus key phrase or synonym appear in the meta description. Well done!",
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!",
 	},
 	metaDescriptionLength: {
 		score: 9,

--- a/src/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -78,7 +78,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKey phrase in meta description%2$s: Focus key phrase or synonym appear in the meta description. Well done!",
+						"%1$sKeyphrase in meta description%2$s: Focus keyphrase or synonym appear in the meta description. Well done!",
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -94,12 +94,12 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					/**
 					 * Translators:
 					 * %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
-					 * %3$s expands to the number of sentences containing the key phrase,
+					 * %3$s expands to the number of sentences containing the keyphrase,
 					 * %4$s expands to a link on yoast.com, %5$s expands to the anchor end tag.
 					 */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKey phrase in meta description%2$s: The meta description contains the focus keyword %3$s times, " +
+						"%1$sKeyphrase in meta description%2$s: The meta description contains the focus keyword %3$s times, " +
 						"which is over the advised maximum of 2 times. %4$sLimit that%5$s!",
 					),
 					this._config.urlTitle,
@@ -123,7 +123,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					 */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%1$sKey phrase in meta description%2$s: All words of focus key phrase or synonym " +
+						"%1$sKeyphrase in meta description%2$s: All words of focus keyphrase or synonym " +
 						"appear in the meta description, but not within one sentence. " +
 						"%3$sTry to use them in one sentence%4$s."
 					),
@@ -136,7 +136,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 			};
 		}
 
-		// BAD if the key phrases is not contained in the meta description.
+		// BAD if the keyphrases is not contained in the meta description.
 		return {
 			score: this._config.scores.bad,
 			resultText: i18n.sprintf(
@@ -147,8 +147,8 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 				 */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sKey phrase in meta description%2$s: The meta description has been specified, " +
-					"but it does not contain the focus key phrase. %3$sFix that%4$s!"
+					"%1$sKeyphrase in meta description%2$s: The meta description has been specified, " +
+					"but it does not contain the focus keyphrase. %3$sFix that%4$s!"
 				),
 				this._config.urlTitle,
 				"</a>",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Changes the spelling of `key phrase` to `keyphrase` in all instances where the right spelling wasn't used yet.

## Test instructions

This PR can be tested by following these steps:

* Run through all possible conditions in the meta description (see https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#4-keyword-is-in-meta-description) and make sure that the feedback strings use `keyphrase` instead of `key phrase`.

Fixes #1858
