### PR TITLE
Add transition words

### DIFF
--- a/spec/helpers/getTransitionWordsSpec.js
+++ b/spec/helpers/getTransitionWordsSpec.js
@@ -1,54 +1,59 @@
 import getTransitionWords from "../../src/helpers/getTransitionWords.js";
 
 describe( "gets transition words, based on language", function() {
-	var properties = [ "transitionWords", "twoPartTransitionWords" ];
+	const properties = [ "transitionWords", "twoPartTransitionWords" ];
 	it( "checks if all properties are set for English", function() {
-		var transitionWords = getTransitionWords( "en_US" );
+		const transitionWords = getTransitionWords( "en_US" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for Spanish", function() {
-		var transitionWords = getTransitionWords( "es_ES" );
+		const transitionWords = getTransitionWords( "es_ES" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for French", function() {
-		var transitionWords = getTransitionWords( "fr_FR" );
+		const transitionWords = getTransitionWords( "fr_FR" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for German", function() {
-		var transitionWords = getTransitionWords( "de_DE" );
+		const transitionWords = getTransitionWords( "de_DE" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for Italian", function() {
-		var transitionWords = getTransitionWords( "it_IT" );
+		const transitionWords = getTransitionWords( "it_IT" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for Portuguese", function() {
-		var transitionWords = getTransitionWords( "pt_PT" );
+		const transitionWords = getTransitionWords( "pt_PT" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for Russian", function() {
-		var transitionWords = getTransitionWords( "ru_RU" );
+		const transitionWords = getTransitionWords( "ru_RU" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for Catalan", function() {
-		var transitionWords = getTransitionWords( "ca_ES" );
+		const transitionWords = getTransitionWords( "ca_ES" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set for Polish", function() {
-		var transitionWords = getTransitionWords( "pl_PL" );
+		const transitionWords = getTransitionWords( "pl_PL" );
+		expect( Object.keys( transitionWords ) ).toEqual( properties );
+	} );
+
+	it( "checks if all properties are set for Swedish", function() {
+		const transitionWords = getTransitionWords( "sv_SE" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
 	it( "checks if all properties are set if no locale is given", function() {
-		var transitionWords = getTransitionWords( "" );
+		const transitionWords = getTransitionWords( "" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 } );

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -369,6 +369,27 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 0 );
 	} );
 
+	it( "returns 1 when a transition word is found in a sentence (Swedish)", function() {
+		// Transition word: Å ena sidan
+		mockPaper = new Paper( "Å ena sidan gillar jag tårta.", { locale: "sv_SE" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+	it( "returns 1 when a two-part transition word is found in a sentence (Swedish)", function() {
+		// Transition word: antingen...eller
+		mockPaper = new Paper( "Jag vill ha antingen tårta eller glass", { locale: "sv_SE" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+	it( "returns 0 when no transition words are present in a sentence (Swedish)", function() {
+		mockPaper = new Paper( "Föräldrarna behöver inte betala..", { locale: "sv_SE" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
+
 	it( "defaults to English in case of a bogus locale", function() {
 		// Transition word: because.
 		mockPaper = new Paper( "Because of a bogus locale.", { locale: "xx_YY" } );

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ import AssessmentResult from "../../values/AssessmentResult";
 import Mark from "../../values/Mark.js";
 import marker from "../../markers/addMark.js";
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl", "sv" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/src/helpers/getTransitionWords.js
+++ b/src/helpers/getTransitionWords.js
@@ -36,8 +36,10 @@ import twoPartTransitionWordsCatalan from "../researches/catalan/twoPartTransiti
 
 import transitionWordsPolishFactory from "../researches/polish/transitionWords.js";
 const transitionWordsPolish = transitionWordsPolishFactory().allWords;
-
 import twoPartTransitionWordsPolish from "../researches/polish/twoPartTransitionWords.js";
+import transitionWordsSwedishFactory from "../researches/swedish/transitionWords.js";
+const transitionWordsSwedish = transitionWordsSwedishFactory().allWords;
+import twoPartTransitionWordsSwedish from "../researches/swedish/twoPartTransitionWords.js";
 import getLanguage from "./getLanguage.js";
 
 /**
@@ -93,6 +95,11 @@ export default function( locale ) {
 			return {
 				transitionWords: transitionWordsPolish,
 				twoPartTransitionWords: twoPartTransitionWordsPolish,
+			};
+		case "sv":
+			return {
+				transitionWords: transitionWordsSwedish,
+				twoPartTransitionWords: twoPartTransitionWordsSwedish,
 			};
 		default:
 		case "en":

--- a/src/researches/swedish/transitionWords.js
+++ b/src/researches/swedish/transitionWords.js
@@ -1,0 +1,38 @@
+/** @module config/transitionWords */
+
+const singleWords = [ "alltså", "ändå", "annars", "ännu", "även", "avslutningsvis", "bl.a.", "d.v.s.", "då", "därefter", "däremot", "därför",
+	"därmed", "dessutom", "dock", "efteråt", "eftersom", "emellertid", "exempelvis", "följaktligen", "förrän", "först",
+	"huvudsakligen", "ifall", "inledningsvis", "innan", "jämförelsevis", "likadant", "likaså", "liksom", "medan", "men",
+	"nämligen", "när", "oavsett", "också", "omvänt", "således", "sålunda", "sammanfattningsvis", "samt", "samtidigt",
+	"särskilt", "såsom", "sist", "slutligen", "speciellt", "t.ex.", "tidigare", "tillika", "tills", "trots",
+	"tvärtemot", "tvärtom", "tydligen", "vidare", "ytterligare" ];
+
+const multipleWords = [ "å andra sidan", "å ena sidan", "allt som allt", "anledningen är", "anledningen blir", "annorlunda än",
+	"av den orsaken", "av detta skäl", "beroende på", "bland annat", "därtill kommer", "det beror på att", "det vill säga",
+	"det visar", "detta beror på", "detta går ut på att", "detta innebär att", "detta medför att", "effekten blir",
+	"efter ett tag", "ej heller", "en effekt av detta", "en förklaring till detta", "ett exempel på detta", "följden blir",
+	"för all del", "för att klargöra", "för att poängtera", "för att säga det på ett annat sätt",
+	"för att understryka", "för det andra", "för det första", "för det tredje",
+	"förr eller senare", "framför allt", "har att göra med", "i båda fallen", "i det fallet", "i det här fallet",
+	"i förhållande till", "i fråga om", "i jämförelse med", "i likhet med", "i ljuset av", "i relation till", "i samband med",
+	"i sin tur", "i själva verket", "i slutändan", "i stället för", "i syfte att", "i synnerhet", "i verkligheten",
+	"icke desto mindre", "ihop med", "inte desto mindre", "jämfört med", "kort sagt", "lika viktigt är", "målet är att",
+	"med andra ord", "med anledning av", "med det i åtanke", "med hänsyn till", "med härledning av", "mot den bakgrunden",
+	"när allt kommer omkring", "när det gäller", "närmare bestämt", "nu när", "orsaken är", "på grund av", "på liknande sätt",
+	"på så sätt", "på samma sätt", "resultatet blir", "så länge som", "så småningom", "så snart som", "sist men inte minst",
+	"slutsatsen blir", "som en följd av", "som ett exempel på", "som ett resultat", "som jag tidigare antytt",
+	"som konklusion kan", "som man kan se", "som nämnt", "som tidigare nämnts", "summa summarum", "tack vare", "till dess",
+	"till exempel", "till en början", "till följd av", "till sist", "tillsammans med", "tvärt om", "under de omständigheterna",
+	"under tiden", "vad mera är", "viktigt att inse", "vilket innebär" ];
+
+/**
+ * Returns an list with transition words to be used by the assessments.
+ * @returns {Object} The list filled with transition word lists.
+ */
+module.exports = function() {
+	return {
+		singleWords: singleWords,
+		multipleWords: multipleWords,
+		allWords: singleWords.concat( multipleWords ),
+	};
+};

--- a/src/researches/swedish/twoPartTransitionWords.js
+++ b/src/researches/swedish/twoPartTransitionWords.js
@@ -1,0 +1,9 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @returns {Array} The array filled with two-part transition words.
+ */
+module.exports = function() {
+	return [ [ "antingen", "eller" ], [ "icke blott", "utan afven" ], [ "ju", "desto" ] ];
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* We should add transition words assessment for Swedish


## Test instructions

This PR can be tested by following these steps:

### Browserified
* Check out the branch
* Build the browserfied example.
* Set locale to sv_SE
* Write a Swedish sentence containing a one or two-part transition word (see list of transition words in the code files)
* Hit the mark transition word sentences button to check if the sentences are correctly marked.

### WordPress
* Create a beta version of the plugin on the stories branch
* In your testing environment, set the language to Swedish ("sv").
* Write a Swedish text.
* Determine that the transition word assessments appears in the list and no error occur.

Fixes #1770
