### PR TITLE
Fix bug with exact matches in URL Keyphrase assessment

### DIFF
--- a/spec/assessments/UrlKeywordAssessmentSpec.js
+++ b/spec/assessments/UrlKeywordAssessmentSpec.js
@@ -65,4 +65,26 @@ describe( "A keyword in url count assessment", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: More than half of your keyphrase appears in the slug. That's great!" );
 	} );
+
+	it( "assesses a keyword was found in the url: in double quotes", function() {
+		const assessment = keywordInUrl.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 100 } ),
+			i18n
+		);
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: Great work!" );
+	} );
+
+	it( "assesses part of the keyphrase was not found in the url: in double quotes", function() {
+		const assessment = keywordInUrl.getResult(
+			mockPaper,
+			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 0 } ),
+			i18n
+		);
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: (Part of) your keyphrase does not appear in the slug. <a href='https://yoa.st/33p' target='_blank'>Change that</a>!" );
+	} );
 } );

--- a/spec/researches/keywordCountInUrlSpec.js
+++ b/spec/researches/keywordCountInUrlSpec.js
@@ -156,4 +156,25 @@ describe( "test to check url for keyword", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 4, percentWordMatches: 50 } );
 	} );
+
+	it( "returns matches for keywords in double quotes", function() {
+		const paper = new Paper( "", { url: "url-with-key-word", keyword: "\"key word\"" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
+	} );
+
+	it( "returns matches for keywords in double quotes", function() {
+		const paper = new Paper( "", { url: "url-with-key-word-and-cats-and-dogs", keyword: "\"word and cats and dogs\"" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
+	} );
+
+	it( "returns matches for keywords in double quotes: ignores morphology", function() {
+		const paper = new Paper( "", { url: "url-with-key-word-and-cats-and-dogs", keyword: "\"words and cat and dog\"" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
+	} );
 } );

--- a/src/researches/keywordCountInUrl.js
+++ b/src/researches/keywordCountInUrl.js
@@ -12,7 +12,7 @@ import { findTopicFormsInString } from "./findKeywordFormsInString.js";
  */
 export default function( paper, researcher ) {
 	const topicForms = researcher.getResearch( "morphology" );
-	const slug = paper.getUrl().replace( "-", " " );
+	const slug = paper.getUrl().replace( /\-/ig, " " );
 
 	const keyphraseInSlug = findTopicFormsInString( topicForms, slug, false, paper.getLocale() );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where the exact matching would not work for slug.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Create a multi-word focus keyphrase, e.g. `dogs and cats`.
* Check if the url keyword assessment works [as expected](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#9-url-keyword-assessment).
* Add quotation marks around the focus keyphrase, e.g., `"dogs and cats"`.
* Check that 
  * If the slug contains an exact match, e.g. `dogs-and-cats`, the assessment returns a good score
  * If the slug does not contain an exact match, e.g., `dog-and-cat`, the assessment returns an okay score

Fixes #1874 
