### PR TITLE
Iverse keyword distribution highlights

### DIFF
--- a/spec/assessments/KeyphraseDistributionAssessmentSpec.js
+++ b/spec/assessments/KeyphraseDistributionAssessmentSpec.js
@@ -95,16 +95,16 @@ describe( "A test for marking keywords in the text", function() {
 	it( "returns markers for sentences specified by the researcher", function() {
 		let mockPaper = new Paper( "A sentence. A sentence containing keywords. Another sentence.", { keyword: "keyword" } );
 		keyphraseDistributionAssessment.getResult( mockPaper, Factory.buildMockResearcher(
-			{ keyphraseDistributionScore: 5, sentencesToHighlight: [ "A sentence.", "Another sentence." ] } ), i18n );
+			{ keyphraseDistributionScore: 5, sentencesToHighlight: [ new Mark( {
+				original: "A sentence with keywords.",
+				marked: "A sentence with<yoastmark class='yoast-text-mark'>keywords</yoastmark>.",
+			} ) ] } ), i18n );
 		let expected = [
 			new Mark( {
-				original: "A sentence.",
-				marked: "<yoastmark class='yoast-text-mark'>A sentence.</yoastmark>",
+				original: "A sentence with keywords.",
+				marked: "A sentence with<yoastmark class='yoast-text-mark'>keywords</yoastmark>.",
 			} ),
-			new Mark( {
-				original: "Another sentence.",
-				marked: "<yoastmark class='yoast-text-mark'>Another sentence.</yoastmark>",
-			} ),
+
 		];
 		expect( keyphraseDistributionAssessment.getMarks() ).toEqual( expected );
 	} );

--- a/spec/researches/keyphraseDistributionSpec.js
+++ b/spec/researches/keyphraseDistributionSpec.js
@@ -6,6 +6,7 @@ import { keyphraseDistributionResearcher } from "../../src/researches/keyphraseD
 import Paper from "../../src/values/Paper.js";
 import Researcher from "../../src/researcher";
 import morphologyData from "../../premium-configuration/data/morphologyData.json";
