### PR TITLE
Optimize dynamically created regex, possibly fixing Chrome70 crash

### DIFF
--- a/spec/helpers/syllableCountSpec.js
+++ b/spec/helpers/syllableCountSpec.js
@@ -18,7 +18,7 @@ describe( "A test for creating a language syllable regex", function() {
 		expect( languageSyllableRegex.getRegex() ).toEqual( /(a)/gi );
 	} );
 
-	it( "creates an language syllable regex with a +1 multiplier", function() {
+	it( "creates an language syllable regex with a -2 multiplier", function() {
 		var mockSyllables = {
 			fragments: [ "ee" ],
 			countModifier: -2,

--- a/spec/helpers/syllableCountSpec.js
+++ b/spec/helpers/syllableCountSpec.js
@@ -15,7 +15,7 @@ describe( "A test for creating a language syllable regex", function() {
 		expect( languageSyllableRegex.countSyllables( "a" ) ).toBe( 1 );
 		expect( languageSyllableRegex.countSyllables( "b" ) ).toBe( 0 );
 
-		expect( languageSyllableRegex.getRegex() ).toEqual( /(a)/gi );
+		expect( languageSyllableRegex.getRegex() ).toEqual( /a/gi );
 	} );
 
 	it( "creates an language syllable regex with a -2 multiplier", function() {
@@ -26,7 +26,7 @@ describe( "A test for creating a language syllable regex", function() {
 		var languageSyllableRegex = new LanguageSyllableRegex( mockSyllables );
 		expect( languageSyllableRegex.countSyllables( "been seen" ) ).toBe( -4 );
 
-		expect( languageSyllableRegex.getRegex() ).toEqual( /(ee)/gi );
+		expect( languageSyllableRegex.getRegex() ).toEqual( /ee/gi );
 	} );
 } );
 

--- a/src/stringProcessing/createRegexFromArray.js
+++ b/src/stringProcessing/createRegexFromArray.js
@@ -2,8 +2,6 @@
 
 import addWordBoundary from "../stringProcessing/addWordboundary.js";
 
-import { map } from "lodash-es";
-
 /**
  * Creates a regex of combined strings from the input array.
  *
@@ -11,18 +9,14 @@ import { map } from "lodash-es";
  * @param {boolean} [disableWordBoundary] Boolean indicating whether or not to disable word boundaries
  * @returns {RegExp} regex The regex created from the array.
  */
-export default function( array, disableWordBoundary ) {
-	var regexString;
-	var _disableWordBoundary = disableWordBoundary || false;
+export default function( array, disableWordBoundary = false ) {
+	let regexString;
 
-	var boundedArray = map( array, function( string ) {
-		if ( _disableWordBoundary ) {
-			return string;
-		}
-		return addWordBoundary( string, true );
-	} );
+	regexString = array.join( "|" );
 
-	regexString = "(" + boundedArray.join( ")|(" ) + ")";
+	if ( ! disableWordBoundary ) {
+		regexString = addWordBoundary( "(" + regexString + ")", true );
+	}
 
 	return new RegExp( regexString, "ig" );
 }

--- a/src/stringProcessing/createRegexFromDoubleArray.js
+++ b/src/stringProcessing/createRegexFromDoubleArray.js
@@ -1,18 +1,7 @@
 /** @module stringProcessing/createRegexFromDoubleArray */
 
 import addWordBoundary from "../stringProcessing/addWordboundary.js";
-
-/**
- * Creates a regex string of combined strings from the input array.
- * @param {array} array The array containing the various parts of a transition word combination.
- * @returns {array} The array with replaced entries.
- */
-var wordCombinationToRegexString = function( array ) {
-	array = array.map( function( word ) {
-		return addWordBoundary( word );
-	} );
-	return array.join( "(.*?)" );
-};
+import { forEach } from "lodash-es";
 
 /**
  * Creates a regex of combined strings from the input array, containing arrays with two entries.
@@ -20,9 +9,13 @@ var wordCombinationToRegexString = function( array ) {
  * @returns {RegExp} The regex created from the array.
  */
 export default function( array ) {
-	array = array.map( function( wordCombination ) {
-		return wordCombinationToRegexString( wordCombination );
+	const first = [];
+	const second = [];
+	forEach( array, ( [ a, b ] ) => {
+		first.push( a );
+		second.push( b );
 	} );
-	var regexString = "(" + array.join( ")|(" ) + ")";
+	const regexString = addWordBoundary( "(" + first.join( "|" ) + ")" ) +
+		".*?" + addWordBoundary( "(" + second.join( "|" ) + ")" );
 	return new RegExp( regexString, "ig" );
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Optimize dynamically created regex

## Relevant technical choices:

The current code produces horribly long regular expression because the word boundary pattern is repeated for each single word. The list of words [may contain hundreds of words](https://github.com/Yoast/YoastSEO.js/blob/v1.41.0/src/stringProcessing/directPrecedenceException.js#L45), leading to regular expressions tens of thousands characters long.
There should be no need to repeat the word boundary pattern: applying it globally once should be enough.

I have however a few questions:

- Should both createRegexFromArray.js and createRegexFromDoubleArray.js refactored in a single file to avoid code duplication? Is it worth it?
- Why don't I get a failure for https://github.com/Yoast/YoastSEO.js/blob/5799f87432fda39e08f9dd2f71ab0d2bf5f3cebe/spec/stringProcessing/createRegexFromArray.js when I run `npm test`? Is it because I don't have the `premium-configuration` module?
- I had to fix `syllableCountSpec.js` because it had an hard coded check of the actual regexp syntax used, is that really needed? I think it might be more useful to test some configurations a little bit more complex, for example with more fragments than one.

It looks like this optimization fixes https://github.com/Yoast/wordpress-seo/issues/11356
