### PR TITLE
Refactor French participle direct precedence exceptions

### DIFF
--- a/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
+++ b/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
@@ -1,14 +1,14 @@
-import FrenchParticiple from "../../../../src/researches/french/passiveVoice/FrenchParticiple.js";
-import checkException from "../../../../src/researches/passiveVoice/periphrastic/checkException.js";
+import FrenchParticiple from "../../../../src/researches/french/passiveVoice/FrenchParticiple";
+import checkException from "../../../../src/researches/passiveVoice/periphrastic/checkException";
 
 describe( "A test for checking the French participle", function() {
 	it( "checks the properties of the French participle object with a passive", function() {
-		var mockParticiple = new FrenchParticiple( "créée", "fut créée par moi.", { auxiliaries: [ "fut" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "créée", "fut créée par moi.", { auxiliaries: [ "fut" ], type: "regular", language: "fr" } );
 		expect( mockParticiple.getParticiple() ).toBe( "créée" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 4, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 4, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
@@ -19,7 +19,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 13, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 13, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
@@ -30,7 +30,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
@@ -41,40 +41,51 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 11, "fr" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 11, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a noun exception ending in é and beginning with a contracted article", function() {
-		const mockParticiple = new FrenchParticiple( "l'intégrité", "Est-ce que la création de cet outil contribuera à améliorer l’intégrité scientifique ?", { auxiliaries: [ "est-ce" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple(
+			"l'intégrité", "Est-ce que la création de cet outil contribuera à améliorer l’intégrité scientifique ?",
+			{ auxiliaries: [ "est-ce" ], type: "regular", language: "fr" },
+		);
 		expect( mockParticiple.getParticiple() ).toBe( "l'intégrité" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 60, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 60, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a noun exception ending in é plus suffix", function() {
-		const mockParticiple = new FrenchParticiple( "cafés", "étaient les deux cafés du village.", { auxiliaries: [ "étaient" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "cafés", "étaient les deux cafés du village.", {
+			auxiliaries: [ "étaient" ],
+			type: "regular",
+			language: "fr",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "cafés" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 17, "fr" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 17, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with an exception from the other list ending in é", function() {
-		const mockParticiple = new FrenchParticiple( "malgré", "était triste malgré tout.", { auxiliaries: [ "était" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "malgré", "était triste malgré tout.", {
+			auxiliaries: [ "était" ],
+			type: "regular",
+			language: "fr",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "malgré" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( true );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
@@ -82,29 +93,41 @@ describe( "A test for checking the French participle", function() {
 	it( "checks the properties of the French participle object with a direct precedence exception", function() {
 		// Direct precedence exception word: en.
 		const mockParticiple = new FrenchParticiple( "vue", "C'est en vue.", { auxiliaries: [ "c'est" ], type: "irregular", language: "fr" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 9, "fr" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 9, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a precedence exception (indirectly preceding)", function() {
 		// Precedence exception word: avoir (in between "n'est" and "vu").
-		const mockParticiple = new FrenchParticiple( "vu", "n'est pas possible de l'avoir déjà vu.", { auxiliaries: [ "n'est" ], type: "irregular", language: "fr" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 35, "fr" ) ).toBe( false );
+		const mockParticiple = new FrenchParticiple( "vu", "n'est pas possible de l'avoir déjà vu.", {
+			auxiliaries: [ "n'est" ],
+			type: "irregular",
+			language: "fr",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 35, "fr" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a precedence exception (directly preceding)", function() {
 		// Precedence exception word: avoir (in between "n'est" and "vu").
-		const mockParticiple = new FrenchParticiple( "vu", "n'est pas nécessaire d'avoir vu le premier film", { auxiliaries: [ "n'est" ], type: "irregular", language: "fr" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 29, "fr" ) ).toBe( false );
+		const mockParticiple = new FrenchParticiple( "vu", "n'est pas nécessaire d'avoir vu le premier film", {
+			auxiliaries: [ "n'est" ],
+			type: "irregular",
+			language: "fr",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 29, "fr" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		const mockParticiple = new FrenchParticiple( "cuisiné", "Ça a été cuisiné par lui.", { auxiliaries: [ "été" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "cuisiné", "Ça a été cuisiné par lui.", {
+			auxiliaries: [ "été" ],
+			type: "regular",
+			language: "fr",
+		} );
 		mockParticiple._participle = null;
 		checkException.call( mockParticiple );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );

--- a/spec/researches/polish/passiveVoice/PolishParticipleSpec.js
+++ b/spec/researches/polish/passiveVoice/PolishParticipleSpec.js
@@ -1,6 +1,5 @@
 import PolishParticiple from "../../../../src/researches/polish/passiveVoice/PolishParticiple.js";
 import checkException from "../../../../src/researches/passiveVoice/periphrastic/checkException.js";
-import getWords from "../../../../src/stringProcessing/getWords";
 
 describe( "A test for checking the Polish participle", function() {
 	it( "checks the properties of the Polish participle object with a passive", function() {
@@ -9,10 +8,9 @@ describe( "A test for checking the Polish participle", function() {
 			type: "irregular",
 			language: "pl",
 		} );
-		const wordsInSentencePart = getWords( mockParticiple._sentencePart );
 
 		expect( mockParticiple.getParticiple() ).toBe( "napisana" );
-		expect( mockParticiple.directPrecedenceException( wordsInSentencePart, 2, "pl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "pl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -23,10 +21,9 @@ describe( "A test for checking the Polish participle", function() {
 			type: "irregular",
 			language: "pl",
 		} );
-		const wordsInSentencePart = getWords( mockParticiple._sentencePart );
 
 		expect( mockParticiple.getParticiple() ).toBe( "znalezione" );
-		expect( mockParticiple.directPrecedenceException( wordsInSentencePart, 3, "pl" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "pl" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 

--- a/src/researches/french/passiveVoice/FrenchParticiple.js
+++ b/src/researches/french/passiveVoice/FrenchParticiple.js
@@ -49,20 +49,20 @@ var checkIrregular = function() {
  */
 FrenchParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
-	const wordsInSentencePart = getWords( sentencePart );
-	const participleIndex = wordsInSentencePart.indexOf( this.getParticiple() );
+	const participle = this.getParticiple();
+	const participleIndex = sentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
 	// Only check precedence exceptions for irregular participles.
 	if ( checkIrregular.call( this ) ) {
-		return ! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
+		return ! this.directPrecedenceException( sentencePart, participle, language ) &&
 			! this.precedenceException( sentencePart, participleIndex, language );
 	}
 	// Check precedence exceptions and exception lists for regular participles.
 	return ! this.isOnAdjectivesVerbsExceptionList() &&
 		! this.isOnNounsExceptionList() &&
 		! this.isOnOthersExceptionList() &&
-		! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
+		! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.precedenceException( sentencePart, participleIndex, language );
 };
 

--- a/src/researches/french/passiveVoice/FrenchParticiple.js
+++ b/src/researches/french/passiveVoice/FrenchParticiple.js
@@ -1,20 +1,18 @@
-import Participle from "../../../values/Participle.js";
-import checkException from "../../passiveVoice/periphrastic/checkException.js";
-import directPrecedenceException from "../../../stringProcessing/directPrecedenceException";
+import { forEach, includes, memoize } from "lodash-es";
+
+import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
+import getWords from "../../../stringProcessing/getWords";
 import precedenceException from "../../../stringProcessing/precedenceException";
+import Participle from "../../../values/Participle";
+import checkException from "../../passiveVoice/periphrastic/checkException";
+import exceptionsParticiplesFactory from "./exceptionsParticiples";
 
-import exceptionsParticiplesAdjectivesVerbsFactory from "./exceptionsParticiples.js";
-var exceptionsParticiplesAdjectivesVerbs = exceptionsParticiplesAdjectivesVerbsFactory().adjectivesVerbs;
-import exceptionsParticiplesNounsVowelFactory from "./exceptionsParticiples.js";
-var exceptionsParticiplesNounsVowel = exceptionsParticiplesNounsVowelFactory().nounsStartingWithVowel;
-import exceptionsParticiplesNounsConsonantFactory from "./exceptionsParticiples.js";
-var exceptionsParticiplesNounsConsonant = exceptionsParticiplesNounsConsonantFactory().nounsStartingWithConsonant;
-import exceptionsParticiplesOthersFactory from "./exceptionsParticiples.js";
-var exceptionsParticiplesOthers = exceptionsParticiplesOthersFactory().others;
-
-import { includes } from "lodash-es";
-import { forEach } from "lodash-es";
-import { memoize } from "lodash-es";
+const {
+	adjectivesVerbs: exceptionsParticiplesAdjectivesVerbs,
+	nounsStartingWithVowel: exceptionsParticiplesNounsVowel,
+	nounsStartingWithConsonant: exceptionsParticiplesNounsConsonant,
+	others: exceptionsParticiplesOthers,
+} = exceptionsParticiplesFactory();
 
 /**
  * Creates an Participle object for the French language.
@@ -51,19 +49,20 @@ var checkIrregular = function() {
  */
 FrenchParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
-	const participleIndex = sentencePart.indexOf( this.getParticiple() );
+	const wordsInSentencePart = getWords( sentencePart );
+	const participleIndex = wordsInSentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
 	// Only check precedence exceptions for irregular participles.
 	if ( checkIrregular.call( this ) ) {
-		return ! this.directPrecedenceException( sentencePart, participleIndex, language ) &&
+		return ! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
 			! this.precedenceException( sentencePart, participleIndex, language );
 	}
 	// Check precedence exceptions and exception lists for regular participles.
 	return ! this.isOnAdjectivesVerbsExceptionList() &&
 		! this.isOnNounsExceptionList() &&
 		! this.isOnOthersExceptionList() &&
-		! this.directPrecedenceException( sentencePart, participleIndex, language ) &&
+		! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
 		! this.precedenceException( sentencePart, participleIndex, language );
 };
 

--- a/src/researches/polish/passiveVoice/PolishParticiple.js
+++ b/src/researches/polish/passiveVoice/PolishParticiple.js
@@ -1,7 +1,6 @@
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import getWords from "../../../stringProcessing/getWords";
 import nonDirectPrecedenceException from "../../passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/nonDirectParticiplePrecedenceException";
 
 /**
@@ -30,12 +29,9 @@ PolishParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
 	const participle = this.getParticiple();
 	const auxiliaries = this.getAuxiliaries();
-
-	const wordsInSentencePart = getWords( sentencePart );
-	const participleIndex = wordsInSentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
-	return ! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
+	return ! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.nonDirectPrecedenceException( sentencePart, participle, auxiliaries, language );
 };
 

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -1,31 +1,50 @@
-import cannotDirectlyPrecedePassiveParticiplePolishFactory from "../researches/polish/functionWords.js";
-const cannotDirectlyPrecedePassiveParticiplePolish = cannotDirectlyPrecedePassiveParticiplePolishFactory().cannotDirectlyPrecedePassiveParticiple;
+import { get } from "lodash-es";
+import functionWordsDutchFactory from "../researches/dutch/functionWords";
+import functionWordsEnglishFactory from "../researches/english/functionWords";
+import functionWordsFrenchFactory from "../researches/french/functionWords";
+import functionWordsItalianFactory from "../researches/italian/functionWords";
+import functionWordsPolishFactory from "../researches/polish/functionWords";
+import functionWordsSpanishFactory from "../researches/spanish/functionWords";
+import getWords from "../stringProcessing/getWords";
+
+const cannotDirectlyPrecedePassiveParticiples = {
+	nl: functionWordsDutchFactory().cannotDirectlyPrecedePassiveParticiple,
+	en: functionWordsEnglishFactory().cannotDirectlyPrecedePassiveParticiple,
+	fr: functionWordsFrenchFactory().cannotDirectlyPrecedePassiveParticiple,
+	it: functionWordsItalianFactory().cannotDirectlyPrecedePassiveParticiple,
+	pl: functionWordsPolishFactory().cannotDirectlyPrecedePassiveParticiple,
+	es: functionWordsSpanishFactory().cannotDirectlyPrecedePassiveParticiple,
+};
 
 /**
  * Checks whether the participle is directly preceded by a word from the direct precedence exception list.
  * If this is the case, the sentence part is not passive.
  *
- * @param {string[]} wordsInSentencePart The words in the sentence part that contains the participle.
- * @param {number}   participleIndex     The index of the participle.
- * @param {string}   language            The language of the participle.
+ * @param {string} sentencePart The sentence part that contains the participle.
+ * @param {string} participle   The participle.
+ * @param {string} language     The language of the participle.
  *
  * @returns {boolean} Returns true if a word from the direct precedence exception list is directly preceding
- * the participle, otherwise returns false.
+ *                    the participle, otherwise returns false.
  */
-export default function( wordsInSentencePart, participleIndex, language ) {
-	// If the participle is the first word, there can't be a word before that.
-	if ( participleIndex === 0 ) {
+export default function( sentencePart, participle, language ) {
+	// Break the sentence part up into words.
+	const wordsInSentencePart = getWords( sentencePart );
+
+	// Search the participle in the word list.
+	const participleIndex = wordsInSentencePart.indexOf( participle );
+
+	// If there is no participle found in the word list, this can not be an exception either.
+	if ( participleIndex === -1 ) {
 		return false;
 	}
+
 	const wordPrecedingParticiple = wordsInSentencePart[ participleIndex - 1 ];
 
-	let directPrecedenceExceptions = [];
-	switch ( language ) {
-		case "pl":
-			directPrecedenceExceptions = cannotDirectlyPrecedePassiveParticiplePolish;
-			break;
-	}
+	// Get the exceptions word list.
+	const directPrecedenceExceptions = get( cannotDirectlyPrecedePassiveParticiples, language, [] );
 
+	// Check if the word preceding the participle is in the exceptions list.
 	for ( let i = 0; i < directPrecedenceExceptions.length; i++ ) {
 		if ( directPrecedenceExceptions[ i ].includes( wordPrecedingParticiple ) ) {
 			return true;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Chrome or Opera browser tab would crash on Windows when a French text contains sentences in passive voice.

## Relevant technical choices:

* Replace the giant RegExp with a for loop with includes in array check (which was created for Polish).

## Test instructions

This PR can be tested by following these steps:

* On Windows 10, in the Chrome browser.
* Change WP Site Language to French (Français).
* Create a New Post/Page and enter French content (you may get content from FR wiki or just use Google Translate).

Fixes https://github.com/Yoast/wordpress-seo/issues/11356