+import Mark from "../../src/values/Mark.js";
 
 describe( "Test for maximizing sentence scores", function() {
 	it( "returns the largest score per sentence over all topics", function() {
@@ -46,6 +47,18 @@ const sentences = [
 	"Words, words, words, how boring!",
 ];
 
+const sentenceMarkersKeyRemarkableSomethingWord = [
+	new Mark( { marked: "How <yoastmark class='yoast-text-mark'>remarkable</yoastmark>!", original: "How remarkable!" } ),
+	new Mark( { marked: "<yoastmark class='yoast-text-mark'>Remarkable</yoastmark> is a funny <yoastmark class='yoast-text-mark'>word</yoastmark>.", original: "Remarkable is a funny word." } ),
+	new Mark( { marked: "I have found a <yoastmark class='yoast-text-mark'>key</yoastmark> and a <yoastmark class='yoast-text-mark'>remarkable word</yoastmark>.", original: "I have found a key and a remarkable word." } ),
+	new Mark( { marked: "And again a <yoastmark class='yoast-text-mark'>key something</yoastmark>.", original: "And again a key something." } ),
+	new Mark( { marked: "Here comes <yoastmark class='yoast-text-mark'>something</yoastmark> that has nothing to do with a keyword.", original: "Here comes something that has nothing to do with a keyword." } ),
+	new Mark( { marked: "Ha, a <yoastmark class='yoast-text-mark'>key</yoastmark>!", original: "Ha, a key!" } ),
+	new Mark( { marked: "<yoastmark class='yoast-text-mark'>Words</yoastmark>, " +
+		"<yoastmark class='yoast-text-mark'>words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>" +
+		", how boring!", original: "Words, words, words, how boring!" } ),
+];
+
 const topicShort = [
 	[ "key", "keys" ],
 	[ "word", "words" ],
@@ -67,6 +80,16 @@ const sentencesIT = [
 	"Ah, una chiave!",
 	"Ancora niente!",
 	"Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
+];
+
+const sentencesMarkersITParolaChiaveStraordinariaQualcosa = [
+	new Mark( { marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!", original: "Che cosa straordinaria!" } ),
+	new Mark( { marked: "<yoastmark class='yoast-text-mark'>Straordinaria</yoastmark> è una <yoastmark class='yoast-text-mark'>parola</yoastmark> strana.", original: "Straordinaria è una parola strana." } ),
+	new Mark( { marked: "Ho trovato una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e una <yoastmark class='yoast-text-mark'>parola straordinaria</yoastmark>.", original: "Ho trovato una chiave e una parola straordinaria." } ),
+	new Mark( { marked: "E ancora una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e <yoastmark class='yoast-text-mark'>qualcosa</yoastmark>.", original: "E ancora una chiave e qualcosa." } ),
+	new Mark( { marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.", original: "È qualcosa che non ha niente da fare con questo che cerchiamo." } ),
+	new Mark( { marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!", original: "Ah, una chiave!" } ),
+	new Mark( { marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!", original: "Una parola e ancora un'altra e poi un'altra ancora, che schifo!" } ),
 ];
 
 const topicShortIT = [
@@ -111,7 +134,7 @@ describe( "Test for computing the step function", function() {
 } );
 
 describe( "Test for a step-function research", function() {
-	it( "returns an average score over all sentences and all topic forms; returns markers for sentences that don't contain the topic at all", function() {
+	it( "returns an average score over all sentences and all topic forms; returns markers for sentences that contain the topic words", function() {
 		const paper = new Paper(
 			sentences.join( " " ),
 			{
@@ -126,7 +149,7 @@ describe( "Test for a step-function research", function() {
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
 			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Again nothing!" ],
+			sentencesToHighlight: sentenceMarkersKeyRemarkableSomethingWord,
 		} );
 	} );
 
@@ -150,7 +173,7 @@ describe( "Test for a step-function research", function() {
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
 			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Again nothing!" ],
+			sentencesToHighlight: sentenceMarkersKeyRemarkableSomethingWord,
 		} );
 	} );
 
@@ -169,7 +192,7 @@ describe( "Test for a step-function research", function() {
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
 			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			sentencesToHighlight: sentencesMarkersITParolaChiaveStraordinariaQualcosa,
 		} );
 	} );
 
@@ -188,7 +211,7 @@ describe( "Test for a step-function research", function() {
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
 			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			sentencesToHighlight: sentencesMarkersITParolaChiaveStraordinariaQualcosa,
 		} );
 	} );
 
@@ -213,7 +236,7 @@ describe( "Test for a step-function research", function() {
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
 			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			sentencesToHighlight: sentencesMarkersITParolaChiaveStraordinariaQualcosa,
 		} );
 	} );
 
@@ -234,7 +257,7 @@ describe( "Test for a step-function research", function() {
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
 			keyphraseDistributionScore: 0.13157894736842105,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			sentencesToHighlight: sentencesMarkersITParolaChiaveStraordinariaQualcosa,
 		} );
 	} );
 } );

--- a/src/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/src/assessments/seo/KeyphraseDistributionAssessment.js
@@ -3,8 +3,6 @@ import { merge } from "lodash-es";
 import Assessment from "../../assessment";
 import AssessmentResult from "../../values/AssessmentResult";
 import countWords from "../../stringProcessing/countWords";
-import Mark from "../../values/Mark";
-import addMark from "../../markers/addMark";
 
 /**
  * Returns a score based on the largest percentage of text in
@@ -158,9 +156,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 	 * @returns {Array} All markers for the current text.
 	 */
 	getMarks() {
-		return this._keyphraseDistribution.sentencesToHighlight.map( function( sentence ) {
-			return new Mark( { original: sentence, marked: addMark( sentence ) } );
-		} );
+		return this._keyphraseDistribution.sentencesToHighlight;
 	}
 
 	/**

--- a/src/researches/keyphraseDistribution.js
+++ b/src/researches/keyphraseDistribution.js
@@ -247,11 +247,6 @@ const keyphraseDistributionResearcher = function( paper, researcher ) {
 	return {
 		// Return Gini coefficient of per-portion scores, increase it by eventual punishment for not using all topic words equally.
 		keyphraseDistributionScore: gini( textPortionScores ) + sum( punishment ) / punishment.length,
-
-		/*
-	     * Sentences that have a maximized score of 3 are used for marking because these do not contain any topic forms.
-	     * Hence these sentences require action most urgently.
-	     */
 		sentencesToHighlight: sentenceScores.markings,
 	};
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Changes marking for the keyword distribution assessment. We now mark keyphrase occurrences (all matches that were counted in the keyword distribution assessment, so also partial matches) instead of marking sentences without keyphrase occurrences.

## Test instructions

This PR can be tested by following these steps:

* Im Premium, add a text and make sure that the keyphrase distribution assessment is triggered (see https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#11-keyphrase-distribution). Use keyphrases of multiple lengths (either <4 or >4 words). Also use synonyms. In the text, use these keyphrases/synonyms in various forms (e.g., plurals).
* Click on the marker button and make sure that all the keyphrase occurrences (also partial ones) get marked.

Fixes #1863 
