### PR TITLE
Add kephrase length assessment config

### DIFF
--- a/spec/assessments/KeyphraseLengthAssessmentSpec.js
+++ b/spec/assessments/KeyphraseLengthAssessmentSpec.js
@@ -16,6 +16,17 @@ describe( "the keyphrase length assessment", function() {
 			"<a href='https://yoa.st/33j' target='_blank'>Set a keyphrase in order to calculate your SEO score</a>." );
 	} );
 
+	it( "should show a different feedback text when no keyphrase is set for a related keyphrase", function() {
+		const paper = new Paper();
+		const researcher = factory.buildMockResearcher( 0 );
+
+		const result = new KeyphraseLengthAssessment( { isRelatedKeyphrase: true } ).getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( -999 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"<a href='https://yoa.st/33j' target='_blank'>Set a keyphrase in order to calculate your SEO score</a>." );
+	} );
+
 	it( "should assess a paper with a keyphrase that's too long as bad", function() {
 		const paper = new Paper( "", { keyword: "keyword" } );
 		const researcher = factory.buildMockResearcher( 11 );

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -83,7 +83,7 @@ class KeyphraseLengthAssessment extends Assessment {
 						/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 						i18n.dgettext(
 							"js-text-analysis",
-							"%1$sKeyphrase length%3$s: No keyphrase was set for this page. " +
+							"%1$sKeyphrase length%3$s: " +
 							"%2$sSet a keyphrase in order to calculate your SEO score%3$s."
 						),
 						this._config.urlTitle,

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -37,6 +37,7 @@ class KeyphraseLengthAssessment extends Assessment {
 			},
 			urlTitle: "<a href='https://yoa.st/33i' target='_blank'>",
 			urlCallToAction: "<a href='https://yoa.st/33j' target='_blank'>",
+			isRelatedKeyphrase: false,
 		};
 
 		this.identifier = "keyphraseLength";
@@ -75,6 +76,22 @@ class KeyphraseLengthAssessment extends Assessment {
 	 */
 	calculateResult( i18n ) {
 		if ( this._keyphraseLength < this._config.parameters.recommendedMinimum ) {
+			if ( this._config.isRelatedKeyphrase ) {
+				return {
+					score: this._config.scores.veryBad,
+					resultText: i18n.sprintf(
+						/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+						i18n.dgettext(
+							"js-text-analysis",
+							"%1$sKeyphrase length%3$s: No keyphrase was set for this page. " +
+							"%2$sSet a keyphrase in order to calculate your SEO score%3$s."
+						),
+						this._config.urlTitle,
+						this._config.urlCallToAction,
+						"</a>"
+					),
+				};
+			}
 			return {
 				score: this._config.scores.veryBad,
 				resultText: i18n.sprintf(

--- a/src/relatedKeywordAssessor.js
+++ b/src/relatedKeywordAssessor.js
@@ -1,6 +1,6 @@
 import { inherits } from "util";
-import Assessor from "./assessor.js";
 
+import Assessor from "./assessor.js";
 import IntroductionKeyword from "./assessments/seo/IntroductionKeywordAssessment.js";
 import KeyphraseLength from "./assessments/seo/KeyphraseLengthAssessment.js";
 import KeywordDensity from "./assessments/seo/KeywordDensityAssessment.js";
@@ -22,7 +22,7 @@ const relatedKeywordAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		new IntroductionKeyword(),
-		new KeyphraseLength(),
+		new KeyphraseLength( { isRelatedKeyphrase: true } ),
 		new KeywordDensity(),
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),

--- a/src/relatedKeywordTaxonomyAssessor.js
+++ b/src/relatedKeywordTaxonomyAssessor.js
@@ -18,7 +18,7 @@ const RelatedKeywordTaxonomyAssessor = function( i18n ) {
 
 	this._assessments = [
 		new IntroductionKeywordAssessment(),
-		new KeyphraseLengthAssessment(),
+		new KeyphraseLengthAssessment( { isRelatedKeyphrase: true } ),
 		new KeywordDensityAssessment(),
 		new MetaDescriptionKeywordAssessment(),
 		// Text Images assessment here.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Add config option for the related keyphrase to the keyphrase length assessment.
* Default config is overwritten in the related keyword assessor and the related keyword taxonomy assessor.

## Test instructions

This PR can be tested by following these steps:

* Go to premium.
* Create a new post.
* Add a related keyword and empty the field again. You should see the feedback string `Keyphrase length: No keyphrase was set for this page. Set a keyphrase in order to calculate your SEO score.` Note the missing of `focus` in front of `keyphrase`.
* Create a new taxonomy.
* Check the same thing again.

Fixes #1869 
