### PR TITLE
Fix keyphrase in slug cornerstone score

### DIFF
--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -252,7 +252,7 @@ describe( "running assessments in the assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.noKeywordInUrl ).toBe( 3 );
+			expect( assessment._config.scores.okay ).toBe( 3 );
 		} );
 
 		test( "UrlLengthAssessment", () => {

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -90,7 +90,7 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 		new UrlKeywordAssessment(
 			{
 				scores: {
-					noKeywordInUrl: 3,
+					okay: 3,
 				},
 			}
 		),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where the cornerstone-specific score would not be picked up for the keyphrase in slug assessment

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Create a post and add a slug that does not contain a keyphrase
* You should receive an orange bullet
* Make your post cornerstone
* The bullet should turn red

Fixes #https://github.com/Yoast/wordpress-seo/issues/11325
