### PR TITLE
Add function words in keyphrase assessment

### DIFF
--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -53,6 +53,20 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments only require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
 	it( "additionally runs assessments that require text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
 		const AssessmentResults = assessor.getValidResults();

--- a/spec/assessments/FunctionWordsInKeyphraseAssessmentSpec.js
+++ b/spec/assessments/FunctionWordsInKeyphraseAssessmentSpec.js
@@ -38,5 +38,4 @@ describe( "An assessment for checking if the keyphrase contains of function word
 		const isApplicableResult = new FunctionWordsInKeyphraseAssessment().isApplicable( new Paper( "some text", { keyword: "something here" } ) );
 		expect( isApplicableResult ).toBe( true );
 	} );
-
 } );

--- a/spec/assessments/FunctionWordsInKeyphraseAssessmentSpec.js
+++ b/spec/assessments/FunctionWordsInKeyphraseAssessmentSpec.js
@@ -1,0 +1,42 @@
+import FunctionWordsInKeyphraseAssessment from "../../src/assessments/seo/FunctionWordsInKeyphraseAssessment";
+import Paper from "../../src/values/Paper";
+import Factory from "../specHelpers/factory";
+
+const i18n = Factory.buildJed();
+
+describe( "An assessment for checking if the keyphrase contains of function words only", function() {
+	it( "returns a consideration feedback if there are only function words in the keyphrase", function() {
+		const assessment = new FunctionWordsInKeyphraseAssessment().getResult(
+			new Paper( "", { keyword: "someone was here" } ),
+			Factory.buildMockResearcher( true ),
+			i18n
+		);
+		expect( assessment.getScore() ).toBe( 0 );
+		expect( assessment.getText() ).toBe(
+			"<a href='https://yoa.st/33z' target='_blank'>Function words in keyphrase</a>: " +
+			"Your keyphrase \"someone was here\" contains function words only. " +
+			"<a href='https://yoa.st/34a' target='_blank'>Learn more about what makes a good keyphrase.</a>"
+		);
+	} );
+
+	it( "returns nothing if there are also content words in the keyphrase", function() {
+		const assessment = new FunctionWordsInKeyphraseAssessment().getResult(
+			new Paper( "", { keyword: "someone smart was here" } ),
+			Factory.buildMockResearcher( false ),
+			i18n
+		);
+		expect( assessment.hasScore() ).toBe( false );
+	} );
+
+
+	it( "applies if no keyword is defined", function() {
+		const isApplicableResult = new FunctionWordsInKeyphraseAssessment().isApplicable( new Paper( "some text" ) );
+		expect( isApplicableResult ).toBe( false );
+	} );
+
+	it( "does not apply if a keyword is defined", function() {
+		const isApplicableResult = new FunctionWordsInKeyphraseAssessment().isApplicable( new Paper( "some text", { keyword: "something here" } ) );
+		expect( isApplicableResult ).toBe( true );
+	} );
+
+} );

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -53,6 +53,19 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments that require a keyword with function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		let assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
 		const text = "a ".repeat( 200 );
 		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );

--- a/spec/cornerstone/relatedKeywordAssessorSpec.js
+++ b/spec/cornerstone/relatedKeywordAssessorSpec.js
@@ -24,6 +24,16 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "runs assessments that only require a keyword that consists of function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		let assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );

--- a/spec/relatedKeywordAssessorSpec.js
+++ b/spec/relatedKeywordAssessorSpec.js
@@ -24,6 +24,16 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "runs assessments that only require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		let assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
 		let assessments = getResults( assessor.getValidResults() );

--- a/spec/relatedKeywordTaxonomyAssessorSpec.js
+++ b/spec/relatedKeywordTaxonomyAssessorSpec.js
@@ -28,6 +28,17 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments that require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
 		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
 		const AssessmentResults = assessor.getValidResults();

