### PR TITLE
Keyphrase in subheading assessment uses the old boundaries again.

### DIFF
--- a/spec/assessments/subheadingsKeywordSpec.js
+++ b/spec/assessments/subheadingsKeywordSpec.js
@@ -6,7 +6,7 @@ const i18n = Factory.buildJed();
 let matchKeywordAssessment = new SubheadingsKeywordAssessment();
 
 describe( "An assessment for matching keywords in subheadings", function() {
-	it( "returns a bad score and appropriate feedback when none of the subheadings contain the keyword", function() {
+	it( "returns an okay score and appropriate feedback when none of the subheadings contain the keyphrase", function() {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
@@ -14,14 +14,13 @@ describe( "An assessment for matching keywords in subheadings", function() {
 			i18n
 		);
 
-		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>" +
-			"Use more keywords or synonyms in your subheadings</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your subheadings</a>!"
 		);
 	} );
 
-	it( "returns a bad score and appropriate feedback when there are too few subheadings containing the keyword", function() {
+	it( "returns a good score and appropriate feedback when one subheading containing the keyphrase.", function() {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
@@ -29,14 +28,13 @@ describe( "An assessment for matching keywords in subheadings", function() {
 			i18n
 		);
 
-		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>" +
-			"Use more keywords or synonyms in your subheadings</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your subheading reflects the topic of your copy. Good job!"
 		);
 	} );
 
-	it( "returns a good score and appropriate feedback when there is a sufficient number of subheadings containing the keyword", function() {
+	it( "returns a good score and appropriate feedback when more than one subheading contains the keyphrase.", function() {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
@@ -46,39 +44,7 @@ describe( "An assessment for matching keywords in subheadings", function() {
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"50% of your subheadings reflect the topic of your copy. Good job!" );
-	} );
-
-	it( "returns a good score and appropriate feedback when there is only one subheading and that subheading contains the keyword", function() {
-		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult(
-			mockPaper,
-			Factory.buildMockResearcher( { count: 1, matches: 1, percentReflectingTopic: 100 } ),
-			i18n
-		);
-
-		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"Your subheading reflects the topic of your copy. Good job!"
-		);
-	} );
-
-	it( "returns a bad score and appropriate feedback when there are too many subheadings containing the keyword", function() {
-		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult(
-			mockPaper,
-			Factory.buildMockResearcher( { count: 4, matches: 4, percentReflectingTopic: 100 } ),
-			i18n
-		);
-
-		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"More than 75% of your subheadings reflect the topic of your copy. That's too much. " +
-			"<a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!"
-		);
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 2 (out of 4) subheadings reflect the topic of your copy. Good job!" );
 	} );
 
 	it( "checks isApplicable for a paper without text", function() {

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -74,7 +74,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 50% of your subheadings reflect the topic of your copy. Good job!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 2 (out of 4) subheadings reflect the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -63,7 +63,7 @@ const expectedResults = {
 	},
 	subheadingsKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 33.3% of your subheadings reflect the topic of your copy. Good job!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your subheading reflects the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -56,8 +56,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!",
 	},
 	subheadingsKeyword: {
-		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 4 (out of 4) subheadings reflect the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		score: 0,

--- a/src/assessments/seo/subheadingsKeywordAssessment.js
+++ b/src/assessments/seo/subheadingsKeywordAssessment.js
@@ -111,11 +111,12 @@ class SubHeadingsKeywordAssessment extends Assessment {
 					 */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%2$s: %3$s of your subheadings reflect the topic of your copy. Good job!"
+						"%1$sKeyphrase in subheading%2$s: %3$s (out of %4$s) subheadings reflect the topic of your copy. Good job!"
 					),
 					this._config.urlTitle,
 					"</a>",
 					this._subHeadings.matches,
+					this._subHeadings.count,
 				),
 			};
 		}
@@ -129,7 +130,7 @@ class SubHeadingsKeywordAssessment extends Assessment {
 				 */
 				i18n.dngettext(
 					"js-text-analysis",
-					"%1$sKeyphrase in subheading%2$s: %3$sUse more keywords or synonyms in your subheadings%4$s!"
+					"%1$sKeyphrase in subheading%2$s: %3$sUse more keyphrases or synonyms in your subheadings%4$s!"
 				),
 				this._config.urlTitle,
 				"</a>",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the boundaries of the keyphrase in subheading assessment to the old ones: OKAY (needs improvement) if no subheading matches the keyphrase, GOOD otherwise.

## Relevant technical choices:

* The feedback strings are now:
     * One match: 
`Keyphrase in subheading: Your subheading reflects the topic of your copy. Good job!`
     * Multiple matches: 
`Keyphrase in subheading: n (out of N) subheadings reflect the topic of your copy. Good job!`
     * No matches: 
`Keyphrase in subheading: Use more keyphrases or synonyms in your subheadings!`

@jdevalk : are they alright as they are, or do they need to be adapted?

## Test instructions

This PR can be tested by following these steps:

* Make a new post.
* Make sure to test out these test cases:
  * Four subheadings, none of them containing the keyphrase, one of its word forms or synonyms. 
      * This should give an orange bullet.
  * Four subheadings, one of them containing the keyphrase, one of its word forms or synonyms.
      * This should give a green bullet.
  * Four subheadings, two of them containing the keyphrase, one of its word forms or synonyms.
      * This should give a green bullet as well.

Fixes #1859 
