### PR TITLE
1870 increase upper keyword density bound for premium

### DIFF
--- a/spec/assessments/KeywordDensityAssessmentSpec.js
+++ b/spec/assessments/KeywordDensityAssessmentSpec.js
@@ -89,3 +89,18 @@ describe( "A test for marking the keyword", function() {
 		expect( keywordDensityAssessment.getMarks() ).toEqual( expected );
 	} );
 } );
+
+describe( "An assessment for keywordDensity when morphology data is available.", function() {
+
+	it("gives a GOOD result when keyword density is 3.0%", function() {
+		const paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
+		const result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {
+			getKeywordDensity: 3,
+			keywordCount: {
+				count: 2,
+			},
+		}, true, true ), i18n );
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 3%. This is great!" );
+	} );
+} );

--- a/spec/assessments/KeywordDensityAssessmentSpec.js
+++ b/spec/assessments/KeywordDensityAssessmentSpec.js
@@ -92,7 +92,7 @@ describe( "A test for marking the keyword", function() {
 
 describe( "An assessment for keywordDensity when morphology data is available.", function() {
 
-	it("gives a GOOD result when keyword density is 3.0%", function() {
+	it( "gives a GOOD result when keyword density is 3.0%", function() {
 		const paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		const result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {
 			getKeywordDensity: 3,

--- a/spec/assessments/KeywordDensityAssessmentSpec.js
+++ b/spec/assessments/KeywordDensityAssessmentSpec.js
@@ -91,7 +91,6 @@ describe( "A test for marking the keyword", function() {
 } );
 
 describe( "An assessment for keywordDensity when morphology data is available.", function() {
-
 	it( "gives a GOOD result when keyword density is 3.0%", function() {
 		const paper = new Paper( "string with the keyword  and keyword ", { keyword: "keyword" } );
 		const result = new KeywordDensityAssessment().getResult( paper, factory.buildMockResearcher( {

--- a/spec/specHelpers/factory.js
+++ b/spec/specHelpers/factory.js
@@ -20,7 +20,7 @@ FactoryProto.prototype.buildJed = function() {
  * @returns {object} Mock HTML element.
  */
 FactoryProto.prototype.buildMockElement = function() {
-	var mockElement;
+	let mockElement;
 
 	mockElement = [];
 	mockElement.nodeType = 1;
@@ -64,12 +64,12 @@ FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue
  * @returns {string} The result.
  */
 FactoryProto.prototype.buildMockString = function( string, repetitions ) {
-	var resultString = "";
+	let resultString = "";
 
 	string = string || "Test ";
 	repetitions = repetitions || 1;
 
-	for ( var i = 0; i < repetitions; i++ ) {
+	for ( let i = 0; i < repetitions; i++ ) {
 		resultString += string;
 	}
 

--- a/spec/specHelpers/factory.js
+++ b/spec/specHelpers/factory.js
@@ -37,7 +37,7 @@ FactoryProto.prototype.buildMockElement = function() {
  *
  * @returns {Researcher} Mock researcher.
  */
-FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue = false, hasMorphologyData = true ) {
+FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue = false, hasMorphologyData = false ) {
 	if( multiValue && typeof expectedValue === "object" ) {
 		return {
 			getResearch: function( research ) {
@@ -52,6 +52,9 @@ FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue
 		getResearch: function() {
 			return expectedValue;
 		},
+		getData: function() {
+			return hasMorphologyData;
+		}
 	};
 };
 

--- a/spec/specHelpers/factory.js
+++ b/spec/specHelpers/factory.js
@@ -45,7 +45,7 @@ FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue
 			},
 			getData: function() {
 				return hasMorphologyData;
-			}
+			},
 		};
 	}
 	return {
@@ -54,7 +54,7 @@ FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue
 		},
 		getData: function() {
 			return hasMorphologyData;
-		}
+		},
 	};
 };
 

--- a/spec/specHelpers/factory.js
+++ b/spec/specHelpers/factory.js
@@ -31,17 +31,21 @@ FactoryProto.prototype.buildMockElement = function() {
 /**
  * Returns a mock researcher
  *
- * @param {object}  expectedValue The expected value or values.
- * @param {boolean} multiValue    True if multiple values are expected.
+ * @param {object}  expectedValue 		The expected value or values.
+ * @param {boolean} multiValue    		True if multiple values are expected.
+ * @param {boolean} hasMorphologyData	True if the researcher has access to morphology data.
  *
  * @returns {Researcher} Mock researcher.
  */
-FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue = false ) {
+FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue = false, hasMorphologyData = true ) {
 	if( multiValue && typeof expectedValue === "object" ) {
 		return {
 			getResearch: function( research ) {
 				return expectedValue[ research ];
 			},
+			getData: function() {
+				return hasMorphologyData;
+			}
 		};
 	}
 	return {

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -34,7 +34,7 @@ class KeywordDensityAssessment extends Assessment {
 
 		const defaultConfig = {
 			parameters: {
-				default: {
+				noWordForms: {
 					overMaximum: 3.5,
 					maximum: 2.5,
 					minimum: 0.5,
@@ -43,7 +43,7 @@ class KeywordDensityAssessment extends Assessment {
 					overMaximum: 3.5,
 					maximum: 3.0,
 					minimum: 0.5,
-				}
+				},
 			},
 			scores: {
 				wayOverMaximum: -50,
@@ -111,7 +111,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    0 and the recommended minimum.
 	 */
 	hasTooFewMatches() {
-		if( this._hasMorphologyData && this._locale === "en_US" ) {
+		if ( this._hasMorphologyData && this._locale === "en_US" ) {
 			return inRangeStartInclusive(
 				this._keywordDensity,
 				0,
@@ -121,7 +121,7 @@ class KeywordDensityAssessment extends Assessment {
 		return inRangeStartInclusive(
 			this._keywordDensity,
 			0,
-			this._config.parameters.default.minimum
+			this._config.parameters.noWordForms.minimum
 		);
 	}
 
@@ -135,7 +135,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    the recommended minimum and the recommended maximum.
 	 */
 	hasGoodNumberOfMatches() {
-		if( this._hasMorphologyData && this._locale === "en_US" ) {
+		if ( this._hasMorphologyData && this._locale === "en_US" ) {
 			return inRangeStartEndInclusive(
 				this._keywordDensity,
 				this._config.parameters.multipleWordForms.minimum,
@@ -144,8 +144,8 @@ class KeywordDensityAssessment extends Assessment {
 		}
 		return inRangeStartEndInclusive(
 			this._keywordDensity,
-			this._config.parameters.default.minimum,
-			this._config.parameters.default.maximum
+			this._config.parameters.noWordForms.minimum,
+			this._config.parameters.noWordForms.maximum
 		);
 	}
 
@@ -161,7 +161,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    value.
 	 */
 	hasTooManyMatches() {
-		if( this.shouldUseMorphologyBoundaries() ) {
+		if ( this.shouldUseMorphologyBoundaries() ) {
 			return inRangeEndInclusive(
 				this._keywordDensity,
 				this._config.parameters.multipleWordForms.maximum,
@@ -170,13 +170,17 @@ class KeywordDensityAssessment extends Assessment {
 		}
 		return inRangeEndInclusive(
 			this._keywordDensity,
-			this._config.parameters.default.maximum,
-			this._config.parameters.default.overMaximum
+			this._config.parameters.noWordForms.maximum,
+			this._config.parameters.noWordForms.overMaximum
 		);
 	}
 
+	/**
+	 * If this assessments should use the morphology score boundaries.
+	 * @returns {boolean} if the assessment should use the morphology score boundaries.
+	 */
 	shouldUseMorphologyBoundaries() {
-		return this._hasMorphologyData && this._locale === "en_US"
+		return this._hasMorphologyData && this._locale === "en_US";
 	}
 
 	/**
@@ -187,9 +191,9 @@ class KeywordDensityAssessment extends Assessment {
 	 * @returns {Object} The object with calculated score and resultText.
 	 */
 	calculateResult( i18n ) {
-		const max = this.shouldUseMorphologyBoundaries() ?
-			this._config.parameters.multipleWordForms.maximum :
-			this._config.parameters.default.maximum;
+		const max = this.shouldUseMorphologyBoundaries()
+			? this._config.parameters.multipleWordForms.maximum
+			: this._config.parameters.noWordForms.maximum;
 		const maxText = `${ max }%`;
 		const roundedKeywordDensity = formatNumber( this._keywordDensity );
 		const keywordDensityPercentage = roundedKeywordDensity + "%";

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -161,7 +161,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    value.
 	 */
 	hasTooManyMatches() {
-		if( this._hasMorphologyData && this._locale === "en_US" ) {
+		if( this.shouldUseMorphologyBoundaries() ) {
 			return inRangeEndInclusive(
 				this._keywordDensity,
 				this._config.parameters.multipleWordForms.maximum,
@@ -175,6 +175,10 @@ class KeywordDensityAssessment extends Assessment {
 		);
 	}
 
+	shouldUseMorphologyBoundaries() {
+		return this._hasMorphologyData && this._locale === "en_US"
+	}
+
 	/**
 	 * Returns the score for the keyword density.
 	 *
@@ -183,7 +187,10 @@ class KeywordDensityAssessment extends Assessment {
 	 * @returns {Object} The object with calculated score and resultText.
 	 */
 	calculateResult( i18n ) {
-		const max = `${ this._config.parameters.default.maximum}%`;
+		const max = this.shouldUseMorphologyBoundaries() ?
+			this._config.parameters.multipleWordForms.maximum :
+			this._config.parameters.default.maximum;
+		const maxText = `${ max }%`;
 		const roundedKeywordDensity = formatNumber( this._keywordDensity );
 		const keywordDensityPercentage = roundedKeywordDensity + "%";
 
@@ -278,7 +285,7 @@ class KeywordDensityAssessment extends Assessment {
 					),
 					keywordDensityPercentage,
 					this._keywordCount.count,
-					max,
+					maxText,
 					this._config.urlTitle,
 					this._config.urlCallToAction,
 					"</a>"
@@ -308,7 +315,7 @@ class KeywordDensityAssessment extends Assessment {
 				),
 				keywordDensityPercentage,
 				this._keywordCount.count,
-				max,
+				maxText,
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -34,9 +34,16 @@ class KeywordDensityAssessment extends Assessment {
 
 		const defaultConfig = {
 			parameters: {
-				overMaximum: 3.5,
-				maximum: 2.5,
-				minimum: 0.5,
+				default: {
+					overMaximum: 3.5,
+					maximum: 2.5,
+					minimum: 0.5,
+				},
+				multipleWordForms: {
+					overMaximum: 3.5,
+					maximum: 3.0,
+					minimum: 0.5,
+				}
 			},
 			scores: {
 				wayOverMaximum: -50,
@@ -70,6 +77,12 @@ class KeywordDensityAssessment extends Assessment {
 
 		this._keywordDensity = researcher.getResearch( "getKeywordDensity" );
 
+		/*
+		 * Use other boundaries when taking morphology into account,
+		 * since multiple keyword forms can be matched.
+		 */
+		this._hasMorphologyData = researcher.getData( "morphology" ) !== false;
+
 		const calculatedScore = this.calculateResult( i18n );
 		assessmentResult.setScore( calculatedScore.score );
 		assessmentResult.setText( calculatedScore.resultText );
@@ -90,28 +103,48 @@ class KeywordDensityAssessment extends Assessment {
 	/**
 	 * Checks whether there are too few keyword matches in the text.
 	 *
+	 * Changes the boundaries based on if we have access to morphology data.
+	 * (Since multiple keyword forms can be matched the boundaries should be relaxed a bit)
+	 *
 	 * @returns {boolean} Returns true if the rounded keyword density is between
 	 *                    0 and the recommended minimum.
 	 */
 	hasTooFewMatches() {
+		if( this._hasMorphologyData ) {
+			return inRangeStartInclusive(
+				this._keywordDensity,
+				0,
+				this._config.parameters.multipleWordForms.minimum
+			);
+		}
 		return inRangeStartInclusive(
 			this._keywordDensity,
 			0,
-			this._config.parameters.minimum
+			this._config.parameters.default.minimum
 		);
 	}
 
 	/**
 	 * Checks whether there is a good number of keyword matches in the text.
 	 *
+	 * Changes the boundaries based on if we have access to morphology data.
+	 * (Since multiple keyword forms can be matched the boundaries should be relaxed a bit)
+	 *
 	 * @returns {boolean} Returns true if the rounded keyword density is between
 	 *                    the recommended minimum and the recommended maximum.
 	 */
 	hasGoodNumberOfMatches() {
+		if( this._hasMorphologyData ) {
+			return inRangeStartEndInclusive(
+				this._keywordDensity,
+				this._config.parameters.multipleWordForms.minimum,
+				this._config.parameters.multipleWordForms.maximum
+			);
+		}
 		return inRangeStartEndInclusive(
 			this._keywordDensity,
-			this._config.parameters.minimum,
-			this._config.parameters.maximum
+			this._config.parameters.default.minimum,
+			this._config.parameters.default.maximum
 		);
 	}
 
@@ -119,15 +152,25 @@ class KeywordDensityAssessment extends Assessment {
 	 * Checks whether the number of keyword matches in the text is between the
 	 * recommended maximum and the specified overMaximum value.
 	 *
+	 * Changes the boundaries based on if we have access to morphology data.
+	 * (Since multiple keyword forms can be matched the boundaries should be relaxed a bit)
+	 *
 	 * @returns {boolean} Returns true if the rounded keyword density is between
 	 *                    the recommended maximum and the specified overMaximum
 	 *                    value.
 	 */
 	hasTooManyMatches() {
+		if( this._hasMorphologyData ) {
+			return inRangeEndInclusive(
+				this._keywordDensity,
+				this._config.parameters.multipleWordForms.maximum,
+				this._config.parameters.multipleWordForms.overMaximum
+			);
+		}
 		return inRangeEndInclusive(
 			this._keywordDensity,
-			this._config.parameters.maximum,
-			this._config.parameters.overMaximum
+			this._config.parameters.default.maximum,
+			this._config.parameters.default.overMaximum
 		);
 	}
 
@@ -139,7 +182,7 @@ class KeywordDensityAssessment extends Assessment {
 	 * @returns {Object} The object with calculated score and resultText.
 	 */
 	calculateResult( i18n ) {
-		const max = `${ this._config.parameters.maximum}%`;
+		const max = `${ this._config.parameters.default.maximum}%`;
 		const roundedKeywordDensity = formatNumber( this._keywordDensity );
 		const keywordDensityPercentage = roundedKeywordDensity + "%";
 

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -111,7 +111,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    0 and the recommended minimum.
 	 */
 	hasTooFewMatches() {
-		if ( this._hasMorphologyData && this._locale === "en_US" ) {
+		if ( this.shouldUseMorphologyBoundaries() ) {
 			return inRangeStartInclusive(
 				this._keywordDensity,
 				0,
@@ -135,7 +135,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    the recommended minimum and the recommended maximum.
 	 */
 	hasGoodNumberOfMatches() {
-		if ( this._hasMorphologyData && this._locale === "en_US" ) {
+		if ( this.shouldUseMorphologyBoundaries() ) {
 			return inRangeStartEndInclusive(
 				this._keywordDensity,
 				this._config.parameters.multipleWordForms.minimum,
@@ -177,6 +177,7 @@ class KeywordDensityAssessment extends Assessment {
 
 	/**
 	 * If this assessments should use the morphology score boundaries.
+	 *
 	 * @returns {boolean} if the assessment should use the morphology score boundaries.
 	 */
 	shouldUseMorphologyBoundaries() {

--- a/src/assessments/seo/KeywordDensityAssessment.js
+++ b/src/assessments/seo/KeywordDensityAssessment.js
@@ -82,6 +82,7 @@ class KeywordDensityAssessment extends Assessment {
 		 * since multiple keyword forms can be matched.
 		 */
 		this._hasMorphologyData = researcher.getData( "morphology" ) !== false;
+		this._locale = paper.getLocale();
 
 		const calculatedScore = this.calculateResult( i18n );
 		assessmentResult.setScore( calculatedScore.score );
@@ -110,7 +111,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    0 and the recommended minimum.
 	 */
 	hasTooFewMatches() {
-		if( this._hasMorphologyData ) {
+		if( this._hasMorphologyData && this._locale === "en_US" ) {
 			return inRangeStartInclusive(
 				this._keywordDensity,
 				0,
@@ -134,7 +135,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    the recommended minimum and the recommended maximum.
 	 */
 	hasGoodNumberOfMatches() {
-		if( this._hasMorphologyData ) {
+		if( this._hasMorphologyData && this._locale === "en_US" ) {
 			return inRangeStartEndInclusive(
 				this._keywordDensity,
 				this._config.parameters.multipleWordForms.minimum,
@@ -160,7 +161,7 @@ class KeywordDensityAssessment extends Assessment {
 	 *                    value.
 	 */
 	hasTooManyMatches() {
-		if( this._hasMorphologyData ) {
+		if( this._hasMorphologyData && this._locale === "en_US" ) {
 			return inRangeEndInclusive(
 				this._keywordDensity,
 				this._config.parameters.multipleWordForms.maximum,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Increased the upper keyword density bound when multiple keyword forms are available.

## Relevant technical choices:

* Added a new `getData` mock function to the mock researcher (created via `factory.createMockResearcher()`). This should be mocked since `researcher.getData( "morphology" )` is used to check if morphology data is available.

## Test instructions

This PR can be tested by following these steps:

* Make sure that SEO free is enabled.
* Make a new post.
* Add a text that has a keyword density bigger than 2.5%, but smaller than 3%.
E.g. this text (keyword = Apple, density=2.6%):

_Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple._ 

_Mauris sit amet urna nisi. Vestibulum at vestibulum nulla. Praesent hendrerit ultricies aliquet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus tempor lacus non tellus faucibus pellentesque ut in velit. In hac habitasse platea dictumst. Curabitur nunc arcu, efficitur ut condimentum ut, lobortis a risus. Nulla facilisi. Quisque non elit mauris. Ut ullamcorper sed odio sit amet luctus. Pellentesque ut ante vitae sapien rhoncus rutrum. Aliquam a consectetur odio. Donec sit amet volutpat leo._

_Maecenas venenatis tellus sit amet risus rutrum pharetra. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse varius posuere urna, in suscipit nisl. Proin sed libero at sem rutrum ullamcorper. In rutrum, odio vitae tincidunt fringilla, dolor erat ultricies felis, ac finibus metus diam id libero. In venenatis odio a massa._

_Maecenas venenatis tellus sit amet risus rutrum pharetra. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse varius posuere urna, in suscipit nisl. Proin sed libero at sem rutrum ullamcorper. In rutrum, odio vitae tincidunt fringilla, dolor erat ultricies felis, ac finibus metus diam id libero. In venenatis odio a massa._

* Result should be: `Keyphrase density: 2.6%. This is over the advised 2.5% maximum; the focus keyword was found 5 times. Don't overoptimize!`

* Follow the steps as above, but now for Premium.
* Result should be: `Keyphrase density: 2.6%. This is great!`.

Fixes #1870 
