### PR TITLE
1854 improve example add assessor switching

### DIFF
--- a/examples/webpack/src/App.js
+++ b/examples/webpack/src/App.js
@@ -90,7 +90,7 @@ class App extends React.Component {
 			.then( ( { result } ) => {
 				setWorkerStatus( "idling" );
 
-				this.props.setResults( formatAnalyzeResult( result ) );
+				this.props.setResults( formatAnalyzeResult( result, "" ) );
 			} );
 	}
 
@@ -166,7 +166,7 @@ class App extends React.Component {
 
 					<li>Performance information</li>
 					<li>Re-order collapsibles</li>
-					<li>Add button to trigger a ton of analyses continiously. This can be used to check for performance & memory leaks.</li>
+					<li>Add button to trigger a ton of analyses continuously. This can be used to check for performance & memory leaks.</li>
 				</ul>
 
 				Design Todos:

--- a/examples/webpack/src/App.js
+++ b/examples/webpack/src/App.js
@@ -102,13 +102,13 @@ class App extends React.Component {
 				<h1>YoastSEO.js development tool</h1>
 
 				<Columns minWidth="768px">
-					<ColumnLeft>
+					<ColumnLeft minWidth="768px">
 						<Collapsible title="Input">
 							<Inputs />
 						</Collapsible>
 					</ColumnLeft>
 
-					<ColumnRight>
+					<ColumnRight minWidth="768px">
 						<Collapsible title="Results">
 							<Results />
 						</Collapsible>

--- a/examples/webpack/src/App.js
+++ b/examples/webpack/src/App.js
@@ -1,6 +1,5 @@
 // External dependencies.
 import React, { Fragment } from "react";
-import styled from "styled-components";
 
 // YoastSEO.js dependencies.
 import testPapers from "yoastspec/fullTextTests/testTexts";
@@ -19,25 +18,7 @@ import { setConfigurationAttribute } from "./redux/actions/configuration";
 import Inputs from "./components/Inputs";
 import { setStatus } from "./redux/actions/worker";
 import formatAnalyzeResult from "./utils/formatAnalyzeResult";
-
-const FlexContainer = styled.div`
-	@media (min-width: 768px) {
-		display: flex;
-		align-content: space-between;
-	}
-`;
-const LeftContentContainer = styled.div`
-	flex: 1;
-	@media (min-width: 768px) {
-		padding-right: 10px;
-	}
-`;
-const RightContentContainer = styled.div`
-	flex: 1;
-	@media (min-width: 768px) {
-		padding-left: 10px;
-	}
-`;
+import { ColumnLeft, ColumnRight, Columns } from "./components/Columns";
 
 class App extends React.Component {
 	/**
@@ -120,19 +101,19 @@ class App extends React.Component {
 			<Fragment>
 				<h1>YoastSEO.js development tool</h1>
 
-				<FlexContainer>
-					<LeftContentContainer>
+				<Columns minWidth="768px">
+					<ColumnLeft>
 						<Collapsible title="Input">
 							<Inputs />
 						</Collapsible>
-					</LeftContentContainer>
+					</ColumnLeft>
 
-					<RightContentContainer>
+					<ColumnRight>
 						<Collapsible title="Results">
 							<Results />
 						</Collapsible>
-					</RightContentContainer>
-				</FlexContainer>
+					</ColumnRight>
+				</Columns>
 
 				<Collapsible title="Markings">
 					<Markings />

--- a/examples/webpack/src/App.js
+++ b/examples/webpack/src/App.js
@@ -113,7 +113,7 @@ class App extends React.Component {
 	/**
 	 * Renders the app.
 	 *
-	 * @returns {ReactElement} The app.
+	 * @returns {React.Element} The app.
 	 */
 	render() {
 		return (

--- a/examples/webpack/src/components/Columns.js
+++ b/examples/webpack/src/components/Columns.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+export const ColumnLeft = styled.div`
+	flex: 1;
+	@media (min-width: 768px) {
+		padding-left: 10px;
+	}
+`;
+
+export const ColumnRight = styled.div`
+	flex: 1;
+	@media (min-width: 768px) {
+		padding-left: 10px;
+		padding-right: 10px;
+	}
+`;
+
+export const Columns = styled.div`
+	@media (min-width: ${ props => props.minWidth }) {
+		display: flex;
+		align-content: space-between;
+	}
+`;
+

--- a/examples/webpack/src/components/Columns.js
+++ b/examples/webpack/src/components/Columns.js
@@ -2,16 +2,15 @@ import styled from "styled-components";
 
 export const ColumnLeft = styled.div`
 	flex: 1;
-	@media (min-width: 768px) {
-		padding-left: 10px;
+	@media (min-width: ${ props => props.minWidth }) {
+		padding-right: 10px;
 	}
 `;
 
 export const ColumnRight = styled.div`
 	flex: 1;
-	@media (min-width: 768px) {
+	@media (min-width: ${ props => props.minWidth }) {
 		padding-left: 10px;
-		padding-right: 10px;
 	}
 `;
 

--- a/examples/webpack/src/components/Container.js
+++ b/examples/webpack/src/components/Container.js
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export default styled.div`
+	margin-top: ${ props => props.marginTop ? props.marginTop : "16px" };
+`;

--- a/examples/webpack/src/components/Controls.js
+++ b/examples/webpack/src/components/Controls.js
@@ -1,22 +1,29 @@
 /* External */
+import { noop } from "lodash-es";
 import React, { Fragment } from "react";
 import { connect } from "react-redux";
+import Toggle from "yoast-components/composites/Plugin/Shared/components/Toggle";
 
 /* Internal */
-import Button from "./Button";
+import { setConfigurationAttribute } from "../redux/actions/configuration";
 import { clearStorage } from "../redux/utils/localstorage";
 import AutomaticAnalysis from "./AutomaticAnalysis";
-import { setConfigurationAttribute } from "../redux/actions/configuration";
-import Toggle from "yoast-components/composites/Plugin/Shared/components/Toggle";
-import { noop } from "lodash-es";
+import Button from "./Button";
+import Container from "./Container";
 
 function clearStorageAction() {
 	clearStorage();
 	window.location.reload();
 }
 
-function Controls( { useKeywordDistribution, onInitialize, onAnalyze,
-					   onAnalyzeSpam, setConfigurationAttribute: setConfigAttribute } ) {
+function Controls( {
+	useKeywordDistribution,
+	useTaxonomy,
+	onInitialize,
+	onAnalyze,
+	onAnalyzeSpam,
+	setConfigurationAttribute: setConfigAttribute,
+} ) {
 	return <Fragment>
 		<div className="button-container">
 			<AutomaticAnalysis />
@@ -29,15 +36,28 @@ function Controls( { useKeywordDistribution, onInitialize, onAnalyze,
 
 		<h2>Configuration</h2>
 
-		<Toggle
-			id="toggle-use-keyword-distribution"
-			labelText="Use keyphrase distribution"
-			isEnabled={ useKeywordDistribution }
-			onSetToggleState={ value => {
-				setConfigAttribute( "useKeywordDistribution", value );
-			} }
-			onToggleDisabled={ noop }
-		/>
+		<Container>
+			<Toggle
+				id="toggle-use-keyword-distribution"
+				labelText="Use keyphrase distribution"
+				isEnabled={ useKeywordDistribution }
+				onSetToggleState={ value => {
+					setConfigAttribute( "useKeywordDistribution", value );
+				} }
+				onToggleDisabled={ noop }
+			/>
+		</Container>
+		<Container>
+			<Toggle
+				id="toggle-use-taxonomy"
+				labelText="Is taxonomy page"
+				isEnabled={ useTaxonomy }
+				onSetToggleState={ value => {
+					setConfigAttribute( "useTaxonomy", value );
+				} }
+				onToggleDisabled={ noop }
+			/>
+		</Container>
 	</Fragment>;
 }
 
@@ -45,6 +65,7 @@ export default connect(
 	( state ) => {
 		return {
 			useKeywordDistribution: state.configuration.useKeywordDistribution,
+			useTaxonomy: state.configuration.useTaxonomy,
 		};
 	},
 	( dispatch ) => {

--- a/examples/webpack/src/components/Controls.js
+++ b/examples/webpack/src/components/Controls.js
@@ -15,7 +15,8 @@ function clearStorageAction() {
 	window.location.reload();
 }
 
-function Controls( { useKeywordDistribution, onInitialize, onAnalyze, onAnalyzeSpam, setConfigurationAttribute: setConfigAttribute } ) {
+function Controls( { useKeywordDistribution, onInitialize, onAnalyze,
+					   onAnalyzeSpam, setConfigurationAttribute: setConfigAttribute } ) {
 	return <Fragment>
 		<div className="button-container">
 			<AutomaticAnalysis />

--- a/examples/webpack/src/components/Controls.js
+++ b/examples/webpack/src/components/Controls.js
@@ -18,7 +18,6 @@ function clearStorageAction() {
 
 function Controls( {
 	useKeywordDistribution,
-	useTaxonomy,
 	onInitialize,
 	onAnalyze,
 	onAnalyzeSpam,
@@ -47,17 +46,6 @@ function Controls( {
 				onToggleDisabled={ noop }
 			/>
 		</Container>
-		<Container>
-			<Toggle
-				id="toggle-use-taxonomy"
-				labelText="Is a taxonomy page"
-				isEnabled={ useTaxonomy }
-				onSetToggleState={ value => {
-					setConfigAttribute( "useTaxonomy", value );
-				} }
-				onToggleDisabled={ noop }
-			/>
-		</Container>
 	</Fragment>;
 }
 
@@ -65,7 +53,6 @@ export default connect(
 	( state ) => {
 		return {
 			useKeywordDistribution: state.configuration.useKeywordDistribution,
-			useTaxonomy: state.configuration.useTaxonomy,
 		};
 	},
 	( dispatch ) => {

--- a/examples/webpack/src/components/Controls.js
+++ b/examples/webpack/src/components/Controls.js
@@ -50,7 +50,7 @@ function Controls( {
 		<Container>
 			<Toggle
 				id="toggle-use-taxonomy"
-				labelText="Is taxonomy page"
+				labelText="Is a taxonomy page"
 				isEnabled={ useTaxonomy }
 				onSetToggleState={ value => {
 					setConfigAttribute( "useTaxonomy", value );

--- a/examples/webpack/src/components/Input.js
+++ b/examples/webpack/src/components/Input.js
@@ -1,9 +1,9 @@
-import React from "react";
-import PropTypes from "prop-types";
 import { isFunction, noop } from "lodash-es";
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
 
 import { H3 } from "./headings";
-import styled from "styled-components";
 
 const TextInput = styled.input`
 	flex: 0 1 100%;

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -56,7 +56,7 @@ function Inputs( props ) {
 		<Container>
 			<Toggle
 				id="toggle-use-cornerstone"
-				labelText="Is cornerstone article"
+				labelText="Is a cornerstone article"
 				isEnabled={ props.useCornerstone }
 				onSetToggleState={ value => {
 					props.setConfigurationAttribute( "useCornerstone", value );

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -36,6 +36,17 @@ function Inputs( props ) {
 	return <section>
 		{ renderPaperAttribute( props, "text", "Write a text", null, null, TextArea ) }
 		{ renderPaperAttribute( props, "keyword", "Choose a focus keyword", "Focus keyphrase" ) }
+		<ToggleContainer>
+			<Toggle
+				id="toggle-is-related-keyword"
+				labelText="Is a related keyphrase"
+				isEnabled={ props.isRelatedKeyphrase }
+				onSetToggleState={ value => {
+					props.setConfigurationAttribute( "isRelatedKeyphrase", value );
+				} }
+				onToggleDisabled={ noop }
+			/>
+		</ToggleContainer>
 		{ renderPaperAttribute( props, "synonyms", "Choose keyword synonyms" ) }
 		{ renderPaperAttribute( props, "title", "Write the SEO title", null, ( id, value ) => {
 			props.setPaperAttribute( id, value );
@@ -57,7 +68,7 @@ function Inputs( props ) {
 		</ToggleContainer>
 		<ToggleContainer>
 			<Toggle
-				id="toggle-use-cornerstone"
+				id="toggle-use-taxonomy"
 				labelText="Is taxonomy page"
 				isEnabled={ props.useTaxonomy }
 				onSetToggleState={ value => {
@@ -75,6 +86,7 @@ export default connect(
 			paper: state.paper,
 			useCornerstone: state.configuration.useCornerstone,
 			useTaxonomy: state.configuration.useTaxonomy,
+			isRelatedKeyphrase: state.configuration.isRelatedKeyphrase,
 		};
 	},
 	( dispatch ) => {

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -55,6 +55,17 @@ function Inputs( props ) {
 				onToggleDisabled={ noop }
 			/>
 		</ToggleContainer>
+		<ToggleContainer>
+			<Toggle
+				id="toggle-use-cornerstone"
+				labelText="Is taxonomy page"
+				isEnabled={ props.useTaxonomy }
+				onSetToggleState={ value => {
+					props.setConfigurationAttribute( "useTaxonomy", value );
+				} }
+				onToggleDisabled={ noop }
+			/>
+		</ToggleContainer>
 	</section>;
 }
 
@@ -63,6 +74,7 @@ export default connect(
 		return {
 			paper: state.paper,
 			useCornerstone: state.configuration.useCornerstone,
+			useTaxonomy: state.configuration.useTaxonomy,
 		};
 	},
 	( dispatch ) => {

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -11,6 +11,7 @@ import Container from "./Container";
 import Input from "./Input";
 import TextArea from "./TextArea";
 import { ColumnLeft, ColumnRight, Columns } from "./Columns";
+import { H3 } from "./headings";
 
 function renderPaperAttribute( props, id, placeholder, label = null, onChange = null, Component = Input, defaultValue = "" ) {
 	if ( onChange === null ) {
@@ -47,7 +48,14 @@ function renderLeftColumn( props ) {
 			props.setPaperAttribute( id, value );
 			props.setPaperAttribute( "titleWidth", measureTextWidth( value ) );
 		} ) }
-		{ renderPaperAttribute( props, "description", "Write a meta description", "Meta description" ) }
+		<TextArea
+			id="description"
+			value={ props.paper.description }
+			label="Meta description"
+			placeholder="Write a meta description"
+			onChange={ props.setPaperAttribute }
+			minHeight="80px"
+		/>
 		{ renderPaperAttribute( props, "url", "Choose a slug", "Slug", ( id, value ) => {
 			props.setPaperAttribute( id, value );
 			props.setPaperAttribute( "permalink", `${window.location.origin}/${value}` );
@@ -58,13 +66,25 @@ function renderLeftColumn( props ) {
 
 function renderRightColumn( props ) {
 	return <section>
+		<H3>Feature toggles</H3>
 		<Container>
 			<Toggle
 				id="toggle-is-related-keyword"
-				labelText="Is a Cornerstone article"
+				labelText="Is a cornerstone article"
 				isEnabled={ props.useCornerstone }
 				onSetToggleState={ value => {
 					props.setConfigurationAttribute( "useCornerstone", value );
+				} }
+				onToggleDisabled={ noop }
+			/>
+		</Container>
+		<Container>
+			<Toggle
+				id="toggle-use-taxonomy"
+				labelText="Is a taxonomy page"
+				isEnabled={ props.useTaxonomy }
+				onSetToggleState={ value => {
+					props.setConfigurationAttribute( "useTaxonomy", value );
 				} }
 				onToggleDisabled={ noop }
 			/>
@@ -75,11 +95,11 @@ function renderRightColumn( props ) {
 function Inputs( props ) {
 	return <Fragment>
 		{ renderPaperAttribute( props, "text", "Write a text", null, null, TextArea ) }
-		<Columns minWidth="1000px">
-			<ColumnLeft>
+		<Columns minWidth="1400px">
+			<ColumnLeft minWidth="1400px">
 				{ renderLeftColumn( props ) }
 			</ColumnLeft>
-			<ColumnRight>
+			<ColumnRight minWidth="1400px">
 				{ renderRightColumn( props ) }
 			</ColumnRight>
 		</Columns>
@@ -92,6 +112,7 @@ export default connect(
 			paper: state.paper,
 			useCornerstone: state.configuration.useCornerstone,
 			isRelatedKeyphrase: state.configuration.isRelatedKeyphrase,
+			useTaxonomy: state.configuration.useTaxonomy,
 		};
 	},
 	( dispatch ) => {

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -1,12 +1,20 @@
 import React from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { capitalize } from "lodash-es";
+import { capitalize, noop } from "lodash-es";
+import styled from "styled-components";
+
+import Toggle from "yoast-components/composites/Plugin/Shared/components/Toggle";
 
 import Input from "./Input";
 import TextArea from "./TextArea";
 import { setPaperAttribute } from "../redux/actions/paper";
 import measureTextWidth from "../utils/measureTextWidth";
+import { setConfigurationAttribute } from "../redux/actions/configuration";
+
+const ToggleContainer = styled.div`
+	margin-top: 8px;
+`;
 
 function renderPaperAttribute( props, id, placeholder, label = null, onChange = null, Component = Input, defaultValue = "" ) {
 	if ( onChange === null ) {
@@ -36,6 +44,17 @@ function Inputs( props ) {
 		{ renderPaperAttribute( props, "description", "Write a meta description" ) }
 		{ renderPaperAttribute( props, "permalink", "Choose a slug", "Slug" ) }
 		{ renderPaperAttribute( props, "locale", "en_US" ) }
+		<ToggleContainer>
+			<Toggle
+				id="toggle-use-cornerstone"
+				labelText="Is cornerstone article"
+				isEnabled={ props.useCornerstone }
+				onSetToggleState={ value => {
+					props.setConfigurationAttribute( "useCornerstone", value );
+				} }
+				onToggleDisabled={ noop }
+			/>
+		</ToggleContainer>
 	</section>;
 }
 
@@ -43,11 +62,13 @@ export default connect(
 	( state ) => {
 		return {
 			paper: state.paper,
+			useCornerstone: state.configuration.useCornerstone,
 		};
 	},
 	( dispatch ) => {
 		return bindActionCreators( {
 			setPaperAttribute,
+			setConfigurationAttribute,
 		}, dispatch );
 	}
 )( Inputs );

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -1,20 +1,15 @@
-import React from "react";
-import { bindActionCreators } from "redux";
-import { connect } from "react-redux";
 import { capitalize, noop } from "lodash-es";
-import styled from "styled-components";
-
+import React from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
 import Toggle from "yoast-components/composites/Plugin/Shared/components/Toggle";
 
-import Input from "./Input";
-import TextArea from "./TextArea";
+import { setConfigurationAttribute } from "../redux/actions/configuration";
 import { setPaperAttribute } from "../redux/actions/paper";
 import measureTextWidth from "../utils/measureTextWidth";
-import { setConfigurationAttribute } from "../redux/actions/configuration";
-
-const ToggleContainer = styled.div`
-	margin-top: 8px;
-`;
+import Container from "./Container";
+import Input from "./Input";
+import TextArea from "./TextArea";
 
 function renderPaperAttribute( props, id, placeholder, label = null, onChange = null, Component = Input, defaultValue = "" ) {
 	if ( onChange === null ) {
@@ -36,7 +31,7 @@ function Inputs( props ) {
 	return <section>
 		{ renderPaperAttribute( props, "text", "Write a text", null, null, TextArea ) }
 		{ renderPaperAttribute( props, "keyword", "Choose a focus keyword", "Focus keyphrase" ) }
-		<ToggleContainer>
+		<Container marginTop="8px">
 			<Toggle
 				id="toggle-is-related-keyword"
 				labelText="Is a related keyphrase"
@@ -46,7 +41,7 @@ function Inputs( props ) {
 				} }
 				onToggleDisabled={ noop }
 			/>
-		</ToggleContainer>
+		</Container>
 		{ renderPaperAttribute( props, "synonyms", "Choose keyword synonyms" ) }
 		{ renderPaperAttribute( props, "title", "Write the SEO title", "SEO title", ( id, value ) => {
 			props.setPaperAttribute( id, value );
@@ -58,7 +53,7 @@ function Inputs( props ) {
 			props.setPaperAttribute( "permalink", `${window.location.origin}/${value}` );
 		} ) }
 		{ renderPaperAttribute( props, "locale", "en_US" ) }
-		<ToggleContainer>
+		<Container>
 			<Toggle
 				id="toggle-use-cornerstone"
 				labelText="Is cornerstone article"
@@ -68,18 +63,7 @@ function Inputs( props ) {
 				} }
 				onToggleDisabled={ noop }
 			/>
-		</ToggleContainer>
-		<ToggleContainer>
-			<Toggle
-				id="toggle-use-taxonomy"
-				labelText="Is taxonomy page"
-				isEnabled={ props.useTaxonomy }
-				onSetToggleState={ value => {
-					props.setConfigurationAttribute( "useTaxonomy", value );
-				} }
-				onToggleDisabled={ noop }
-			/>
-		</ToggleContainer>
+		</Container>
 	</section>;
 }
 
@@ -88,7 +72,6 @@ export default connect(
 		return {
 			paper: state.paper,
 			useCornerstone: state.configuration.useCornerstone,
-			useTaxonomy: state.configuration.useTaxonomy,
 			isRelatedKeyphrase: state.configuration.isRelatedKeyphrase,
 		};
 	},

--- a/examples/webpack/src/components/Inputs.js
+++ b/examples/webpack/src/components/Inputs.js
@@ -1,5 +1,5 @@
 import { capitalize, noop } from "lodash-es";
-import React from "react";
+import React, { Fragment } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import Toggle from "yoast-components/composites/Plugin/Shared/components/Toggle";
@@ -10,6 +10,7 @@ import measureTextWidth from "../utils/measureTextWidth";
 import Container from "./Container";
 import Input from "./Input";
 import TextArea from "./TextArea";
+import { ColumnLeft, ColumnRight, Columns } from "./Columns";
 
 function renderPaperAttribute( props, id, placeholder, label = null, onChange = null, Component = Input, defaultValue = "" ) {
 	if ( onChange === null ) {
@@ -27,9 +28,8 @@ function renderPaperAttribute( props, id, placeholder, label = null, onChange = 
 	);
 }
 
-function Inputs( props ) {
+function renderLeftColumn( props ) {
 	return <section>
-		{ renderPaperAttribute( props, "text", "Write a text", null, null, TextArea ) }
 		{ renderPaperAttribute( props, "keyword", "Choose a focus keyword", "Focus keyphrase" ) }
 		<Container marginTop="8px">
 			<Toggle
@@ -53,10 +53,15 @@ function Inputs( props ) {
 			props.setPaperAttribute( "permalink", `${window.location.origin}/${value}` );
 		} ) }
 		{ renderPaperAttribute( props, "locale", "en_US" ) }
+	</section>;
+}
+
+function renderRightColumn( props ) {
+	return <section>
 		<Container>
 			<Toggle
-				id="toggle-use-cornerstone"
-				labelText="Is a cornerstone article"
+				id="toggle-is-related-keyword"
+				labelText="Is a Cornerstone article"
 				isEnabled={ props.useCornerstone }
 				onSetToggleState={ value => {
 					props.setConfigurationAttribute( "useCornerstone", value );
@@ -65,6 +70,20 @@ function Inputs( props ) {
 			/>
 		</Container>
 	</section>;
+}
+
+function Inputs( props ) {
+	return <Fragment>
+		{ renderPaperAttribute( props, "text", "Write a text", null, null, TextArea ) }
+		<Columns minWidth="1000px">
+			<ColumnLeft>
+				{ renderLeftColumn( props ) }
+			</ColumnLeft>
+			<ColumnRight>
+				{ renderRightColumn( props ) }
+			</ColumnRight>
+		</Columns>
+	</Fragment>;
 }
 
 export default connect(

--- a/examples/webpack/src/components/TextArea.js
+++ b/examples/webpack/src/components/TextArea.js
@@ -21,7 +21,7 @@ const TextareaInput = styled.textarea`
 	cursor: text;
 	
 	width: 100%;
-	min-height: 300px;
+	min-height: ${ props => props.minHeight };
 `;
 
 class TextArea extends React.PureComponent {
@@ -61,10 +61,10 @@ class TextArea extends React.PureComponent {
 	/**
 	 * Renders the TextArea component.
 	 *
-	 * @returns {void}
+	 * @returns {React.Component} the React TextArea component and header.
 	 */
 	render() {
-		const { id, value, label, placeholder } = this.props;
+		const { id, value, label, placeholder, minHeight } = this.props;
 
 		return (
 			<React.Fragment>
@@ -79,6 +79,7 @@ class TextArea extends React.PureComponent {
 					value={ value }
 					placeholder={ placeholder }
 					onChange={ this.handleChange }
+					minHeight={ minHeight }
 				/>
 			</React.Fragment>
 		);
@@ -91,12 +92,14 @@ TextArea.propTypes = {
 	label: PropTypes.string,
 	placeholder: PropTypes.string,
 	onChange: PropTypes.func,
+	minHeight: PropTypes.string,
 };
 
 TextArea.defaultProps = {
 	label: "",
 	placeholder: "",
 	onChange: noop,
+	minHeight: "300px",
 };
 
 export default TextArea;

--- a/examples/webpack/src/index.css
+++ b/examples/webpack/src/index.css
@@ -14,6 +14,11 @@ body {
 	padding: 0 24px;
 }
 
+h1 {
+	padding-left: 10px;
+	font-size: 1.5em;
+}
+
 *, *:after, *:before {
 	box-sizing: inherit;
 }

--- a/examples/webpack/src/redux/utils/StoreSubscriber.js
+++ b/examples/webpack/src/redux/utils/StoreSubscriber.js
@@ -73,7 +73,6 @@ export default class StoreSubscriber {
 		if ( ! isEqual( prevConfiguration, configuration ) ) {
 			this._worker.initialize( configuration ).then( () => {
 				if ( state.configuration.isRelatedKeyphrase ) {
-					console.log( "analyzing related keyphrase..." );
 					return this.analyzeRelatedKeyphrase( state.paper );
 				}
 				return this.analyzePaper( state.paper );

--- a/examples/webpack/src/redux/utils/StoreSubscriber.js
+++ b/examples/webpack/src/redux/utils/StoreSubscriber.js
@@ -36,7 +36,19 @@ export default class StoreSubscriber {
 		this._worker.analyze( Paper.parse( paper ) )
 			.then( ( { result } ) => {
 				this.dispatch( setStatus( "idling" ) );
-				this.dispatch( setResults( formatAnalyzeResult( result ) ) );
+				this.dispatch( setResults( formatAnalyzeResult( result, "" ) ) );
+			} );
+	}
+
+	analyzeRelatedKeyphrase( paper ) {
+		const relatedKeyphrase = {
+			keyword: paper.keyword,
+			synonyms: paper.synonyms,
+		};
+		this._worker.analyzeRelatedKeywords( Paper.parse( paper ), { relatedKeyphrase } )
+			.then( ( { result } ) => {
+				this.dispatch( setStatus( "idling" ) );
+				this.dispatch( setResults( formatAnalyzeResult( result, "relatedKeyphrase" ) ) );
 			} );
 	}
 
@@ -46,7 +58,11 @@ export default class StoreSubscriber {
 
 		if ( ! isEqual( paper, prevPaper ) ) {
 			this.dispatch( setStatus( "analyzing" ) );
-			this.analyzePaper( paper );
+			if ( state.configuration.isRelatedKeyphrase ) {
+				this.analyzeRelatedKeyphrase( paper );
+			} else {
+				this.analyzePaper( paper );
+			}
 		}
 	}
 
@@ -55,7 +71,13 @@ export default class StoreSubscriber {
 		const { configuration } = state;
 
 		if ( ! isEqual( prevConfiguration, configuration ) ) {
-			this._worker.initialize( configuration ).then( () => this.analyzePaper( state.paper ) );
+			this._worker.initialize( configuration ).then( () => {
+				if ( state.configuration.isRelatedKeyphrase ) {
+					console.log( "analyzing related keyphrase..." );
+					return this.analyzeRelatedKeyphrase( state.paper );
+				}
+				return this.analyzePaper( state.paper );
+			} );
 		}
 	}
 

--- a/examples/webpack/src/redux/utils/StoreSubscriber.js
+++ b/examples/webpack/src/redux/utils/StoreSubscriber.js
@@ -1,5 +1,5 @@
 import Paper from "../../../../../src/values/Paper";
-import { isEqual, debounce, get } from "lodash-es";
+import { isEqual, debounce } from "lodash-es";
 
 import { setStatus } from "../actions/worker";
 import { setResults } from "../actions/results";
@@ -54,10 +54,8 @@ export default class StoreSubscriber {
 		const { configuration: prevConfiguration } = prevState;
 		const { configuration } = state;
 
-		if ( get( prevConfiguration, [ "useKeywordDistribution" ] ) !== get( configuration, "useKeywordDistribution" ) ) {
-			this._worker.initialize( {
-				useKeywordDistribution: configuration.useKeywordDistribution,
-			} ).then( () => this.analyzePaper( state.paper ) );
+		if ( ! isEqual( prevConfiguration, configuration ) ) {
+			this._worker.initialize( configuration ).then( () => this.analyzePaper( state.paper ) );
 		}
 	}
 

--- a/examples/webpack/src/utils/formatAnalyzeResult.js
+++ b/examples/webpack/src/utils/formatAnalyzeResult.js
@@ -67,12 +67,13 @@ function mapResults( results ) {
  * Adapts the results to be used with our components.
  *
  * @param {Object} analyzeResults The original results object as received by the worker.
+ * @param {String} keyphraseId The id of the keyphrase to show (e.g. when analyzing relevant keyphrase).
  *
  * @returns {Object} The results as wanted by the components.
  */
-export default function formatAnalyzeResults( analyzeResults ) {
+export default function formatAnalyzeResults( analyzeResults, keyphraseId ) {
 	if ( analyzeResults.seo ) {
-		analyzeResults.seo[ "" ].results = mapResults( analyzeResults.seo[ "" ].results );
+		analyzeResults.seo[ "" ].results = mapResults( analyzeResults.seo[ keyphraseId ].results );
 	}
 
 	if ( analyzeResults.readability ) {

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -687,7 +687,6 @@ export default class AnalysisWebWorker {
 					synonyms: this._relatedKeywords[ key ].synonyms,
 				} );
 
-
 				this._relatedKeywordAssessor.assess( relatedPaper );
 
 				this._results.seo[ key ] = {

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -684,6 +684,8 @@ export default class AnalysisWebWorker {
 					synonyms: this._relatedKeywords[ key ].synonyms,
 				} );
 
+				console.log( this._relatedKeywords[ key ] );
+
 				this._relatedKeywordAssessor.assess( relatedPaper );
 
 				this._results.seo[ key ] = {

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -687,7 +687,6 @@ export default class AnalysisWebWorker {
 					synonyms: this._relatedKeywords[ key ].synonyms,
 				} );
 
-				console.log( this._relatedKeywords[ key ] );
 
 				this._relatedKeywordAssessor.assess( relatedPaper );
 


### PR DESCRIPTION
## Summary

**Note**: this branch was branched from the #1826 branch. #1826 should be merged first before merging this branch into develop.

This PR can be summarized in the following changelog entry:

* Adds toggles to use the different assessors in the webpack example. E.g. for all the different combinations for cornerstone and taxonomy pages and related keyphrase.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Startup the webpack example.
   * I.o.w. go to `examples/webpack` in the console and enter the `yarn start` command.
* Test out all the different combinations of the `Is a related keyphrase`, `Is cornerstone article` and `is taxonomy page`.
   * For each combination, check whether all the assessments that are defined for this assessor are run (see [this wiki page](https://github.com/Yoast/YoastSEO.js/wiki/SEO-Assessors) for a list).
   * For each combination, (sanity) check whether all the assessments that are run provide the expected results.

Fixes #1854 
