### PR TITLE
Fix bug with exact matches in Title Keyword assessment

### DIFF
--- a/spec/assessments/TitleKeywordAssessmentSpec.js
+++ b/spec/assessments/TitleKeywordAssessmentSpec.js
@@ -12,7 +12,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: false, position: -1 } ),
+			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 2 );
@@ -30,7 +30,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: true, allWordsFound: true, position: 0 } ),
+			Factory.buildMockResearcher( { exactMatch: true, allWordsFound: true, position: 0, exactMatchKeyphrase: false } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
@@ -47,7 +47,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: true, allWordsFound: true, position: 41 } ),
+			Factory.buildMockResearcher( { exactMatch: true, allWordsFound: true, position: 41, exactMatchKeyphrase: false } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
@@ -58,14 +58,14 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		);
 	} );
 
-	it( "returns an assementresult with keyword not found at all", function() {
+	it( "returns an assement result with keyword not found at all", function() {
 		const paper = new Paper( "", {
 			keyword: "keyword",
 			title: "a non-empty title",
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: true, position: -1 } ),
+			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: true, position: -1, exactMatchKeyphrase: false  } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
@@ -74,6 +74,24 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 			"<a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title</a>."
 		);
 	} );
+
+	it( "returns a bad result for an exact match keyphrase when the word order of the keyphrase is different in the title", function() {
+		const paper = new Paper( "", {
+			keyword: "\"cats and dogs\"",
+			title: "dogs and cats",
+		} );
+		const assessment = new TitleKeywordAssessment().getResult(
+			paper,
+			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: false, position: 0, exactMatchKeyphrase: true } ),
+			i18n );
+
+		expect( assessment.getScore() ).toBe( 2 );
+		expect( assessment.getText() ).toBe(
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Does not contain the exact match. " +
+			"<a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title</a>."
+		);
+	} );
+
 
 	it( "returns false isApplicable for a paper without title", function() {
 		const isApplicableResult = new TitleKeywordAssessment().isApplicable( new Paper( "", { keyword: "some keyword", title: "" } ) );

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -240,7 +240,7 @@ describe( "Match keywords in string", function() {
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
-	it( "returns all-words-found match if keyphrase words were shuffled in the title for French", function() {
+	it( "returns all-words-found match if keyphrase words were shuffled in the title for Swedish", function() {
 		const mockPaper = new Paper( "", {
 			keyword: "promenader i naturen",
 			title: "Jag gillar att ta promenader i naturen.",
@@ -252,6 +252,45 @@ describe( "Match keywords in string", function() {
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
 		expect( result.position ).toBe( 18 );
+	} );
+
+	it( "returns an exact match at the beginning", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"Walking in the nature\"",
+			title: "Walking in the nature is awesome.",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns an exact match not at the beginning", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"Walking in the nature\"",
+			title: "My opinion: Walking in the nature is awesome.",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 12 );
+	} );
+
+	it( "returns an exact match not found", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"Walking in the nature\"",
+			title: "My opinion: Walking in nature is awesome.",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.allWordsFound ).toBe( false );
 	} );
 } );
 

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -264,6 +264,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -277,6 +278,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.position ).toBe( 12 );
 	} );
 
@@ -290,6 +292,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.allWordsFound ).toBe( false );
 	} );
 } );

--- a/src/assessments/seo/TitleKeywordAssessment.js
+++ b/src/assessments/seo/TitleKeywordAssessment.js
@@ -87,6 +87,7 @@ class TitleKeywordAssessment extends Assessment {
 		const exactMatch = this._keywordMatches.exactMatch;
 		const position = this._keywordMatches.position;
 		const allWordsFound = this._keywordMatches.allWordsFound;
+		const exactMatchKeyphrase = this._keywordMatches.exactMatchKeyphrase;
 
 		if ( exactMatch === true ) {
 			if ( position === 0 ) {
@@ -136,6 +137,25 @@ class TitleKeywordAssessment extends Assessment {
 					this._config.urlTitle,
 					this._config.urlCallToAction,
 					"</a>"
+				),
+			};
+		}
+
+		if( exactMatchKeyphrase ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s and %2$s expand to a link on yoast.com,
+					%3$s expands to the anchor end tag. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%1$sKeyphrase in title%3$s: Does not contain the exact match. %2$sTry to write the exact match of " +
+						"your keyphrase in the SEO title%3$s."
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>",
+					keyword
 				),
 			};
 		}

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -3,7 +3,7 @@
 import wordMatch from "../stringProcessing/matchTextWithWord.js";
 const findTopicFormsInString = require( "./findKeywordFormsInString.js" ).findTopicFormsInString;
 
-import { escapeRegExp } from "lodash-es";
+import { escapeRegExp, includes } from "lodash-es";
 
 /**
  * Counts the occurrences of the keyword in the page title. Returns the result that contains information on
@@ -17,11 +17,17 @@ import { escapeRegExp } from "lodash-es";
  * @returns {Object} result with the information on whether the keyphrase was matched in the title and how.
  */
 export default function( paper, researcher ) {
-	const keyword = escapeRegExp( paper.getKeyword() );
+	let keyword = escapeRegExp( paper.getKeyword() );
 	const title = paper.getTitle();
 	const locale = paper.getLocale();
 
 	const result = { exactMatch: false, allWordsFound: false, position: -1 };
+
+	// First check if morphology is suppressed. If so, strip the quotation marks from the keyphrase.
+	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
+	if ( includes( doubleQuotes, keyword[ 0 ] ) && includes( doubleQuotes, keyword[ keyword.length - 1 ] ) ) {
+		keyword = keyword.substring( 1, keyword.length - 1 );
+	}
 
 	// Check 1: Is the exact match of the keyphrase found in the title?
 	const keywordMatched = wordMatch( title, keyword, locale );

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -21,12 +21,13 @@ export default function( paper, researcher ) {
 	const title = paper.getTitle();
 	const locale = paper.getLocale();
 
-	const result = { exactMatch: false, allWordsFound: false, position: -1 };
+	const result = { exactMatch: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false  };
 
 	// First check if morphology is suppressed. If so, strip the quotation marks from the keyphrase.
 	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
 	if ( includes( doubleQuotes, keyword[ 0 ] ) && includes( doubleQuotes, keyword[ keyword.length - 1 ] ) ) {
 		keyword = keyword.substring( 1, keyword.length - 1 );
+		result.exactMatchKeyphrase = true;
 	}
 
 	// Check 1: Is the exact match of the keyphrase found in the title?


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where a keyphrase with suppressed morphology would not be matched at the beginning of the title.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Define a keyphrase, e.g., `dog` or `dogs and cats` and make sure that it works [as expected](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#8-page-title-keyword-assessment)
* Add quotes around the keyphrase, e.g., `"dog"` or `"dogs and cats"` and make sure that
  * Only exact matches are found. E.g., keyphrase `"dog"` should not be matched in title `Dogs and cats`
  * The exact matches are found correctly. E.g., keyphrase `"dog"` is correctly found at the beginning of the title (and the good feedback is returned) in title `Dog toys` and is correctly found **not** at the beginning of the title (and the orange feedback is returned) in title `Cool dog toys`

Fixes #1873 
