### PR TITLE
Meta description keyword assessment now only looks at keyphrase counts in entire description.

### DIFF
--- a/spec/assessments/MetaDescriptionKeywordAssessmentSpec.js
+++ b/spec/assessments/MetaDescriptionKeywordAssessmentSpec.js
@@ -4,11 +4,10 @@ import Factory from "../specHelpers/factory";
 
 const i18n = Factory.buildJed();
 
-const mockResearcherNoMatches = Factory.buildMockResearcher( { fullDescription: 0, perSentence: [ 0 ] } );
-const mockResearcherOneMatch = Factory.buildMockResearcher( { fullDescription: 100, perSentence: [ 100, 0, 0 ] } );
-const mockResearcherTwoMatches = Factory.buildMockResearcher( { fullDescription: 100, perSentence: [ 100, 100, 50 ] } );
-const mockResearcherThreeMatches = Factory.buildMockResearcher( { fullDescription: 100, perSentence: [ 100, 100, 100 ] } );
-const mockResearcherMatchesDescription = Factory.buildMockResearcher( { fullDescription: 100, perSentence: [ 50, 50 ] } );
+const mockResearcherNoMatches = Factory.buildMockResearcher( 0 );
+const mockResearcherOneMatch = Factory.buildMockResearcher( 1 );
+const mockResearcherTwoMatches = Factory.buildMockResearcher( 2 );
+const mockResearcherThreeMatches = Factory.buildMockResearcher( 3 );
 
 describe( "the metadescription keyword assessment", function() {
 	it( "returns a bad result when the meta description doesn't contain the keyword", function() {
@@ -41,14 +40,6 @@ describe( "the metadescription keyword assessment", function() {
 
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description contains the keyphrase 3 times, which is over the advised maximum of 2 times. <a href='https://yoa.st/33l' target='_blank'>Limit that</a>!" );
-	} );
-
-	it( "returns an okay result when the meta description contains the keyword one time, but not in the same sentence", function() {
-		const mockPaper = new Paper();
-		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherMatchesDescription, i18n );
-
-		expect( assessment.getScore() ).toBe( 6 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>." );
 	} );
 
 	it( "is not applicable when the paper doesn't have a keyword", function() {

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -54,8 +54,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0.7%. This is great!",
 	},
 	metaDescriptionKeyword: {
-		score: 6,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: All words of keyphrase or synonym appear in the meta description, but not within one sentence. <a href='https://yoa.st/33l' target='_blank'>Try to use them in one sentence</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!",
 	},
 	metaDescriptionLength: {
 		score: 9,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -54,8 +54,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0.7%. This is great!",
 	},
 	metaDescriptionKeyword: {
-		score: 9,
-		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!",
+		score: 3,
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: The meta description has been specified, but it does not contain the keyphrase. <a href='https://yoa.st/33l' target='_blank'>Fix that</a>!",
 	},
 	metaDescriptionLength: {
 		score: 9,

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -12,36 +12,36 @@ describe( "the metadescription keyword match research", function() {
 	it( "returns the number ( 1 ) of keywords found", function() {
 		var paper = new Paper( "", { keyword: "word", description: "a description with a word" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWord );
-		expect( result ).toEqual( { fullDescription: 100, perSentence: [ 100 ] } );
+		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 2 ) of keywords found", function() {
 		var paper = new Paper( "", { keyword: "word", description: "a description with a word and a word" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWord );
-		expect( result ).toEqual( { fullDescription: 100, perSentence: [ 100 ] } );
+		expect( result ).toEqual( 2 );
 	} );
 
 	it( "returns the number ( 0 ) of keywords found", function() {
 		var paper = new Paper( "", { keyword: "word", description: "a description with a bla" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWord );
-		expect( result ).toEqual( { fullDescription: 0, perSentence: [ 0 ] } );
+		expect( result ).toEqual( 0 );
 	} );
 
 	it( "returns -1 because there is no meta", function() {
 		var paper = new Paper( "", { keyword: "word", description: "" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWord );
-		expect( result ).toBe( null );
+		expect( result ).toBe( -1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords found", function() {
 		var paper = new Paper( "", { keyword: "keywörd", description: "a description with a keyword", locale: "en_US" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWordUmlaut );
-		expect( result ).toEqual( { fullDescription: 100, perSentence: [ 100 ] } );
+		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords found when the keyword begins with $", function() {
 		var paper = new Paper( "", { keyword: "$keyword", description: "a description with a $keyword" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWordDollarSign );
-		expect( result ).toEqual( { fullDescription: 100, perSentence: [ 100 ] } );
+		expect( result ).toEqual( 1 );
 	} );
 } );

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -98,4 +98,12 @@ describe( "the metadescription keyword match research", function() {
 		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 2 );
 	} );
+
+	it( "returns the number ( 2 ) of keywords and synonyms found.", function() {
+		const paper = new Paper( "", { keyword: "cats and dogs", synonyms: "hounds and felines", description: "This is a meta description. It’s about dogs and cats and hounds and felines and more felines. A sdfkjhsdk hskdf sd. And hounds." } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
+		expect( result ).toEqual( 2 );
+	} );
 } );

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -29,14 +29,6 @@ describe( "the metadescription keyword match research", function() {
 		expect( result ).toEqual( 0 );
 	} );
 
-	it( "returns -1 because there is no meta", function() {
-		const paper = new Paper( "", { keyword: "word", description: "" } );
-		const researcher = new Researcher( paper );
-		researcher.addResearchData( "morphology", morphologyData );
-		const result = metaDescriptionKeyword( paper, researcher );
-		expect( result ).toBe( -1 );
-	} );
-
 	it( "returns the number ( 1 ) of keywords found", function() {
 		const paper = new Paper( "", { keyword: "keywörd", description: "a description with a keyword", locale: "en_US" } );
 		const researcher = new Researcher( paper );

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -1,70 +1,79 @@
 import metaDescriptionKeyword from "../../src/researches/metaDescriptionKeyword.js";
 import Paper from "../../src/values/Paper.js";
-import Factory from "../specHelpers/factory.js";
 
-const mockResearcherWord = Factory.buildMockResearcher( { keyphraseForms: [ [ "word", "words" ] ] } );
-const mockResearcherWordUmlaut = Factory.buildMockResearcher( { keyphraseForms: [ [ "keywörd", "keywörds" ] ] } );
-
-// The morphological research escapes the forms that it adds to the list of forms, so we should mimic this behavior here.
-const mockResearcherWordDollarSign = Factory.buildMockResearcher( { keyphraseForms: [ [ "\\$keyword", "\\$keywords" ] ] } );
-
-const mockResearcherKeyWordPhrase = Factory.buildMockResearcher( {
-	keyphraseForms: [ [ "key", "keys" ], [ "word", "words" ] ],
-	synonymsForms: [ [ [ "key", "keys" ], [ "phrase", "phrases" ] ] ],
-} );
+import Researcher from "../../src/researcher";
+import morphologyData from "../../premium-configuration/data/morphologyData.json";
 
 describe( "the metadescription keyword match research", function() {
 	it( "returns the number ( 1 ) of keywords found", function() {
-		var paper = new Paper( "", { keyword: "word", description: "a description with a word" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherWord );
+		const paper = new Paper( "", { keyword: "word", description: "a description with a word" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 2 ) of keywords found", function() {
-		var paper = new Paper( "", { keyword: "word", description: "a description with a word and a word" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherWord );
+		const paper = new Paper( "", { keyword: "word", description: "a description with a word and a word" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 2 );
 	} );
 
 	it( "returns the number ( 0 ) of keywords found", function() {
-		var paper = new Paper( "", { keyword: "word", description: "a description with a bla" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherWord );
+		const paper = new Paper( "", { keyword: "word", description: "a description with a bla" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 0 );
 	} );
 
 	it( "returns -1 because there is no meta", function() {
-		var paper = new Paper( "", { keyword: "word", description: "" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherWord );
+		const paper = new Paper( "", { keyword: "word", description: "" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toBe( -1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords found", function() {
-		var paper = new Paper( "", { keyword: "keywörd", description: "a description with a keyword", locale: "en_US" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherWordUmlaut );
+		const paper = new Paper( "", { keyword: "keywörd", description: "a description with a keyword", locale: "en_US" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords found when the keyword begins with $", function() {
-		var paper = new Paper( "", { keyword: "$keyword", description: "a description with a $keyword" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherWordDollarSign );
+		const paper = new Paper( "", { keyword: "$keyword", description: "a description with a $keyword" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords found when the keyword", function() {
-		var paper = new Paper( "", { keyword: "key word", description: "a description with a key word and a key" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherKeyWordPhrase );
+		const paper = new Paper( "", { keyword: "key word", description: "a description with a key word and a key" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords and synonyms found", function() {
-		var paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "a description with a key word and a phrase" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherKeyWordPhrase );
+		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "a description with a key word and a phrase" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
 
 	it( "returns the number ( 1 ) of keywords and synonyms found", function() {
-		var paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "a description with a key phrase" } );
-		var result = metaDescriptionKeyword( paper, mockResearcherKeyWordPhrase );
+		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "a description with a key phrase" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
 } );

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -8,6 +8,11 @@ const mockResearcherWordUmlaut = Factory.buildMockResearcher( { keyphraseForms: 
 // The morphological research escapes the forms that it adds to the list of forms, so we should mimic this behavior here.
 const mockResearcherWordDollarSign = Factory.buildMockResearcher( { keyphraseForms: [ [ "\\$keyword", "\\$keywords" ] ] } );
 
+const mockResearcherKeyWordPhrase = Factory.buildMockResearcher( {
+	keyphraseForms: [ [ "key", "keys" ], [ "word", "words" ] ],
+	synonymsForms: [ [ [ "key", "keys" ], [ "phrase", "phrases" ] ] ],
+} );
+
 describe( "the metadescription keyword match research", function() {
 	it( "returns the number ( 1 ) of keywords found", function() {
 		var paper = new Paper( "", { keyword: "word", description: "a description with a word" } );
@@ -42,6 +47,24 @@ describe( "the metadescription keyword match research", function() {
 	it( "returns the number ( 1 ) of keywords found when the keyword begins with $", function() {
 		var paper = new Paper( "", { keyword: "$keyword", description: "a description with a $keyword" } );
 		var result = metaDescriptionKeyword( paper, mockResearcherWordDollarSign );
+		expect( result ).toEqual( 1 );
+	} );
+
+	it( "returns the number ( 1 ) of keywords found when the keyword", function() {
+		var paper = new Paper( "", { keyword: "key word", description: "a description with a key word and a key" } );
+		var result = metaDescriptionKeyword( paper, mockResearcherKeyWordPhrase );
+		expect( result ).toEqual( 1 );
+	} );
+
+	it( "returns the number ( 1 ) of keywords and synonyms found", function() {
+		var paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "a description with a key word and a phrase" } );
+		var result = metaDescriptionKeyword( paper, mockResearcherKeyWordPhrase );
+		expect( result ).toEqual( 1 );
+	} );
+
+	it( "returns the number ( 1 ) of keywords and synonyms found", function() {
+		var paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "a description with a key phrase" } );
+		var result = metaDescriptionKeyword( paper, mockResearcherKeyWordPhrase );
 		expect( result ).toEqual( 1 );
 	} );
 } );

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -70,10 +70,32 @@ describe( "the metadescription keyword match research", function() {
 	} );
 
 	it( "returns the number ( 3 ) of keywords and synonyms found", function() {
-		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "keys word. key wordly. keys phrases." } );
+		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "Keys word. Key wordly. Keys phrases." } );
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 3 );
+	} );
+
+	it( "returns the number ( 3 ) of keywords and synonyms found, even when the keyphrase contains function words.", function() {
+		const paper = new Paper( "", { keyword: "key and word", synonyms: "key or phrase", description: "Keys word. Key wordly. Keys phrases." } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
+		expect( result ).toEqual( 3 );
+	} );
+
+	it( "returns the number ( 1 ) of keywords and synonyms found, with no morphology data.", function() {
+		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "Key word. Key wordly. Keys phrases." } );
+		const researcher = new Researcher( paper );
+		const result = metaDescriptionKeyword( paper, researcher );
+		expect( result ).toEqual( 1 );
+	} );
+
+	it( "returns the number ( 2 ) of keywords and synonyms found, with no morphology data.", function() {
+		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "Key word. Key wordly. Key phrase." } );
+		const researcher = new Researcher( paper );
+		const result = metaDescriptionKeyword( paper, researcher );
+		expect( result ).toEqual( 2 );
 	} );
 } );

--- a/spec/researches/metaDescriptionKeywordSpec.js
+++ b/spec/researches/metaDescriptionKeywordSpec.js
@@ -76,4 +76,12 @@ describe( "the metadescription keyword match research", function() {
 		const result = metaDescriptionKeyword( paper, researcher );
 		expect( result ).toEqual( 1 );
 	} );
+
+	it( "returns the number ( 3 ) of keywords and synonyms found", function() {
+		const paper = new Paper( "", { keyword: "key word", synonyms: "key phrase", description: "keys word. key wordly. keys phrases." } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = metaDescriptionKeyword( paper, researcher );
+		expect( result ).toEqual( 3 );
+	} );
 } );

--- a/src/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -48,7 +48,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {AssessmentResult} The assessment result.
 	 */
 	getResult( paper, researcher, i18n ) {
-		this._keywordMatches = researcher.getResearch( "metaDescriptionKeyword" );
+		this._keyphraseCounts = researcher.getResearch( "metaDescriptionKeyword" );
 		const assessmentResult = new AssessmentResult();
 		const calculatedResult = this.calculateResult( i18n );
 
@@ -66,12 +66,9 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {Object} Result object with score and text.
 	 */
 	calculateResult( i18n ) {
-		const nrOfSentencesWithAllKeywords = this._keywordMatches.perSentence
-			.filter( percentageKeywordsMatched => percentageKeywordsMatched === 100 )
-			.length;
 
-		// GOOD result when one or two sentences contain every keyword term at least once.
-		if ( nrOfSentencesWithAllKeywords >= 1 && nrOfSentencesWithAllKeywords <= 2 ) {
+		// GOOD result when the meta description contains every keyhrase 1 or 2 times (including synonyms).
+		if ( this._keyphraseCounts === 1 || this._keyphraseCounts === 2 ) {
 			return {
 				score: this._config.scores.good,
 				resultText: i18n.sprintf(
@@ -87,7 +84,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 		}
 
 		// BAD if the description contains every keyword term more than twice.
-		if ( nrOfSentencesWithAllKeywords >= 3 ) {
+		if ( this._keyphraseCounts >= 3 ) {
 			return {
 				score: this._config.scores.bad,
 				resultText: i18n.sprintf(
@@ -104,34 +101,9 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 					),
 					this._config.urlTitle,
 					"</a>",
-					nrOfSentencesWithAllKeywords,
+					this._keyphraseCounts,
 					this._config.urlCallToAction,
 					"</a>"
-				),
-			};
-		}
-
-		// OK result when the full description contains every keyword term at least once.
-		if ( this._keywordMatches.fullDescription === 100 ) {
-			return {
-				score: this._config.scores.ok,
-				resultText: i18n.sprintf(
-					/**
-					 * Translators:
-					 * %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.
-					 * %3$s expands to a link on yoast.com, %4$s expands to the anchor end tag.
-					 */
-					i18n.dngettext(
-						"js-text-analysis",
-						"%1$sKeyphrase in meta description%2$s: All words of keyphrase or synonym " +
-						"appear in the meta description, but not within one sentence. " +
-						"%3$sTry to use them in one sentence%4$s."
-					),
-					this._config.urlTitle,
-					"</a>",
-					this._config.urlCallToAction,
-					"</a>"
-
 				),
 			};
 		}

--- a/src/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -67,7 +67,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 */
 	calculateResult( i18n ) {
 
-		// GOOD result when the meta description contains every keyhrase 1 or 2 times (including synonyms).
+		// GOOD result when the meta description contains keyhrase or a synonym 1 or 2 times.
 		if ( this._keyphraseCounts === 1 || this._keyphraseCounts === 2 ) {
 			return {
 				score: this._config.scores.good,

--- a/src/researches/metaDescriptionKeyword.js
+++ b/src/researches/metaDescriptionKeyword.js
@@ -41,20 +41,17 @@ const matchPerSentence = function( sentence, topicForms, locale ) {
 	sentence = replaceFoundKeywordForms( sentence, matchesKeyphrase, fullKeyphraseMatches );
 
 	// Keyphrase synonyms matches.
-	let fullSynonymsMatches = [];
-	if ( topicForms.synonymsForms ) {
-		fullSynonymsMatches = topicForms.synonymsForms.map(
-			synonymForms => {
-				// Synonym keyphrase matches.
-				let matches = synonymForms.map( keywordForms => matchWords( sentence, keywordForms, locale ) );
-				// Count the number of matches that contain every word in the entire synonym keyphrase.
-				const fullSynonymMatches = Math.min( ...matches.map( match => match.count ) );
-				// Replace all full matches so we do not match them for other synonyms.
-				sentence = replaceFoundKeywordForms( sentence, matchesKeyphrase, fullSynonymMatches );
-				return fullSynonymMatches;
-			}
-		);
-	}
+	let fullSynonymsMatches = topicForms.synonymsForms.map(
+		synonymForms => {
+			// Synonym keyphrase matches.
+			let matches = synonymForms.map( keywordForms => matchWords( sentence, keywordForms, locale ) );
+			// Count the number of matches that contain every word in the entire synonym keyphrase.
+			const fullSynonymMatches = Math.min( ...matches.map( match => match.count ) );
+			// Replace all full matches so we do not match them for other synonyms.
+			sentence = replaceFoundKeywordForms( sentence, matchesKeyphrase, fullSynonymMatches );
+			return fullSynonymMatches;
+		}
+	);
 
 	return [ fullKeyphraseMatches, ...fullSynonymsMatches ].reduce( ( sum, count ) => sum + count, 0 );
 };
@@ -71,7 +68,7 @@ export default function( paper, researcher ) {
 	if ( paper.getDescription() === "" ) {
 		return -1;
 	}
-	let description = paper.getDescription();
+	const description = paper.getDescription();
 	const locale = paper.getLocale();
 
 	const topicForms = researcher.getResearch( "morphology" );

--- a/src/researches/metaDescriptionKeyword.js
+++ b/src/researches/metaDescriptionKeyword.js
@@ -65,9 +65,6 @@ const matchPerSentence = function( sentence, topicForms, locale ) {
  * @returns {Number} The number of keyphrase matches for the entire description.
  */
 export default function( paper, researcher ) {
-	if ( paper.getDescription() === "" ) {
-		return -1;
-	}
 	const description = paper.getDescription();
 	const locale = paper.getLocale();
 

--- a/src/researches/metaDescriptionKeyword.js
+++ b/src/researches/metaDescriptionKeyword.js
@@ -6,12 +6,13 @@ import getSentences from "../stringProcessing/getSentences";
  *
  * @param {string} description the description to remove the matched keyword forms from.
  * @param {Object[]} matchedKeywordForms the matched keyword forms to remove from the description.
+ * @param {Number} maxToRemove the maximum amount of matches of each individual keyword to remove.
  * @returns {string} the description with the keywords removed.
  */
 const replaceFoundKeywordForms = function( description, matchedKeywordForms, maxToRemove ) {
 	// Replace matches so we do not match them for synonyms.
 	matchedKeywordForms.forEach( keywordForm =>
-		keywordForm.matches.slice(0, maxToRemove).forEach(
+		keywordForm.matches.slice( 0, maxToRemove ).forEach(
 			match => {
 				description = description.replace( match, "" );
 			}

--- a/src/researches/metaDescriptionKeyword.js
+++ b/src/researches/metaDescriptionKeyword.js
@@ -26,7 +26,7 @@ const replaceFoundKeywordForms = function( description, matchedKeywordForms ) {
  * A full keyphrase is when all keywords in the keyphrase match.
  *
  * @param {string} sentence the sentence that needs to be analyzed.
- * @param {Object}topicForms the keyphrase (and its optional synonyms') word forms.
+ * @param {Object} topicForms the keyphrase (and its optional synonyms') word forms.
  * @param {string} locale the current locale
  * @returns {Number} the number of matched keyphrases in the sentence.
  */

--- a/src/researches/metaDescriptionKeyword.js
+++ b/src/researches/metaDescriptionKeyword.js
@@ -1,5 +1,12 @@
 import matchWords from "../stringProcessing/matchTextWithArray";
 
+/**
+ * Replaces found keyword forms in the given description.
+ *
+ * @param {string} description the description to remove the matched keyword forms from.
+ * @param {Object[]} matchedKeywordForms the matched keyword forms to remove from the description.
+ * @returns {string} the description with the keywords removed.
+ */
 const replaceFoundKeywordForms = function( description, matchedKeywordForms ) {
 	// Replace matches so we do not match them for synonyms.
 	matchedKeywordForms.forEach( keywordForm =>


### PR DESCRIPTION
## Summary
**Note:** tests need to be adapted to the new scoring scheme.

This PR can be summarized in the following changelog entry:

* Changes the meta description keyphrase assessment to only look at the amount of matches in the full description, instead of a combination of per sentence and full description.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Make sure that Premium is active and running.
* Make a new post.
* Enter a keyphrase and one or more synonyms.
* Set the meta description to:
     * A text containing **none** of the words in the keyphrase (or its synonyms):
       * This should give a BAD result:
`The meta description has been specified, but it does not contain the keyphrase. Fix that!`
    * A text containing all of the words in the keyphrase (or its synonyms) **once**:
       * This should give a GOOD result: 
`Keyphrase or synonym appear in the meta description. Well done!`
     * A text containing all of the words in the keyphrase (or its synonyms) **twice**:
        * This should give the same GOOD result as the one above.
   * A text containing all of the words in the keyphrase (or its synonyms) **thrice or more**:
       * This should give a BAD result: 
`The meta description contains the keyphrase 3 times, which is over the advised maximum of 2 times. Limit that!`

Fixes https://github.com/Yoast/wordpress-seo/issues/11303
