### PR TITLE
Replace 'focus keyword' by 'keyword' in assessment names and feedback

### DIFF
--- a/spec/assessments/KeyphraseLengthAssessmentSpec.js
+++ b/spec/assessments/KeyphraseLengthAssessmentSpec.js
@@ -12,8 +12,8 @@ describe( "the keyphrase length assessment", function() {
 
 		expect( result.getScore() ).toEqual( -999 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
-			"No focus keyphrase was set for this page. " +
-			"<a href='https://yoa.st/33j' target='_blank'>Set a focus keyphrase in order to calculate your SEO score</a>." );
+			"No keyphrase was set for this page. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Set a keyphrase in order to calculate your SEO score</a>." );
 	} );
 
 	it( "should assess a paper with a keyphrase that's too long as bad", function() {

--- a/spec/assessments/KeywordDensityAssessmentSpec.js
+++ b/spec/assessments/KeywordDensityAssessmentSpec.js
@@ -15,7 +15,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0%. This is too low; the focus keyword was found 0 times. <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0%. This is too low; the keyword was found 0 times. <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {
@@ -25,7 +25,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0.1%. This is too low; the focus keyword was found 1 time. <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0.1%. This is too low; the keyword was found 1 time. <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {
@@ -35,7 +35,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 10%. This is way over the advised 2.5% maximum; the focus keyword was found 1 time. <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 10%. This is way over the advised 2.5% maximum; the keyword was found 1 time. <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
 
 		paper = new Paper( "string with the keyword", { keyword: "keyword" } );
 		result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {
@@ -55,7 +55,7 @@ describe( "An assessment for the keywordDensity", function() {
 			},
 		}, true ), i18n );
 		expect( result.getScore() ).toBe( -10 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 3%. This is over the advised 2.5% maximum; the focus keyword was found 2 times. <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 3%. This is over the advised 2.5% maximum; the keyword was found 2 times. <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
 
 		paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {

--- a/spec/assessments/MetaDescriptionKeywordAssessmentSpec.js
+++ b/spec/assessments/MetaDescriptionKeywordAssessmentSpec.js
@@ -16,7 +16,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherNoMatches, i18n );
 
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description has been specified, but it does not contain the focus keyphrase. <a href='https://yoa.st/33l' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description has been specified, but it does not contain the keyphrase. <a href='https://yoa.st/33l' target='_blank'>Fix that</a>!" );
 	} );
 
 	it( "returns a good result and an appropriate feedback message when at least one sentence contains every keyword term at least once in the same sentence.", function() {
@@ -24,7 +24,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherOneMatch, i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!" );
 	} );
 
 	it( "returns a good result and an appropriate feedback message when the meta description contains the keyword two times in the same sentence", function() {
@@ -32,7 +32,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherTwoMatches, i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!" );
 	} );
 
 	it( "returns a bad result when the meta description contains the keyword three times in the same sentence", function() {
@@ -40,7 +40,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherThreeMatches, i18n );
 
 		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description contains the focus keyphrase 3 times, which is over the advised maximum of 2 times. <a href='https://yoa.st/33l' target='_blank'>Limit that</a>!" );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description contains the keyphrase 3 times, which is over the advised maximum of 2 times. <a href='https://yoa.st/33l' target='_blank'>Limit that</a>!" );
 	} );
 
 	it( "returns an okay result when the meta description contains the keyword one time, but not in the same sentence", function() {
@@ -48,7 +48,7 @@ describe( "the metadescription keyword assessment", function() {
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherMatchesDescription, i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of focus keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>." );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>." );
 	} );
 
 	it( "is not applicable when the paper doesn't have a keyword", function() {

--- a/spec/assessments/TextCompetingLinksAssessmentSpec.js
+++ b/spec/assessments/TextCompetingLinksAssessmentSpec.js
@@ -33,7 +33,7 @@ describe( "An assessment for competing links in the text", function() {
 		);
 
 		expect( result.getScore() ).toBe( 2 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/34l' target='_blank'>Link focus keyphrase</a>: " +
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/34l' target='_blank'>Link keyphrase</a>: " +
 			"You're linking to another page with the words you want this page to rank for. " +
 			"<a href='https://yoa.st/34m' target='_blank'>Don't do that</a>!" );
 	} );

--- a/spec/assessments/TitleKeywordAssessmentSpec.js
+++ b/spec/assessments/TitleKeywordAssessmentSpec.js
@@ -35,7 +35,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe(
-			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus " +
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the " +
 			"keyphrase appears at the beginning of the SEO title. Good job!"
 		);
 	} );