--- a/spec/researches/functionWordsInKeyphraseSpec.js
+++ b/spec/researches/functionWordsInKeyphraseSpec.js
@@ -1,0 +1,45 @@
+import functionWordsInKeyphrase from "../../src/researches/functionWordsInKeyphrase.js";
+
+import Paper from "../../src/values/Paper.js";
+
+describe( "Test for checking if the keyphrase contains function words only", function() {
+	it( "returns true if the keyphrase contains one function word only", function() {
+		let mockPaper = new Paper( "", { keyword: "a", locale: "en_EN" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( true );
+	} );
+
+	it( "returns true if the keyphrase contains function words only", function() {
+		let mockPaper = new Paper( "", { keyword: "un deux", locale: "fr_FR" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( true );
+	} );
+
+	it( "returns true if the keyphrase contains function words only (empty locale)", function() {
+		let mockPaper = new Paper( "", { keyword: "something was there" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( true );
+	} );
+
+	it( "returns false if the keyphrase is embedded in quotes", function() {
+		let mockPaper = new Paper( "", { keyword: "\"something was there\"" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );
+	} );
+
+	it( "returns false if there are content words in the keyphrase", function() {
+		let mockPaper = new Paper( "", { keyword: "something was there and it was pretty" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );
+	} );
+
+	it( "returns false if there are content words in the keyphrase", function() {
+		let mockPaper = new Paper( "", { keyword: "something was there and it was pretty", locale: "en_EN" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );
+	} );
+
+	it( "returns false if there are content words in the keyphrase", function() {
+		let mockPaper = new Paper( "", { keyword: "daar zat iets en het was mooi", locale: "nl_NL" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );
+	} );
+
+	it( "returns false if there are content words in the keyphrase", function() {
+		let mockPaper = new Paper( "", { keyword: "Keyphrase keyphrase keyphrase" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );
+	} );
+} );

--- a/spec/researches/functionWordsInKeyphraseSpec.js
+++ b/spec/researches/functionWordsInKeyphraseSpec.js
@@ -18,6 +18,11 @@ describe( "Test for checking if the keyphrase contains function words only", fun
 		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( true );
 	} );
 
+	it( "returns false for unknown locale", function() {
+		let mockPaper = new Paper( "", { keyword: "something", locale: "xx_XX" } );
+		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );
+	} );
+
 	it( "returns false if the keyphrase is embedded in quotes", function() {
 		let mockPaper = new Paper( "", { keyword: "\"something was there\"" } );
 		expect( functionWordsInKeyphrase( mockPaper ) ).toBe( false );

--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -46,6 +46,20 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments that require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a text, a keyword and a title", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword", title: "title" } ) );
 		const AssessmentResults = assessor.getValidResults();

--- a/src/assessments/seo/FunctionWordsInKeyphraseAssessment.js
+++ b/src/assessments/seo/FunctionWordsInKeyphraseAssessment.js
@@ -1,0 +1,83 @@
+import { escape, merge } from "lodash-es";
+
+import Assessment from "../../assessment";
+import AssessmentResult from "../../values/AssessmentResult";
+
+/**
+ * Assessment to check whether the keyphrase only contains function words.
+ */
+class FunctionWordsInKeyphraseAssessment extends Assessment {
+	/**
+	 * Sets the identifier and the config.
+	 *
+	 * @param {Object} [config] The configuration to use.
+	 * @param {number} [config.scores.onlyFunctionWords] The score to return if the keyphrase contains only function words.
+	 * @param {string} [config.urlTitle] The URL to the relevant KB article.
+	 * @param {string} [config.urlCallToAction] The URL to the call-to-action article.
+	 *
+	 * @returns {void}
+	 */
+	constructor( config = {} ) {
+		super();
+
+		const defaultConfig = {
+			scores: {
+				onlyFunctionWords: 0,
+			},
+			urlTitle: "<a href='https://yoa.st/33z' target='_blank'>",
+			urlCallToAction: "<a href='https://yoa.st/34a' target='_blank'>",
+		};
+
+		this.identifier = "functionWordsInKeyphrase";
+		this._config = merge( defaultConfig, config );
+	}
+
+	/**
+	 * Runs the functionWordsInKeyphrase researcher, based on this returns an assessment result with score.
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 * @param {Researcher} researcher The researcher used for calling research.
+	 * @param {Jed} i18n The object used for translations.
+	 *
+	 * @returns {AssessmentResult} The result of the assessment.
+	 */
+	getResult( paper, researcher, i18n ) {
+		this._functionWordsInKeyphrase = researcher.getResearch( "functionWordsInKeyphrase" );
+		this._keyword = escape( paper.getKeyword() );
+		const assessmentResult = new AssessmentResult();
+
+		if ( this._functionWordsInKeyphrase ) {
+			assessmentResult.setScore( this._config.scores.onlyFunctionWords );
+			assessmentResult.setText( i18n.sprintf(
+				/**
+				 * Translators:
+				 * %1$s and %2$s expand to links on yoast.com,
+				 * %3$s expands to the anchor end tag,
+				 * %4$s expands to the focus keyphrase of the article.
+				 */
+				i18n.dgettext( "js-text-analysis", "%1$sFunction words in keyphrase%3$s: " +
+					"Your keyphrase \"%4$s\" contains function words only. " +
+					"%2$sLearn more about what makes a good keyphrase.%3$s" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>",
+				this._keyword,
+			) );
+		}
+
+		return assessmentResult;
+	}
+
+	/**
+	 * Checks if assessment is applicable to the paper.
+	 *
+	 * @param {Paper} paper The paper to be analyzed.
+	 *
+	 * @returns {boolean} Whether the paper has keyword.
+	 */
+	isApplicable( paper ) {
+		return paper.hasKeyword();
+	}
+}
+
+export default FunctionWordsInKeyphraseAssessment;

--- a/src/cornerstone/relatedKeywordAssessor.js
+++ b/src/cornerstone/relatedKeywordAssessor.js
@@ -7,6 +7,7 @@ import KeywordDensity from "../assessments/seo/KeywordDensityAssessment.js";
 import MetaDescriptionKeyword from "../assessments/seo/MetaDescriptionKeywordAssessment.js";
 import TextImages from "../assessments/seo/textImagesAssessment.js";
 import TextCompetingLinks from "../assessments/seo/TextCompetingLinksAssessment.js";
+import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 
 /**
  * Creates the Assessor
@@ -34,6 +35,7 @@ const relatedKeywordAssessor = function( i18n, options ) {
 				noAlt: 3,
 			},
 		} ),
+		new FunctionWordsInKeyphrase(),
 	];
 };
 

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -18,6 +18,7 @@ import OutboundLinks from "../assessments/seo/outboundLinksAssessment";
 import TitleWidth from "../assessments/seo/pageTitleWidthAssessment";
 import UrlLength from "../assessments/seo/urlLengthAssessment";
 import urlStopWords from "../assessments/seo/urlStopWordsAssessment";
+import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 
 /**
  * Creates the Assessor
@@ -99,6 +100,7 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 			},
 		} ),
 		urlStopWords,
+		new FunctionWordsInKeyphrase(),
 	];
 };
 

--- a/src/relatedKeywordAssessor.js
+++ b/src/relatedKeywordAssessor.js
@@ -7,6 +7,7 @@ import KeywordDensity from "./assessments/seo/KeywordDensityAssessment.js";
 import MetaDescriptionKeyword from "./assessments/seo/MetaDescriptionKeywordAssessment.js";
 import TextImages from "./assessments/seo/textImagesAssessment.js";
 import TextCompetingLinks from "./assessments/seo/TextCompetingLinksAssessment.js";
+import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
 
 /**
  * Creates the Assessor
@@ -27,6 +28,7 @@ const relatedKeywordAssessor = function( i18n, options ) {
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),
 		new TextImages(),
+		new FunctionWordsInKeyphrase(),
 	];
 };
 

--- a/src/relatedKeywordTaxonomyAssessor.js
+++ b/src/relatedKeywordTaxonomyAssessor.js
@@ -5,6 +5,7 @@ import KeyphraseLengthAssessment from "./assessments/seo/KeyphraseLengthAssessme
 import KeywordDensityAssessment from "./assessments/seo/KeywordDensityAssessment";
 import MetaDescriptionKeywordAssessment from "./assessments/seo/MetaDescriptionKeywordAssessment";
 import Assessor from "./assessor";
+import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
 
 /**
  * Creates the Assessor used for taxonomy pages.
@@ -22,6 +23,7 @@ const RelatedKeywordTaxonomyAssessor = function( i18n ) {
 		new KeywordDensityAssessment(),
 		new MetaDescriptionKeywordAssessment(),
 		// Text Images assessment here.
+		new FunctionWordsInKeyphrase(),
 	];
 };
 

--- a/src/researcher.js
+++ b/src/researcher.js
@@ -44,6 +44,7 @@ import { keyphraseDistributionResearcher } from "./researches/keyphraseDistribut
 const keyphraseDistribution = keyphraseDistributionResearcher;
 import { research } from "./researches/buildKeywordForms";
 const morphology = research;
+import functionWordsInKeyphrase from "./researches/functionWordsInKeyphrase";
 
 /**
  * This contains all possible, default researches.
@@ -90,6 +91,7 @@ var Researcher = function( paper ) {
 		sentences,
 		keyphraseDistribution: keyphraseDistribution,
 		morphology: morphology,
+		functionWordsInKeyphrase: functionWordsInKeyphrase,
 	};
 
 	this._data = {};

--- a/src/researches/functionWordsInKeyphrase.js
+++ b/src/researches/functionWordsInKeyphrase.js
@@ -1,4 +1,3 @@
-import { filterFunctionWords } from "./buildKeywordForms";
 import getWords from "../stringProcessing/getWords";
 import getLanguage from "../helpers/getLanguage";
 import getFunctionWordsFactory from "../helpers/getFunctionWords.js";

--- a/src/researches/functionWordsInKeyphrase.js
+++ b/src/researches/functionWordsInKeyphrase.js
@@ -1,0 +1,31 @@
+import { filterFunctionWords } from "./buildKeywordForms";
+import getWords from "../stringProcessing/getWords";
+import getLanguage from "../helpers/getLanguage";
+import getFunctionWordsFactory from "../helpers/getFunctionWords.js";
+const getFunctionWords = getFunctionWordsFactory();
+import { filter, get, includes, isEmpty } from "lodash-es";
+/**
+ * Checks if the keyphrase contains of function words only.
+ *
+ * @param {object} paper The paper containing the keyword.
+ *
+ * @returns {boolean} Whether the keyphrase contains of content words only.
+ */
+export default function( paper ) {
+	const keyphrase = paper.getKeyword();
+
+	// Return false if there are double quotes around the keyphrase.
+	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
+	if ( includes( doubleQuotes, keyphrase[ 0 ] ) && includes( doubleQuotes, keyphrase[ keyphrase.length - 1 ] ) ) {
+		return false;
+	}
+
+	let keyphraseWords = getWords( keyphrase );
+	const functionWords = get( getFunctionWords, [ getLanguage( paper.getLocale() ) ], [] );
+
+	keyphraseWords = filter( keyphraseWords, function( word ) {
+		return ( ! includes( functionWords.all, word.trim().toLocaleLowerCase() ) );
+	} );
+
+	return isEmpty( keyphraseWords );
+}

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -17,6 +17,7 @@ import OutboundLinks from "./assessments/seo/outboundLinksAssessment";
 import TitleWidth from "./assessments/seo/pageTitleWidthAssessment";
 import UrlLength from "./assessments/seo/urlLengthAssessment";
 import urlStopWords from "./assessments/seo/urlStopWordsAssessment";
+import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
 /**
  * Creates the Assessor
  *
@@ -47,6 +48,7 @@ const SEOAssessor = function( i18n, options ) {
 		new UrlKeywordAssessment(),
 		new UrlLength(),
 		urlStopWords,
+		new FunctionWordsInKeyphrase(),
 	];
 };
 

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -12,6 +12,7 @@ import taxonomyTextLengthAssessment from "./assessments/seo/taxonomyTextLengthAs
 import PageTitleWidthAssessment from "./assessments/seo/pageTitleWidthAssessment";
 import UrlLengthAssessment from "./assessments/seo/urlLengthAssessment";
 import urlStopWordsAssessment from "./assessments/seo/urlStopWordsAssessment";
+import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
 
 /**
  * Creates the Assessor used for taxonomy pages.
@@ -35,6 +36,7 @@ const TaxonomyAssessor = function( i18n ) {
 		new UrlKeywordAssessment(),
 		new UrlLengthAssessment(),
 		urlStopWordsAssessment,
+		new FunctionWordsInKeyphrase(),
 	];
 };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an assessment that checks if the keyphrase contains function words only and returns a consideration if so.

## Relevant technical choices:

* The assessment is only triggered if there is a keyword.
* The assessment does not return a consideration feedback if the keyphrase is embedded in double quotes (i.e., exact matches will be used).

## Test instructions

This PR can be tested by following these steps:

### For languages with function-word support
* Add a kephrase that contains a content word only, a few content words, a content word and a function word, a few content words together with function words. Check the assessment is not triggered.
* Add a keyphrase with one function word. Check if the assessment is triggered.
* Add more function words to your keyphrase. Check if the assessment is still triggered.
* Add a content word to the keyphrase. Check if the assessment is not triggered anymore.
* Remove the content word from the keyphrase. Check if the assessment is triggered again.
* Put double quotes around your keyphrase. Check if the assessment is not triggered anymore.

### For languages without function word support
* Check that the assessment is not triggered.


Fixes #1884
