### PR TITLE
Relax keyphrase distribution assessment

### DIFF
--- a/spec/assessments/KeyphraseDistributionAssessmentSpec.js
+++ b/spec/assessments/KeyphraseDistributionAssessmentSpec.js
@@ -111,7 +111,7 @@ describe( "Checks if the assessment is applicable", function() {
 	} );
 
 
-	it( "is not applicable to papers with less than 10 sentences", function() {
+	it( "is not applicable to papers with less than 15 sentences", function() {
 		let mockPaper = new Paper( "Lorem ipsum dolor sit amet.", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.isApplicable( mockPaper );
 

--- a/spec/assessments/KeyphraseDistributionAssessmentSpec.js
+++ b/spec/assessments/KeyphraseDistributionAssessmentSpec.js
@@ -23,7 +23,7 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			"<a href='https://yoa.st/33u' target='_blank'>Include your keyphrase or its synonyms in the text so that we can check keyphrase distribution</a>." );
 	} );
 
-	it( "returns a bad score when the % of sentences between topic occurrences is above 40%", function() {
+	it( "returns a bad score when the % of sentences between topic occurrences is above 50%", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.getResult(
 			mockPaper,

--- a/spec/assessments/KeyphraseDistributionAssessmentSpec.js
+++ b/spec/assessments/KeyphraseDistributionAssessmentSpec.js
@@ -7,12 +7,12 @@ import Mark from "../../src/values/Mark.js";
 let keyphraseDistributionAssessment = new KeyphraseDistributionAssessment();
 
 describe( "An assessment to check your keyphrase distribution", function() {
-	it( "returns a 'consideration' score when the Gini coefficient calculated from the step function is -1 (as a result of no keyword occurrences)", function() {
+	it( "returns a 'consideration' score when no keyword occurs", function() {
 		let mockPaper = new Paper( "a string", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.getResult(
 			mockPaper,
 			Factory.buildMockResearcher( {
-				keyphraseDistributionScore: -1,
+				keyphraseDistributionScore: 100,
 				sentencesToHighlight: [],
 			} ),
 			i18n
@@ -23,12 +23,12 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			"<a href='https://yoa.st/33u' target='_blank'>Include your keyphrase or its synonyms in the text so that we can check keyphrase distribution</a>." );
 	} );
 
-	it( "returns a bad score when the Gini coefficient calculated from the step function is higher than the recommended good score", function() {
+	it( "returns a bad score when the % of sentences between topic occurrences is above 40%", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.getResult(
 			mockPaper,
 			Factory.buildMockResearcher( {
-				keyphraseDistributionScore: 0.7,
+				keyphraseDistributionScore: 60,
 				sentencesToHighlight: [],
 			} ),
 			i18n
@@ -39,12 +39,12 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			"Large parts of your text do not contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>." );
 	} );
 
-	it( "returns an okay score when the Gini coefficient calculated from the step function is between recommended acceptable and good score", function() {
+	it( "returns an okay score when the % of sentences between topic occurrences is between recommended acceptable and good score", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.getResult(
 			mockPaper,
 			Factory.buildMockResearcher( {
-				keyphraseDistributionScore: 0.5,
+				keyphraseDistributionScore: 40,
 				sentencesToHighlight: [],
 			} ),
 			i18n
@@ -55,12 +55,12 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			"Some parts of your text do not contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>." );
 	} );
 
-	it( "returns a good score score when the Gini coefficient calculated from the step functionn is lower than the recommended good score", function() {
+	it( "returns a good score score when the %  of sentences between topic occurrences is lower than the recommended good score", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.getResult(
 			mockPaper,
 			Factory.buildMockResearcher( {
-				keyphraseDistributionScore: 0.3,
+				keyphraseDistributionScore: 25,
 				sentencesToHighlight: [],
 			} ),
 			i18n
@@ -72,7 +72,7 @@ describe( "An assessment to check your keyphrase distribution", function() {
 } );
 
 describe( "Checks if the assessment is applicable", function() {
-	it( "is applicable to papers with more than 200 words when a keyword is set", function() {
+	it( "is applicable to papers with more than 10 sentences when a keyword is set", function() {
 		let mockPaper = new Paper( "Lorem ipsum dolor sit amet, vim illum aeque" +
 			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
 			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
@@ -91,7 +91,7 @@ describe( "Checks if the assessment is applicable", function() {
 		expect( assessment ).toBe( true );
 	} );
 
-	it( "is not applicable to papers with more than 200 words when no keyword is set", function() {
+	it( "is not applicable to papers with more than 10 sentences when no keyword is set", function() {
 		let mockPaper = new Paper( "Lorem ipsum dolor sit amet, vim illum aeque" +
 			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
 			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
@@ -111,7 +111,7 @@ describe( "Checks if the assessment is applicable", function() {
 	} );
 
 
-	it( "is not applicable to papers with less than 200 words", function() {
+	it( "is not applicable to papers with less than 10 sentences", function() {
 		let mockPaper = new Paper( "Lorem ipsum dolor sit amet.", { keyword: "keyword" } );
 		let assessment = keyphraseDistributionAssessment.isApplicable( mockPaper );
 

--- a/spec/assessments/KeyphraseDistributionAssessmentSpec.js
+++ b/spec/assessments/KeyphraseDistributionAssessmentSpec.js
@@ -9,7 +9,14 @@ let keyphraseDistributionAssessment = new KeyphraseDistributionAssessment();
 describe( "An assessment to check your keyphrase distribution", function() {
 	it( "returns a 'consideration' score when the Gini coefficient calculated from the step function is -1 (as a result of no keyword occurrences)", function() {
 		let mockPaper = new Paper( "a string", { keyword: "keyword" } );
-		let assessment = keyphraseDistributionAssessment.getResult( mockPaper, Factory.buildMockResearcher( { keyphraseDistributionScore: -1 } ), i18n );
+		let assessment = keyphraseDistributionAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( {
+				keyphraseDistributionScore: -1,
+				sentencesToHighlight: [],
+			} ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: " +
@@ -18,7 +25,14 @@ describe( "An assessment to check your keyphrase distribution", function() {
 
 	it( "returns a bad score when the Gini coefficient calculated from the step function is higher than the recommended good score", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
-		let assessment = keyphraseDistributionAssessment.getResult( mockPaper, Factory.buildMockResearcher( { keyphraseDistributionScore: 0.7 } ), i18n );
+		let assessment = keyphraseDistributionAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( {
+				keyphraseDistributionScore: 0.7,
+				sentencesToHighlight: [],
+			} ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 1 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Very uneven. " +
@@ -27,7 +41,14 @@ describe( "An assessment to check your keyphrase distribution", function() {
 
 	it( "returns an okay score when the Gini coefficient calculated from the step function is between recommended acceptable and good score", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
-		let assessment = keyphraseDistributionAssessment.getResult( mockPaper, Factory.buildMockResearcher( { keyphraseDistributionScore: 0.5 } ), i18n );
+		let assessment = keyphraseDistributionAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( {
+				keyphraseDistributionScore: 0.5,
+				sentencesToHighlight: [],
+			} ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Uneven. " +
@@ -36,7 +57,14 @@ describe( "An assessment to check your keyphrase distribution", function() {
 
 	it( "returns a good score score when the Gini coefficient calculated from the step functionn is lower than the recommended good score", function() {
 		let mockPaper = new Paper( "string with the keyword and the keyword", { keyword: "keyword" } );
-		let assessment = keyphraseDistributionAssessment.getResult( mockPaper, Factory.buildMockResearcher( { keyphraseDistributionScore: 0.3 } ), i18n );
+		let assessment = keyphraseDistributionAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( {
+				keyphraseDistributionScore: 0.3,
+				sentencesToHighlight: [],
+			} ),
+			i18n
+		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Good job!" );
@@ -94,8 +122,24 @@ describe( "Checks if the assessment is applicable", function() {
 describe( "A test for marking keywords in the text", function() {
 	it( "returns markers for sentences specified by the researcher", function() {
 		let mockPaper = new Paper( "A sentence. A sentence containing keywords. Another sentence.", { keyword: "keyword" } );
-		keyphraseDistributionAssessment.getResult( mockPaper, Factory.buildMockResearcher(
-			{ keyphraseDistributionScore: 5, sentencesToHighlight: [ "A sentence.", "Another sentence." ] } ), i18n );
+		keyphraseDistributionAssessment.getResult(
+			mockPaper,
+			Factory.buildMockResearcher(
+				{
+					keyphraseDistributionScore: 5,
+					sentencesToHighlight: [
+						new Mark( {
+							original: "A sentence.",
+							marked: "<yoastmark class='yoast-text-mark'>A sentence.</yoastmark>",
+						} ),
+						new Mark( {
+							original: "Another sentence.",
+							marked: "<yoastmark class='yoast-text-mark'>Another sentence.</yoastmark>",
+						} ),
+					],
+				} ),
+			i18n
+		);
 		let expected = [
 			new Mark( {
 				original: "A sentence.",

--- a/spec/fullTextTests/runFullTextTests.js
+++ b/spec/fullTextTests/runFullTextTests.js
@@ -200,7 +200,7 @@ testPapers.forEach( function( testPaper ) {
 		it( "returns a score and the associated feedback text for the titleKeyword assessment", function() {
 			result.titleKeyword = new TitleKeywordAssessment().getResult(
 				paper,
-				factory.buildMockResearcher( findKeywordInPageTitle( paper ) ),
+				factory.buildMockResearcher( findKeywordInPageTitle( paper, researcher ) ),
 				i18n
 			);
 			expect( result.titleKeyword.getScore() ).toBe( expectedResults.titleKeyword.score );

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -117,8 +117,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!",
 	},
 	keyphraseDistribution: {
-		score: 6,
-		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Uneven. Some parts of your text do not contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Good job!",
 	},
 	fleschReadingEase: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -106,8 +106,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!",
 	},
 	keyphraseDistribution: {
-		score: 9,
-		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Good job!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Uneven. Some parts of your text do not contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>.",
 	},
 	fleschReadingEase: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -106,9 +106,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!",
 	},
 	keyphraseDistribution: {
-		score: 6,
-		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Uneven. " +
-		"Some parts of your text do not contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Good job!",
 	},
 	fleschReadingEase: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -26,12 +26,12 @@ const paper = new Paper( "<div class=\"content content__first\">\n" +
 	"</ul>\n" +
 	"</div>", {
 	keyword: "social media strategy",
+	synonyms: "social media SEO, Facebook strategy",
 	description: "Social media should be a part of your SEO strategy. In this post, Marieke explains the first steps towards developing your own social media strategy.",
 	title: "Social Media Strategy: Where to begin?",
 	titleWidth: 450,
 	locale: "en_EN",
 	url: "https://yoast.com/social-media-strategy-where-to-begin/",
-	synonyms: "social media SEO strategy, Facebook strategy",
 } );
 
 const expectedResults = {
@@ -100,10 +100,9 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains stop words. <a href='https://yoa.st/34q' target='_blank'>Remove them</a>!",
 	},
 	keyphraseDistribution: {
-		score: 9,
-		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Good job!",
+		score: 1,
+		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Very uneven. Large parts of your text do not contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>.",
 	},
-
 	fleschReadingEase: {
 		score: 9,
 		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 63.8 in the test, which is considered ok to read. Good job!",

--- a/spec/researches/keyphraseDistributionSpec.js
+++ b/spec/researches/keyphraseDistributionSpec.js
@@ -4,6 +4,7 @@ import { maximizeSentenceScores } from "../../src/researches/keyphraseDistributi
 import { step } from "../../src/researches/keyphraseDistribution.js";
 import { keyphraseDistributionResearcher } from "../../src/researches/keyphraseDistribution.js";
 import Paper from "../../src/values/Paper.js";
+import Mark from "../../src/values/Mark";
 import Researcher from "../../src/researcher";
 import morphologyData from "../../premium-configuration/data/morphologyData.json";
 
@@ -84,19 +85,19 @@ const topicLongIT = [
 
 describe( "Test for computing the sentence score", function() {
 	it( "for a short topic", function() {
-		expect( computeScoresPerSentenceShortTopic( topicShort, sentences, "en_EN" ) ).toEqual( [ 0, 6, 9, 6, 0, 6, 0, 6 ] );
+		expect( computeScoresPerSentenceShortTopic( topicShort, sentences, "en_EN" ) ).toEqual( [ 3, 6, 9, 6, 3, 6, 3, 6 ] );
 	} );
 
 	it( "for a long topic", function() {
-		expect( computeScoresPerSentenceLongTopic( topicLong, sentences, "en_EN" ) ).toEqual( [ 6, 6, 9, 6, 6, 6, 0, 6 ] );
+		expect( computeScoresPerSentenceLongTopic( topicLong, sentences, "en_EN" ) ).toEqual( [ 6, 6, 9, 6, 6, 6, 3, 6 ] );
 	} );
 
 	it( "for a short topic for a language that doesn't support morphology", function() {
-		expect( computeScoresPerSentenceShortTopic( topicShortIT, sentencesIT, "it_IT" ) ).toEqual( [ 0, 6, 9, 6, 0, 6, 0, 6 ] );
+		expect( computeScoresPerSentenceShortTopic( topicShortIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 6, 9, 6, 3, 6, 3, 6 ] );
 	} );
 
 	it( "for a long topic for a language that doesn't support morphology", function() {
-		expect( computeScoresPerSentenceLongTopic( topicLongIT, sentencesIT, "it_IT" ) ).toEqual( [ 6, 6, 9, 6, 6, 6, 0, 6 ] );
+		expect( computeScoresPerSentenceLongTopic( topicLongIT, sentencesIT, "it_IT" ) ).toEqual( [ 6, 6, 9, 6, 6, 6, 3, 6 ] );
 	} );
 } );
 
@@ -111,7 +112,7 @@ describe( "Test for computing the step function", function() {
 } );
 
 describe( "Test for a step-function research", function() {
-	it( "returns an average score over all sentences and all topic forms; returns markers for sentences that don't contain the topic at all", function() {
+	it( "returns an average score over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
 		const paper = new Paper(
 			sentences.join( " " ),
 			{
@@ -125,8 +126,37 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Again nothing!" ],
+			keyphraseDistributionScore: 0.08865248226950355,
+			sentencesToHighlight: [
+				new Mark( {
+					marked: "How <yoastmark class='yoast-text-mark'>remarkable</yoastmark>!",
+					original: "How remarkable!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Remarkable</yoastmark> is a funny <yoastmark class='yoast-text-mark'>word</yoastmark>.",
+					original: "Remarkable is a funny word.",
+				} ),
+				new Mark( {
+					marked: "I have found a <yoastmark class='yoast-text-mark'>key</yoastmark> and a <yoastmark class='yoast-text-mark'>remarkable word</yoastmark>.",
+					original: "I have found a key and a remarkable word.",
+				} ),
+				new Mark( {
+					marked: "And again a <yoastmark class='yoast-text-mark'>key something</yoastmark>.",
+					original: "And again a key something.",
+				} ),
+				new Mark( {
+					marked: "Here comes <yoastmark class='yoast-text-mark'>something</yoastmark> that has nothing to do with a keyword.",
+					original: "Here comes something that has nothing to do with a keyword.",
+				} ),
+				new Mark( {
+					marked: "Ha, a <yoastmark class='yoast-text-mark'>key</yoastmark>!",
+					original: "Ha, a key!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, how boring!",
+					original: "Words, words, words, how boring!",
+				} ),
+			],
 		} );
 	} );
 
@@ -149,12 +179,41 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Again nothing!" ],
+			keyphraseDistributionScore: 0.08865248226950355,
+			sentencesToHighlight: [
+				new Mark( {
+					marked: "How <yoastmark class='yoast-text-mark'>remarkable</yoastmark>!",
+					original: "How remarkable!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Remarkable</yoastmark> is a funny <yoastmark class='yoast-text-mark'>word</yoastmark>.",
+					original: "Remarkable is a funny word.",
+				} ),
+				new Mark( {
+					marked: "I have found a <yoastmark class='yoast-text-mark'>key</yoastmark> and a <yoastmark class='yoast-text-mark'>remarkable word</yoastmark>.",
+					original: "I have found a key and a remarkable word.",
+				} ),
+				new Mark( {
+					marked: "And again a <yoastmark class='yoast-text-mark'>key something</yoastmark>.",
+					original: "And again a key something.",
+				} ),
+				new Mark( {
+					marked: "Here comes <yoastmark class='yoast-text-mark'>something</yoastmark> that has nothing to do with a keyword.",
+					original: "Here comes something that has nothing to do with a keyword.",
+				} ),
+				new Mark( {
+					marked: "Ha, a <yoastmark class='yoast-text-mark'>key</yoastmark>!",
+					original: "Ha, a key!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, how boring!",
+					original: "Words, words, words, how boring!",
+				} ),
+			],
 		} );
 	} );
 
-	it( "returns an average score (for a language without morphology support) over all sentences and all topic forms; returns markers for sentences that don't contain the topic at all", function() {
+	it( "returns an average score (for a language without morphology support) over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
 		const paper = new Paper(
 			sentencesIT.join( " " ),
 			{
@@ -168,8 +227,37 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			keyphraseDistributionScore: 0.08865248226950355,
+			sentencesToHighlight: [
+				new Mark( {
+					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
+					original: "Che cosa straordinaria!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Straordinaria</yoastmark> è una <yoastmark class='yoast-text-mark'>parola</yoastmark> strana.",
+					original: "Straordinaria è una parola strana.",
+				} ),
+				new Mark( {
+					marked: "Ho trovato una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e una <yoastmark class='yoast-text-mark'>parola straordinaria</yoastmark>.",
+					original: "Ho trovato una chiave e una parola straordinaria.",
+				} ),
+				new Mark( {
+					marked: "E ancora una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e <yoastmark class='yoast-text-mark'>qualcosa</yoastmark>.",
+					original: "E ancora una chiave e qualcosa.",
+				} ),
+				new Mark( {
+					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
+					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
+				} ),
+				new Mark( {
+					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
+					original: "Ah, una chiave!",
+				} ),
+				new Mark( {
+					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
+					original: "Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
+				} ),
+			],
 		} );
 	} );
 
@@ -187,8 +275,37 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			keyphraseDistributionScore: 0.08865248226950355,
+			sentencesToHighlight: [
+				new Mark( {
+					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
+					original: "Che cosa straordinaria!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Straordinaria</yoastmark> è una <yoastmark class='yoast-text-mark'>parola</yoastmark> strana.",
+					original: "Straordinaria è una parola strana.",
+				} ),
+				new Mark( {
+					marked: "Ho trovato una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e una <yoastmark class='yoast-text-mark'>parola straordinaria</yoastmark>.",
+					original: "Ho trovato una chiave e una parola straordinaria.",
+				} ),
+				new Mark( {
+					marked: "E ancora una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e <yoastmark class='yoast-text-mark'>qualcosa</yoastmark>.",
+					original: "E ancora una chiave e qualcosa.",
+				} ),
+				new Mark( {
+					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
+					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
+				} ),
+				new Mark( {
+					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
+					original: "Ah, una chiave!",
+				} ),
+				new Mark( {
+					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
+					original: "Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
+				} ),
+			],
 		} );
 	} );
 
@@ -212,8 +329,37 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.12222222222222222,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			keyphraseDistributionScore: 0.08865248226950355,
+			sentencesToHighlight: [
+				new Mark( {
+					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
+					original: "Che cosa straordinaria!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Straordinaria</yoastmark> è una <yoastmark class='yoast-text-mark'>parola</yoastmark> strana.",
+					original: "Straordinaria è una parola strana.",
+				} ),
+				new Mark( {
+					marked: "Ho trovato una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e una <yoastmark class='yoast-text-mark'>parola straordinaria</yoastmark>.",
+					original: "Ho trovato una chiave e una parola straordinaria.",
+				} ),
+				new Mark( {
+					marked: "E ancora una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e <yoastmark class='yoast-text-mark'>qualcosa</yoastmark>.",
+					original: "E ancora una chiave e qualcosa.",
+				} ),
+				new Mark( {
+					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
+					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
+				} ),
+				new Mark( {
+					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
+					original: "Ah, una chiave!",
+				} ),
+				new Mark( {
+					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
+					original: "Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
+				} ),
+			],
 		} );
 	} );
 
@@ -233,8 +379,37 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.13157894736842105,
-			sentencesToHighlight: [ "Ancora niente!" ],
+			keyphraseDistributionScore: 0.09166666666666667,
+			sentencesToHighlight: [
+				new Mark( {
+					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
+					original: "Che cosa straordinaria!",
+				} ),
+				new Mark( {
+					marked: "<yoastmark class='yoast-text-mark'>Straordinaria</yoastmark> è una <yoastmark class='yoast-text-mark'>parola</yoastmark> strana.",
+					original: "Straordinaria è una parola strana.",
+				} ),
+				new Mark( {
+					marked: "Ho trovato una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e una <yoastmark class='yoast-text-mark'>parola straordinaria</yoastmark>.",
+					original: "Ho trovato una chiave e una parola straordinaria.",
+				} ),
+				new Mark( {
+					marked: "E ancora una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e <yoastmark class='yoast-text-mark'>qualcosa</yoastmark>.",
+					original: "E ancora una chiave e qualcosa.",
+				} ),
+				new Mark( {
+					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
+					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
+				} ),
+				new Mark( {
+					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
+					original: "Ah, una chiave!",
+				} ),
+				new Mark( {
+					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
+					original: "Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
+				} ),
+			],
 		} );
 	} );
 } );

--- a/spec/researches/keyphraseDistributionSpec.js
+++ b/spec/researches/keyphraseDistributionSpec.js
@@ -1,8 +1,8 @@
 import { computeScoresPerSentenceShortTopic } from "../../src/researches/keyphraseDistribution.js";
 import { computeScoresPerSentenceLongTopic } from "../../src/researches/keyphraseDistribution.js";
 import { maximizeSentenceScores } from "../../src/researches/keyphraseDistribution.js";
-import { step } from "../../src/researches/keyphraseDistribution.js";
 import { keyphraseDistributionResearcher } from "../../src/researches/keyphraseDistribution.js";
+import { getDistraction } from "../../src/researches/keyphraseDistribution";
 import Paper from "../../src/values/Paper.js";
 import Mark from "../../src/values/Mark";
 import Researcher from "../../src/researcher";
@@ -33,6 +33,45 @@ describe( "Test for maximizing sentence scores", function() {
 		const expectedOutput = [ 5, 10, 1 ];
 
 		expect( maximizeSentenceScores( inputArray ) ).toEqual( expectedOutput );
+	} );
+} );
+
+describe( "Test for finding the longest distraction trains", function() {
+	it( "returns the largest distraction train in the middle of the text", function() {
+		const sentenceScores = [ 3, 3, 6, 9, 3, 3, 9, 6, 6, 9, 6, 3, 3, 3, 3, 3, 3, 3, 3, 6, 9, 6, 3 ];
+
+		expect( getDistraction( sentenceScores ) ).toEqual( 8 );
+	} );
+
+	it( "returns the largest distraction train in the middle of the text", function() {
+		const sentenceScores = [ 6, 3, 3, 6, 9, 3, 3, 9, 6, 6, 9, 6, 3, 3, 3, 3, 3, 3, 3, 3, 6, 9, 6, 3, 9 ];
+
+		expect( getDistraction( sentenceScores ) ).toEqual( 8 );
+	} );
+
+	it( "returns the largest distraction train in the end of the text", function() {
+		const sentenceScores = [ 6, 3, 3, 6, 9, 3, 3, 9, 6, 6, 9, 6, 3, 3, 3, 3, 3, 3, 3, 3 ];
+
+		expect( getDistraction( sentenceScores ) ).toEqual( 8 );
+	} );
+
+
+	it( "returns the largest distraction train in the beginning of the text", function() {
+		const sentenceScores = [ 3, 3, 3, 3, 3, 3, 3, 3, 6, 3, 3, 6, 9, 3, 3, 9, 6, 6, 9, 6, 3, 3, 3, 3 ];
+
+		expect( getDistraction( sentenceScores ) ).toEqual( 8 );
+	} );
+
+	it( "returns the largest distraction train in the text without topic", function() {
+		const sentenceScores = [ 3, 3, 3 ];
+
+		expect( getDistraction( sentenceScores ) ).toEqual( 3 );
+	} );
+
+	it( "returns the largest distraction train in the text with topic only", function() {
+		const sentenceScores = [ 6, 9, 9, 6 ];
+
+		expect( getDistraction( sentenceScores ) ).toEqual( 0 );
 	} );
 } );
 
@@ -85,34 +124,25 @@ const topicLongIT = [
 
 describe( "Test for computing the sentence score", function() {
 	it( "for a short topic", function() {
-		expect( computeScoresPerSentenceShortTopic( topicShort, sentences, "en_EN" ) ).toEqual( [ 3, 6, 9, 6, 3, 6, 3, 6 ] );
+		expect( computeScoresPerSentenceShortTopic( topicShort, sentences, "en_EN" ) ).toEqual( [ 3, 3, 9, 3, 3, 3, 3, 3 ] );
 	} );
 
 	it( "for a long topic", function() {
-		expect( computeScoresPerSentenceLongTopic( topicLong, sentences, "en_EN" ) ).toEqual( [ 6, 6, 9, 6, 6, 6, 3, 6 ] );
+		expect( computeScoresPerSentenceLongTopic( topicLong, sentences, "en_EN" ) ).toEqual( [ 3, 9, 9, 9, 3, 3, 3, 3 ]  );
 	} );
 
 	it( "for a short topic for a language that doesn't support morphology", function() {
-		expect( computeScoresPerSentenceShortTopic( topicShortIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 6, 9, 6, 3, 6, 3, 6 ] );
+		expect( computeScoresPerSentenceShortTopic( topicShortIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 3, 9, 3, 3, 3, 3, 3 ] );
 	} );
 
 	it( "for a long topic for a language that doesn't support morphology", function() {
-		expect( computeScoresPerSentenceLongTopic( topicLongIT, sentencesIT, "it_IT" ) ).toEqual( [ 6, 6, 9, 6, 6, 6, 3, 6 ] );
+		expect( computeScoresPerSentenceLongTopic( topicLongIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 9, 9, 9, 3, 3, 3, 3 ] );
 	} );
 } );
 
-const inputSentenceScores = [ 1, 5, 7, 2, 4, 9, 1, 1, 1, 4, 1, 9 ];
-describe( "Test for computing the step function", function() {
-	it( "Returns the scores for the hypothetical text with a 3-sentence window", function() {
-		expect( step( inputSentenceScores, 3 ) ).toEqual( [ 13 / 3, 14 / 3, 13 / 3, 15 / 3, 14 / 3, 11 / 3, 3 / 3, 6 / 3, 6 / 3, 14 / 3 ] );
-	} );
-	it( "Returns the scores for the hypothetical text with a 5-sentence window", function() {
-		expect( step( inputSentenceScores, 5 ) ).toEqual( [  19 / 5, 27 / 5, 23 / 5, 17 / 5, 16 / 5, 16 / 5, 8 / 5, 16 / 5 ] );
-	} );
-} );
 
-describe( "Test for a step-function research", function() {
-	it( "returns an average score over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
+describe( "Test for the research", function() {
+	it( "returns a score over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
 		const paper = new Paper(
 			sentences.join( " " ),
 			{
@@ -126,7 +156,7 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.08865248226950355,
+			keyphraseDistributionScore: 25,
 			sentencesToHighlight: [
 				new Mark( {
 					marked: "How <yoastmark class='yoast-text-mark'>remarkable</yoastmark>!",
@@ -147,10 +177,6 @@ describe( "Test for a step-function research", function() {
 				new Mark( {
 					marked: "Here comes <yoastmark class='yoast-text-mark'>something</yoastmark> that has nothing to do with a keyword.",
 					original: "Here comes something that has nothing to do with a keyword.",
-				} ),
-				new Mark( {
-					marked: "Ha, a <yoastmark class='yoast-text-mark'>key</yoastmark>!",
-					original: "Ha, a key!",
 				} ),
 				new Mark( {
 					marked: "<yoastmark class='yoast-text-mark'>Words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, how boring!",
@@ -179,7 +205,7 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.08865248226950355,
+			keyphraseDistributionScore: 25,
 			sentencesToHighlight: [
 				new Mark( {
 					marked: "How <yoastmark class='yoast-text-mark'>remarkable</yoastmark>!",
@@ -202,10 +228,6 @@ describe( "Test for a step-function research", function() {
 					original: "Here comes something that has nothing to do with a keyword.",
 				} ),
 				new Mark( {
-					marked: "Ha, a <yoastmark class='yoast-text-mark'>key</yoastmark>!",
-					original: "Ha, a key!",
-				} ),
-				new Mark( {
 					marked: "<yoastmark class='yoast-text-mark'>Words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, <yoastmark class='yoast-text-mark'>words</yoastmark>, how boring!",
 					original: "Words, words, words, how boring!",
 				} ),
@@ -213,7 +235,7 @@ describe( "Test for a step-function research", function() {
 		} );
 	} );
 
-	it( "returns an average score (for a language without morphology support) over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
+	it( "returns a score (for a language without morphology support) over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
 		const paper = new Paper(
 			sentencesIT.join( " " ),
 			{
@@ -227,7 +249,7 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.08865248226950355,
+			keyphraseDistributionScore: 25,
 			sentencesToHighlight: [
 				new Mark( {
 					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
@@ -248,10 +270,6 @@ describe( "Test for a step-function research", function() {
 				new Mark( {
 					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
 					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
-				} ),
-				new Mark( {
-					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
-					original: "Ah, una chiave!",
 				} ),
 				new Mark( {
 					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
@@ -275,7 +293,7 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.08865248226950355,
+			keyphraseDistributionScore: 25,
 			sentencesToHighlight: [
 				new Mark( {
 					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
@@ -296,10 +314,6 @@ describe( "Test for a step-function research", function() {
 				new Mark( {
 					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
 					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
-				} ),
-				new Mark( {
-					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
-					original: "Ah, una chiave!",
 				} ),
 				new Mark( {
 					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
@@ -329,7 +343,7 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.08865248226950355,
+			keyphraseDistributionScore: 25,
 			sentencesToHighlight: [
 				new Mark( {
 					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
@@ -350,10 +364,6 @@ describe( "Test for a step-function research", function() {
 				new Mark( {
 					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
 					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
-				} ),
-				new Mark( {
-					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
-					original: "Ah, una chiave!",
 				} ),
 				new Mark( {
 					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
@@ -379,20 +389,8 @@ describe( "Test for a step-function research", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
-			keyphraseDistributionScore: 0.09166666666666667,
+			keyphraseDistributionScore: 37.5,
 			sentencesToHighlight: [
-				new Mark( {
-					marked: "Che cosa <yoastmark class='yoast-text-mark'>straordinaria</yoastmark>!",
-					original: "Che cosa straordinaria!",
-				} ),
-				new Mark( {
-					marked: "<yoastmark class='yoast-text-mark'>Straordinaria</yoastmark> è una <yoastmark class='yoast-text-mark'>parola</yoastmark> strana.",
-					original: "Straordinaria è una parola strana.",
-				} ),
-				new Mark( {
-					marked: "Ho trovato una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e una <yoastmark class='yoast-text-mark'>parola straordinaria</yoastmark>.",
-					original: "Ho trovato una chiave e una parola straordinaria.",
-				} ),
 				new Mark( {
 					marked: "E ancora una <yoastmark class='yoast-text-mark'>chiave</yoastmark> e <yoastmark class='yoast-text-mark'>qualcosa</yoastmark>.",
 					original: "E ancora una chiave e qualcosa.",
@@ -401,15 +399,28 @@ describe( "Test for a step-function research", function() {
 					marked: "È <yoastmark class='yoast-text-mark'>qualcosa</yoastmark> che non ha niente da fare con questo che cerchiamo.",
 					original: "È qualcosa che non ha niente da fare con questo che cerchiamo.",
 				} ),
-				new Mark( {
-					marked: "Ah, una <yoastmark class='yoast-text-mark'>chiave</yoastmark>!",
-					original: "Ah, una chiave!",
-				} ),
-				new Mark( {
-					marked: "Una <yoastmark class='yoast-text-mark'>parola</yoastmark> e ancora un'altra e poi un'altra ancora, che schifo!",
-					original: "Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
-				} ),
 			],
+		} );
+	} );
+
+	it( "when no keyphrase or synonyms is used in the text at all", function() {
+		const paper = new Paper(
+			"This is a text without keyphrase1 or synonyms1",
+			{
+				// Fictitious locale that doesn't have function word support.
+				locale: "en_EN",
+				keyword: "keyphrase",
+				// The added function words are now analyzed as content words, so the score changes.
+				synonyms: "synonym",
+			}
+		);
+
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		expect( keyphraseDistributionResearcher( paper, researcher ) ).toEqual( {
+			keyphraseDistributionScore: 100,
+			sentencesToHighlight: [],
 		} );
 	} );
 } );

--- a/src/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/src/assessments/seo/KeyphraseDistributionAssessment.js
@@ -3,8 +3,6 @@ import { merge } from "lodash-es";
 import Assessment from "../../assessment";
 import AssessmentResult from "../../values/AssessmentResult";
 import countWords from "../../stringProcessing/countWords";
-import Mark from "../../values/Mark";
-import addMark from "../../markers/addMark";
 
 /**
  * Returns a score based on the largest percentage of text in
@@ -67,7 +65,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		assessmentResult.setHasMarks( calculatedResult.score > 0 && calculatedResult.score < 9 );
+		assessmentResult.setHasMarks( this._keyphraseDistribution.sentencesToHighlight.length > 0 );
 
 		return assessmentResult;
 	}
@@ -158,9 +156,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 	 * @returns {Array} All markers for the current text.
 	 */
 	getMarks() {
-		return this._keyphraseDistribution.sentencesToHighlight.map( function( sentence ) {
-			return new Mark( { original: sentence, marked: addMark( sentence ) } );
-		} );
+		return this._keyphraseDistribution.sentencesToHighlight;
 	}
 
 	/**

--- a/src/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/src/assessments/seo/KeyphraseDistributionAssessment.js
@@ -2,7 +2,7 @@ import { merge } from "lodash-es";
 
 import Assessment from "../../assessment";
 import AssessmentResult from "../../values/AssessmentResult";
-import countWords from "../../stringProcessing/countWords";
+import getSentences from "../../stringProcessing/getSentences";
 
 /**
  * Returns a score based on the largest percentage of text in
@@ -30,8 +30,8 @@ class KeyphraseDistributionAssessment extends Assessment {
 
 		const defaultConfig = {
 			parameters: {
-				goodDistributionScore: 0.4,
-				acceptableDistributionScore: 0.6,
+				goodDistributionScore: 30,
+				acceptableDistributionScore: 50,
 			},
 			scores: {
 				good: 9,
@@ -80,7 +80,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 	calculateResult( i18n ) {
 		const distributionScore = this._keyphraseDistribution.keyphraseDistributionScore;
 
-		if ( distributionScore < 0 ) {
+		if ( distributionScore === 100 ) {
 			return {
 				score: this._config.scores.consideration,
 				resultText: i18n.sprintf(
@@ -160,14 +160,14 @@ class KeyphraseDistributionAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks whether the paper has a text with at least 200 words and a keyword.
+	 * Checks whether the paper has a text with at least 10 words and a keyword.
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 *
-	 * @returns {boolean} True when there is a keyword and a text with 200 words or more.
+	 * @returns {boolean} True when there is a keyword and a text with 10 words or more.
 	 */
 	isApplicable( paper ) {
-		return paper.hasText() && paper.hasKeyword() && countWords( paper.getText() ) >= 200;
+		return paper.hasText() && paper.hasKeyword() && getSentences( paper.getText() ).length >= 10;
 	}
 }
 

--- a/src/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/src/assessments/seo/KeyphraseDistributionAssessment.js
@@ -167,7 +167,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 	 * @returns {boolean} True when there is a keyword and a text with 10 words or more.
 	 */
 	isApplicable( paper ) {
-		return paper.hasText() && paper.hasKeyword() && getSentences( paper.getText() ).length >= 10;
+		return paper.hasText() && paper.hasKeyword() && getSentences( paper.getText() ).length >= 15;
 	}
 }
 

--- a/src/researches/keyphraseDistribution.js
+++ b/src/researches/keyphraseDistribution.js
@@ -145,8 +145,7 @@ const step = function( maximizedSentenceScores, stepSize ) {
 };
 
 /**
- * Computes the punishment for not using all content words within the window. Windows are determined in the same way as
- * in the step function
+ * Computes the punishment for having overall low scores in per-sentence matching of keyphrase and synonyms.
  *
  * @param {Array} sentenceScores The array of sentenceScores to calculate penalty based on.
  *

--- a/src/researches/keyphraseDistribution.js
+++ b/src/researches/keyphraseDistribution.js
@@ -1,12 +1,13 @@
 import getSentences from "../stringProcessing/getSentences";
 import { findWordFormsInString } from "./findKeywordFormsInString";
-import { findTopicFormsInString } from "./findKeywordFormsInString";
-import { max } from "lodash-es";
+import { max, uniq as unique } from "lodash-es";
 import { round } from "lodash-es";
 import { sum } from "lodash-es";
 import { isUndefined } from "lodash-es";
 import { zipWith } from "lodash-es";
+import { flattenDeep } from "lodash-es";
 import gini from "../helpers/gini";
+import { markWordsInSentences } from "../stringProcessing/markWordsInSentences";
 
 /**
  * Gets neighbourhood for a sentence. For a sentence checks if there are sentences before and after it and returns a
@@ -60,7 +61,7 @@ const computeScoresPerSentenceLongTopic = function( topic, sentences, locale ) {
 		} else if ( foundInCurrentSentence.percentWordMatches > 0 ) {
 			sentenceScores[ i ] = 6;
 		} else {
-			sentenceScores[ i ] = 0;
+			sentenceScores[ i ] = 3;
 		}
 	}
 
@@ -92,7 +93,7 @@ const computeScoresPerSentenceShortTopic = function( topic, sentences, locale ) 
 		} else if ( foundInCurrentSentence.percentWordMatches > 0 ) {
 			sentenceScores[ i ] = 6;
 		} else {
-			sentenceScores[ i ] = 0;
+			sentenceScores[ i ] = 3;
 		}
 	}
 
@@ -147,25 +148,22 @@ const step = function( maximizedSentenceScores, stepSize ) {
  * Computes the punishment for not using all content words within the window. Windows are determined in the same way as
  * in the step function
  *
- * @param {Array} sentences The sentences to analyze.
- * @param {Object} topicForms The topicForms of the paper.
- * @param {string} locale The locale of the paper.
- * @param {number} stepSize The number of sentences that should be in every step to average over.
+ * @param {Array} sentenceScores The array of sentenceScores to calculate penalty based on.
  *
- * @returns {Array} The scores per portion of text.
+ * @returns {number} The additional penalty for not using all keyphrase terms.
  */
-const getPortionPunishment = function( sentences, topicForms, locale, stepSize ) {
-	const numberOfSteps = sentences.length - stepSize + 1;
+const getPunishment = function( sentenceScores ) {
+	const averageScore = sum( sentenceScores ) / sentenceScores.length;
 
-	let result = [];
-
-	for ( let i = 0; i < numberOfSteps; i++ ) {
-		const windowText = sentences.slice( i, stepSize + i ).join( " " );
-		const topicInWindow = findTopicFormsInString( topicForms, windowText, true, locale );
-
-		result.push( topicInWindow.percentWordMatches <= 50 ? 0.5 : 0 );
+	if ( averageScore > 5 ) {
+		return 0;
 	}
-	return result;
+
+	if ( averageScore > 4 ) {
+		return 0.2;
+	}
+
+	return 0.4;
 };
 
 
@@ -173,7 +171,7 @@ const getPortionPunishment = function( sentences, topicForms, locale, stepSize )
  * Computes the per-sentence scores depending on the length of the topic phrase and maximizes them over all topic phrases.
  *
  * @param {Array}  sentences              The sentences to get scores for.
- * @param {Array}  topicFormsInOneArray   The topic phrases forms to seach for in the sentences.
+ * @param {Array}  topicFormsInOneArray   The topic phrases forms to search for in the sentences.
  * @param {string} locale                 The locale to work in.
  *
  * @returns {Object} An array with maximized score per sentence and an array with all sentences that do not contain the topic.
@@ -201,12 +199,12 @@ const getSentenceScores = function( sentences, topicFormsInOneArray, locale ) {
 		return { sentence, score };
 	} );
 
-	// Filter sentences that contain no topic words.
-	const sentencesWithoutTopic = sentencesWithMaximizedScores.filter( sentenceObject => sentenceObject.score < 4 );
+	// Filter sentences that contain topic words for future highlights.
+	const sentencesWithTopic = sentencesWithMaximizedScores.filter( sentenceObject => sentenceObject.score > 3 );
 
 	return {
 		maximizedSentenceScores: maximizedSentenceScores,
-		sentencesWithoutTopic: sentencesWithoutTopic.map( sentenceObject => sentenceObject.sentence ),
+		sentencesWithTopic: sentencesWithTopic.map( sentenceObject => sentenceObject.sentence ),
 	};
 };
 
@@ -229,25 +227,25 @@ const keyphraseDistributionResearcher = function( paper, researcher ) {
 		topicFormsInOneArray.push( synonym );
 	} );
 
+	const allTopicWords = unique( flattenDeep( topicFormsInOneArray ) ).sort( ( a, b ) => b.length - a.length );
+
 	// Get per-sentence scores and sentences that do not have topic.
 	const sentenceScores = getSentenceScores( sentences, topicFormsInOneArray, locale );
+	const maximizedSentenceScores = sentenceScores.maximizedSentenceScores;
 
 	// Apply step function: to begin with take a third of the text or at least 3 sentences.
 	const stepSize = max( [ round( sentences.length / 10 ), 3 ] );
-	let textPortionScores = step( sentenceScores.maximizedSentenceScores, stepSize );
+	const textPortionScores = step( maximizedSentenceScores, stepSize );
 
-	// Check if any windows do not have all topic words matched, assign a punishment if so.
-	const punishment = getPortionPunishment( sentences, topicForms, locale, stepSize );
+	// Check the average score of the sentences and calculate eventual punishment for not using all keyphrase terms.
+	const punishment = getPunishment( maximizedSentenceScores );
 
 	return {
 		// Return Gini coefficient of per-portion scores, increase it by eventual punishment for not using all topic words equally.
-		keyphraseDistributionScore: gini( textPortionScores ) + sum( punishment ) / punishment.length,
+		keyphraseDistributionScore: gini( textPortionScores ) + punishment,
 
-		/*
-	     * Sentences that have a maximized score of 3 are used for marking because these do not contain any topic forms.
-	     * Hence these sentences require action most urgently.
-	     */
-		sentencesToHighlight: sentenceScores.sentencesWithoutTopic,
+		// Sentences that have a maximized score of above 3 are used for marking because these contain topic forms.
+		sentencesToHighlight: markWordsInSentences( allTopicWords, sentenceScores.sentencesWithTopic, locale ),
 	};
 };
 

--- a/src/researches/keyphraseDistribution.js
+++ b/src/researches/keyphraseDistribution.js
@@ -1,47 +1,21 @@
 import getSentences from "../stringProcessing/getSentences";
 import { findWordFormsInString } from "./findKeywordFormsInString";
 import { max, uniq as unique } from "lodash-es";
-import { round } from "lodash-es";
-import { sum } from "lodash-es";
-import { isUndefined } from "lodash-es";
 import { zipWith } from "lodash-es";
 import { flattenDeep } from "lodash-es";
-import gini from "../helpers/gini";
+import { indexOf } from "lodash-es";
 import { markWordsInSentences } from "../stringProcessing/markWordsInSentences";
+import getLanguage from "../helpers/getLanguage";
 
 /**
- * Gets neighbourhood for a sentence. For a sentence checks if there are sentences before and after it and returns a
- * string with the concatenated neighbourhood (previous sentence - current sentence - next sentence).
- *
- * @param {Array}  sentences An array of all sentences in the text.
- * @param {number} index     The index of the sentence to get neighbourhood for.
- *
- * @returns {string} The neighbourhood sentences.
- */
-const getNeighbourhood = function( sentences, index ) {
-	let neighbourhood = sentences[ index ];
-
-	if ( ! isUndefined( sentences[ index - 1 ] ) ) {
-		neighbourhood = sentences[ index - 1 ].concat( " ", neighbourhood );
-	}
-	if ( ! isUndefined( sentences[ index + 1 ] ) ) {
-		neighbourhood = neighbourhood.concat( " ", sentences[ index + 1 ] );
-	}
-
-	return neighbourhood;
-};
-
-/**
- * Checks whether at least 3 content words from the topic are found within one sentence and the rest within +-1 sentence
- * away from it. Assigns a score to every sentence following the following schema:
- * 9 if all content words from the topic are in the sentence, or at least 3 content words from the topic
- * are in the sentence and the rest are in the neighbour sentences,
- * 6 if only some content words from the topic are found in the sentence but not all,
- * 3 if no content words from the topic were found in the sentence.
+ * Checks whether at least half of the content words from the topic are found within the sentence.
+ * Assigns a score to every sentence following the following schema:
+ * 9 if at least half of the content words from the topic are in the sentence,
+ * 3 otherwise.
  *
  * @param {Array}  topic     The word forms of all content words in a keyphrase or a synonym.
  * @param {Array}  sentences An array of all sentences in the text.
- * @param {string}  locale    The locale of the paper to analyse.
+ * @param {string} locale    The locale of the paper to analyse.
  *
  * @returns {Array} The scores per sentence.
  */
@@ -49,17 +23,10 @@ const computeScoresPerSentenceLongTopic = function( topic, sentences, locale ) {
 	let sentenceScores = Array( sentences.length );
 
 	for ( let i = 0; i < sentences.length; i++ ) {
-		// First search in the current sentence
 		const foundInCurrentSentence = findWordFormsInString( topic, sentences[ i ], locale );
 
-		// Then search in the current sentence and on previous and one next sentences.
-		const neighbourhood = getNeighbourhood( sentences, i );
-		const foundInNeighbourhood = findWordFormsInString( topic, neighbourhood, locale );
-
-		if ( foundInCurrentSentence.countWordMatches >= 3 && foundInNeighbourhood.percentWordMatches === 100 ) {
+		if ( foundInCurrentSentence.percentWordMatches >= 50 ) {
 			sentenceScores[ i ] = 9;
-		} else if ( foundInCurrentSentence.percentWordMatches > 0 ) {
-			sentenceScores[ i ] = 6;
 		} else {
 			sentenceScores[ i ] = 3;
 		}
@@ -68,35 +35,30 @@ const computeScoresPerSentenceLongTopic = function( topic, sentences, locale ) {
 	return sentenceScores;
 };
 
+
 /**
  * Checks whether all content words from the topic are found within one sentence.
  * Assigns a score to every sentence following the following schema:
  * 9 if all content words from the topic are in the sentence,
- * 6 if only some content words from the topic are found in the sentence but not all,
- * 3 if no content words from the topic were found in the sentence.
+ * 3 if not all content words from the topic were found in the sentence.
  *
  * @param {Array}  topic     The word forms of all content words in a keyphrase or a synonym.
  * @param {Array}  sentences An array of all sentences in the text.
- * @param {string}  locale    The locale of the paper to analyse.
+ * @param {string} locale    The locale of the paper to analyse.
  *
  * @returns {Array} The scores per sentence.
  */
 const computeScoresPerSentenceShortTopic = function( topic, sentences, locale ) {
 	let sentenceScores = Array( sentences.length );
-
 	for ( let i = 0; i < sentences.length; i++ ) {
 		const currentSentence = sentences[ i ];
-
 		const foundInCurrentSentence = findWordFormsInString( topic, currentSentence, locale );
-		if  ( foundInCurrentSentence.percentWordMatches === 100 ) {
+		if ( foundInCurrentSentence.percentWordMatches === 100 ) {
 			sentenceScores[ i ] = 9;
-		} else if ( foundInCurrentSentence.percentWordMatches > 0 ) {
-			sentenceScores[ i ] = 6;
 		} else {
 			sentenceScores[ i ] = 3;
 		}
 	}
-
 	return sentenceScores;
 };
 
@@ -121,50 +83,43 @@ const maximizeSentenceScores = function( sentenceScores ) {
 
 
 /**
- * Computes the per-window scores based on a step function.
- * Start with the first third of the text (based on the total number of sentences) and calculate an average score
- * over all sentences in this set. Move down by one sentence, calculate an average score again.
- * Continue until the end of the text is reached.
+ * Computes the maximally long piece of text that does not include the topic.
  *
- * @param {Array} maximizedSentenceScores The maximal scores for every sentence.
- * @param {number} stepSize The number of sentences that should be in every step to average over.
+ * @param {Array} sentenceScores The array of scores per sentence.
  *
- * @returns {Array} The scores per portion of text.
+ * @returns {number} The maximum number of sentences that do not include the topic.
  */
-const step = function( maximizedSentenceScores, stepSize ) {
-	const numberOfSteps = maximizedSentenceScores.length - stepSize + 1;
+const getDistraction = function( sentenceScores ) {
+	const numberOfSentences = sentenceScores.length;
+	let allTopicSentencesIndices = [];
 
-	let result = [];
-	let toAnalyze = [];
-
-	for ( let i = 0; i < numberOfSteps; i++ ) {
-		toAnalyze = maximizedSentenceScores.slice( i, stepSize + i );
-		result.push( sum( toAnalyze ) / stepSize );
+	for ( let i = 0; i < numberOfSentences; i++ ) {
+		if ( sentenceScores[ i ] > 3 ) {
+			allTopicSentencesIndices.push( i );
+		}
 	}
-	return result;
+
+	const numberOfTopicSentences = allTopicSentencesIndices.length;
+
+	if ( numberOfTopicSentences === 0 ) {
+		return numberOfSentences;
+	}
+
+	/**
+	 * Add fake topic sentences at the very beginning and at the very end
+	 * to account for cases when the text starts or ends with a train of distraction.
+	 */
+	allTopicSentencesIndices.unshift( -1 );
+	allTopicSentencesIndices.push( numberOfSentences );
+
+	const distances = [];
+
+	for ( let i = 1; i < numberOfTopicSentences + 2; i++ ) {
+		distances.push( allTopicSentencesIndices[ i ] - allTopicSentencesIndices[ i - 1 ] - 1 );
+	}
+
+	return max( distances );
 };
-
-/**
- * Computes the punishment for having overall low scores in per-sentence matching of keyphrase and synonyms.
- *
- * @param {Array} sentenceScores The array of sentenceScores to calculate penalty based on.
- *
- * @returns {number} The additional penalty for not using all keyphrase terms.
- */
-const getPunishment = function( sentenceScores ) {
-	const averageScore = sum( sentenceScores ) / sentenceScores.length;
-
-	if ( averageScore > 5 ) {
-		return 0;
-	}
-
-	if ( averageScore > 4 ) {
-		return 0.2;
-	}
-
-	return 0.4;
-};
-
 
 /**
  * Computes the per-sentence scores depending on the length of the topic phrase and maximizes them over all topic phrases.
@@ -181,12 +136,24 @@ const getSentenceScores = function( sentences, topicFormsInOneArray, locale ) {
 
 	let sentenceScores = Array( topicNumber );
 
-	for ( let i = 0; i < topicNumber; i++ ) {
-		const topic = topicFormsInOneArray[ i ];
-		if ( topic.length < 4 ) {
+	// Determine whether the language has function words.
+	const language = getLanguage( locale );
+
+	// For languages with function words apply either full match or partial match depending on topic length
+	if ( indexOf( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl" ], language  ) >= 0 ) {
+		for ( let i = 0; i < topicNumber; i++ ) {
+			const topic = topicFormsInOneArray[ i ];
+			if ( topic.length < 4 ) {
+				sentenceScores[ i ] = computeScoresPerSentenceShortTopic( topic, sentences, locale );
+			} else {
+				sentenceScores[ i ] = computeScoresPerSentenceLongTopic( topic, sentences, locale );
+			}
+		}
+	} else {
+		// For languages without function words apply the full match always
+		for ( let i = 0; i < topicNumber; i++ ) {
+			const topic = topicFormsInOneArray[ i ];
 			sentenceScores[ i ] = computeScoresPerSentenceShortTopic( topic, sentences, locale );
-		} else {
-			sentenceScores[ i ] = computeScoresPerSentenceLongTopic( topic, sentences, locale );
 		}
 	}
 
@@ -228,23 +195,14 @@ const keyphraseDistributionResearcher = function( paper, researcher ) {
 
 	const allTopicWords = unique( flattenDeep( topicFormsInOneArray ) ).sort( ( a, b ) => b.length - a.length );
 
-	// Get per-sentence scores and sentences that do not have topic.
+	// Get per-sentence scores and sentences that have topic.
 	const sentenceScores = getSentenceScores( sentences, topicFormsInOneArray, locale );
 	const maximizedSentenceScores = sentenceScores.maximizedSentenceScores;
-
-	// Apply step function: to begin with take a third of the text or at least 3 sentences.
-	const stepSize = max( [ round( sentences.length / 10 ), 3 ] );
-	const textPortionScores = step( maximizedSentenceScores, stepSize );
-
-	// Check the average score of the sentences and calculate eventual punishment for not using all keyphrase terms.
-	const punishment = getPunishment( maximizedSentenceScores );
+	const maxLengthDistraction = getDistraction( maximizedSentenceScores );
 
 	return {
-		// Return Gini coefficient of per-portion scores, increase it by eventual punishment for not using all topic words equally.
-		keyphraseDistributionScore: gini( textPortionScores ) + punishment,
-
-		// Sentences that have a maximized score of above 3 are used for marking because these contain topic forms.
 		sentencesToHighlight: markWordsInSentences( allTopicWords, sentenceScores.sentencesWithTopic, locale ),
+		keyphraseDistributionScore: maxLengthDistraction / sentences.length * 100,
 	};
 };
 
@@ -252,6 +210,6 @@ export {
 	computeScoresPerSentenceShortTopic,
 	computeScoresPerSentenceLongTopic,
 	maximizeSentenceScores,
-	step,
 	keyphraseDistributionResearcher,
+	getDistraction,
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adjusts the scoring schema of the keyphrase distribution to return overall higher scores.

## Relevant technical choices:

* Deprecates previously introduced punishment for not using all keyphrase terms within a large window in the text
* Introduces a new punishment for having overall low scores per-sentence
* The PR also fixes the markings of the keyphrase.
* Partly duplicates PR #1865.

## Update:
* Deprecates previously introduced gini-coefficient-based estimation of the keyphrase distribution uniformity
* Instead, relies on the distance between topic usages (in sentences).
* For English and other languages with function words:
  * Short topic (<4 words): all content words should be matched for the sentence to reflect the topic.
  * Long topic ( >=4 words): more than half content words should be matched for the sentence to reflect the topic.
* For languages without function words:
  * All words should be matched for the sentence to reflect the topic.

## Test instructions

This PR can be tested by following these steps:

* Assessment is only in Premium.
* Take a few articles that rank well on Google and check if the assessment returns a Good score.
* Check that the markings work to highlight keyphrase and synonym words, not sentences without those.
* Change the keyphrase on these articles to some nonsense. The score should drop.

Fixes #1868 Fixes #1863