@@ -52,7 +52,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe(
-			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus " +
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the " +
 			"keyphrase appears in the SEO title, but not at the beginning. " +
 			"<a href='https://yoa.st/33h' target='_blank'>Try to move it to the beginning</a>."
 		);

--- a/spec/assessments/keywordStopWordsSpec.js
+++ b/spec/assessments/keywordStopWordsSpec.js
@@ -23,7 +23,7 @@ describe( "A stop word in keyword assessment", function() {
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.hasScore() ).toEqual( true );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34b' target='_blank'>Stopwords</a>: The focus keyphrase contains stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/34c' target='_blank'>Learn more about stop words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34b' target='_blank'>Stopwords</a>: The keyphrase contains stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/34c' target='_blank'>Learn more about stop words</a>." );
 	} );
 
 	it( "assesses multiple stop words in the keyword", function() {
@@ -33,7 +33,7 @@ describe( "A stop word in keyword assessment", function() {
 
 		var assessment = stopWordsInKeywordAssessment.getResult( mockPaper, Factory.buildMockResearcher( [ "about", "before" ] ), i18n );
 		expect( assessment.getScore() ).toEqual( 0 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34b' target='_blank'>Stopwords</a>: The focus keyphrase contains stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/34c' target='_blank'>Learn more about stop words</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34b' target='_blank'>Stopwords</a>: The keyphrase contains stop words. This may or may not be wise depending on the circumstances. <a href='https://yoa.st/34c' target='_blank'>Learn more about stop words</a>." );
 	} );
 } );
 

--- a/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -23,24 +23,24 @@ describe( "checks for keyword doubles", function() {
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
 		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).score ).toBe( 6 );
 		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
-			"You've used this focus keyphrase <a href='http://post?1' target='_blank'>once before</a>. " +
-			"<a href='https://yoa.st/33y' target='_blank'>Do not use your focus keyphrase more than once</a>." );
+			"You've used this keyphrase <a href='http://post?1' target='_blank'>once before</a>. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 
 		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).score ).toBe( 1 );
 		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
-			"You've used this focus keyphrase <a href='http://search?keyword' target='_blank'>2 times before</a>. " +
-			"<a href='https://yoa.st/33y' target='_blank'>Do not use your focus keyphrase more than once</a>." );
+			"You've used this keyphrase <a href='http://search?keyword' target='_blank'>2 times before</a>. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 
 		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).score ).toBe( 9 );
-		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: You've not used this focus keyphrase before, very good." );
+		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: You've not used this keyphrase before, very good." );
 	} );
 
 	it( "escapes the keyword's special characters in the url", function() {
 		var paper = new Paper( "text", { keyword: "keyword/bla" } );
 		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
 		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
-			"You've used this focus keyphrase <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. " +
-			"<a href='https://yoa.st/33y' target='_blank'>Do not use your focus keyphrase more than once</a>." );
+			"You've used this keyphrase <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 	} );
 } );
 

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -66,7 +66,7 @@ const expectedResults = {
 	},
 	metaDescriptionKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!",
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!",
 	},
 	metaDescriptionLength: {
 		score: 6,
@@ -98,7 +98,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job!",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!",
 	},
 	titleWidth: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -55,7 +55,7 @@ const expectedResults = {
 	},
 	metaDescriptionKeyword: {
 		score: 6,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of focus keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>.",
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>.",
 	},
 	metaDescriptionLength: {
 		score: 9,
@@ -87,7 +87,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 6,
-		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears in the SEO title, but not at the beginning. <a href='https://yoa.st/33h' target='_blank'>Try to move it to the beginning</a>.",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the keyphrase appears in the SEO title, but not at the beginning. <a href='https://yoa.st/33h' target='_blank'>Try to move it to the beginning</a>.",
 	},
 	titleWidth: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -49,7 +49,7 @@ const expectedResults = {
 	},
 	metaDescriptionKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Focus keyphrase or synonym appear in the meta description. Well done!",
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!",
 	},
 	metaDescriptionLength: {
 		score: 9,
@@ -81,7 +81,7 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		score: 9,
-		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job!",
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!",
 	},
 	titleWidth: {
 		score: 9,

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -81,8 +81,8 @@ class KeyphraseLengthAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase length%3$s: No focus keyphrase was set for this page. " +
-						"%2$sSet a focus keyphrase in order to calculate your SEO score%3$s."
+						"%1$sKeyphrase length%3$s: No keyphrase was set for this page. " +
+						"%2$sSet a keyphrase in order to calculate your SEO score%3$s."
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -155,7 +155,7 @@ class KeywordDensityAssessment extends Assessment {
 					i18n.dgettext(
 						"js-text-analysis",
 						"%3$sKeyphrase density%5$s: %1$s. " +
-						"This is too low; the focus keyword was found %2$d times. %4$sFocus on your keyphrase%5$s!",
+						"This is too low; the keyword was found %2$d times. %4$sFocus on your keyphrase%5$s!",
 					),
 					keywordDensityPercentage,
 					this._keywordCount.count,
@@ -178,9 +178,9 @@ class KeywordDensityAssessment extends Assessment {
 					i18n.dngettext(
 						"js-text-analysis",
 						"%3$sKeyphrase density%5$s: %1$s. " +
-						"This is too low; the focus keyword was found %2$d time. %4$sFocus on your keyphrase%5$s!",
+						"This is too low; the keyword was found %2$d time. %4$sFocus on your keyphrase%5$s!",
 						"%3$sKeyphrase density%5$s: %1$s. " +
-						"This is too low; the focus keyword was found %2$d times. %4$sFocus on your keyphrase%5$s!",
+						"This is too low; the keyword was found %2$d times. %4$sFocus on your keyphrase%5$s!",
 						this._keywordCount.count
 					),
 					keywordDensityPercentage,
@@ -225,10 +225,10 @@ class KeywordDensityAssessment extends Assessment {
 					i18n.dngettext(
 						"js-text-analysis",
 						"%4$sKeyphrase density%6$s: %1$s. " +
-						"This is over the advised %3$s maximum; the focus keyword was found %2$d time. " +
+						"This is over the advised %3$s maximum; the keyword was found %2$d time. " +
 						"%5$sDon't overoptimize%6$s!",
 						"%4$sKeyphrase density%6$s: %1$s. " +
-						"This is over the advised %3$s maximum; the focus keyword was found %2$d times. " +
+						"This is over the advised %3$s maximum; the keyword was found %2$d times. " +
 						"%5$sDon't overoptimize%6$s!",
 						this._keywordCount.count
 					),
@@ -255,10 +255,10 @@ class KeywordDensityAssessment extends Assessment {
 				i18n.dngettext(
 					"js-text-analysis",
 					"%4$sKeyphrase density%6$s: %1$s. " +
-					"This is way over the advised %3$s maximum; the focus keyword was found %2$d time. " +
+					"This is way over the advised %3$s maximum; the keyword was found %2$d time. " +
 					"%5$sDon't overoptimize%6$s!",
 					"%4$sKeyphrase density%6$s: %1$s. " +
-					"This is way over the advised %3$s maximum; the focus keyword was found %2$d times. " +
+					"This is way over the advised %3$s maximum; the keyword was found %2$d times. " +
 					"%5$sDon't overoptimize%6$s!",
 					this._keywordCount.count
 				),

--- a/src/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -78,7 +78,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in meta description%2$s: Focus keyphrase or synonym appear in the meta description. Well done!",
+						"%1$sKeyphrase in meta description%2$s: Keyphrase or synonym appear in the meta description. Well done!",
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -99,7 +99,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					 */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in meta description%2$s: The meta description contains the focus keyphrase %3$s times, " +
+						"%1$sKeyphrase in meta description%2$s: The meta description contains the keyphrase %3$s times, " +
 						"which is over the advised maximum of 2 times. %4$sLimit that%5$s!",
 					),
 					this._config.urlTitle,
@@ -123,7 +123,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					 */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in meta description%2$s: All words of focus keyphrase or synonym " +
+						"%1$sKeyphrase in meta description%2$s: All words of keyphrase or synonym " +
 						"appear in the meta description, but not within one sentence. " +
 						"%3$sTry to use them in one sentence%4$s."
 					),
@@ -148,7 +148,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 				i18n.dgettext(
 					"js-text-analysis",
 					"%1$sKeyphrase in meta description%2$s: The meta description has been specified, " +
-					"but it does not contain the focus keyphrase. %3$sFix that%4$s!"
+					"but it does not contain the keyphrase. %3$sFix that%4$s!"
 				),
 				this._config.urlTitle,
 				"</a>",

--- a/src/assessments/seo/TextCompetingLinksAssessment.js
+++ b/src/assessments/seo/TextCompetingLinksAssessment.js
@@ -8,7 +8,7 @@ import Mark from "../../values/Mark";
 import addMark from "../../markers/addMark";
 
 /**
- * Assessment to check whether you're linking to a different page with the focus keyword from this page.
+ * Assessment to check whether you're linking to a different page with the keyword from this page.
  */
 class TextCompetingLinksAssessment extends Assessment {
 	/**
@@ -93,7 +93,7 @@ class TextCompetingLinksAssessment extends Assessment {
 					/* Translators:  %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sLink focus keyphrase%3$s: " +
+						"%1$sLink keyphrase%3$s: " +
 						"You're linking to another page with the words you want this page to rank for. " +
 						"%2$sDon't do that%3$s!"
 					),

--- a/src/assessments/seo/TitleKeywordAssessment.js
+++ b/src/assessments/seo/TitleKeywordAssessment.js
@@ -97,7 +97,7 @@ class TitleKeywordAssessment extends Assessment {
 						%2$s expands to the anchor end tag. */
 						i18n.dgettext(
 							"js-text-analysis",
-							"%1$sKeyphrase in title%2$s: The exact match of the focus keyphrase appears at the beginning " +
+							"%1$sKeyphrase in title%2$s: The exact match of the keyphrase appears at the beginning " +
 							"of the SEO title. Good job!",
 						),
 						this._config.urlTitle,
@@ -112,7 +112,7 @@ class TitleKeywordAssessment extends Assessment {
 					%3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in title%3$s: The exact match of the focus keyphrase appears in the SEO title, but not " +
+						"%1$sKeyphrase in title%3$s: The exact match of the keyphrase appears in the SEO title, but not " +
 						"at the beginning. %2$sTry to move it to the beginning%3$s."
 					),
 					this._config.urlTitle,

--- a/src/assessments/seo/keywordStopWordsAssessment.js
+++ b/src/assessments/seo/keywordStopWordsAssessment.js
@@ -20,7 +20,7 @@ var calculateStopWordsCountResult = function( stopWordCount, i18n ) {
 			text: i18n.dngettext(
 				"js-text-analysis",
 				/* Translators: %1$s and %2$s open links to Yoast articles, %3$s is the anchor end tag */
-				"%1$sStopwords%3$s: The focus keyphrase contains stop words. " +
+				"%1$sStopwords%3$s: The keyphrase contains stop words. " +
 				"This may or may not be wise depending on the circumstances. " +
 				"%2$sLearn more about stop words%3$s.",
 			),

--- a/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/src/bundledPlugins/previouslyUsedKeywords.js
@@ -72,7 +72,7 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 				/* Translators:
 				%1$s expands to a link to an article on yoast.com,
 				%2$s expands to an anchor tag. */
-				i18n.dgettext( "js-text-analysis", "%1$sPreviously used keyphrase%2$s: You've not used this focus keyphrase before, very good." ),
+				i18n.dgettext( "js-text-analysis", "%1$sPreviously used keyphrase%2$s: You've not used this keyphrase before, very good." ),
 				this.urlTitle,
 				"</a>"
 			),
@@ -82,11 +82,11 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 	if( count === 1 ) {
 		var url = "<a href='" + this.postUrl.replace( "{id}", id ) + "' target='_blank'>";
 		return {
-			/* Translators: %1$s and %2$s expand to an admin link where the focus keyword is already used. %3$s and %4$s
+			/* Translators: %1$s and %2$s expand to an admin link where the keyword is already used. %3$s and %4$s
 			expand to links on yoast.com, %4$s expands to the anchor end tag. */
 			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%3$sPreviously used keyphrase%5$s: " +
-				"You've used this focus keyphrase %1$sonce before%2$s. " +
-				"%4$sDo not use your focus keyphrase more than once%5$s." ),
+				"You've used this keyphrase %1$sonce before%2$s. " +
+				"%4$sDo not use your keyphrase more than once%5$s." ),
 			url,
 			"</a>",
 			this.urlTitle,
@@ -99,12 +99,12 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 	if ( count > 1 ) {
 		url = "<a href='" + this.searchUrl.replace( "{keyword}", encodeURIComponent( paper.getKeyword() ) ) + "' target='_blank'>";
 		return {
-			/* Translators: %1$s and $3$s expand to the admin search page for the focus keyword, %2$d expands to the number
-			of times this focus keyword has been used before, %4$s and %5$s expand to links to yoast.com, %6$s expands to
+			/* Translators: %1$s and $3$s expand to the admin search page for the keyword, %2$d expands to the number
+			of times this keyword has been used before, %4$s and %5$s expand to links to yoast.com, %6$s expands to
 			the anchor end tag */
 			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%4$sPreviously used keyphrase%6$s: " +
-				"You've used this focus keyphrase %1$s%2$d times before%3$s. " +
-				"%5$sDo not use your focus keyphrase more than once%6$s." ),
+				"You've used this keyphrase %1$s%2$d times before%3$s. " +
+				"%5$sDo not use your keyphrase more than once%6$s." ),
 			url,
 			count,
 			"</a>",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Replace 'focus keyword' by 'keyword' in assessment names and feedback because we don't know whether we're dealing with a focus keyword or a related keyword.

## Test instructions

This PR can be tested by following these steps:

* Make sure the unittests succeed in Travis

Fixes #
