### PR TITLE
Refactor precedence exceptions

### DIFF
--- a/spec/researches/dutch/passiveVoice/DutchParticipleSpec.js
+++ b/spec/researches/dutch/passiveVoice/DutchParticipleSpec.js
@@ -3,38 +3,54 @@ import checkException from "../../../../src/researches/passiveVoice/periphrastic
 
 describe( "A test for checking the Dutch participle", function() {
 	it( "checks the properties of the Dutch participle object with a passive", function() {
-		const mockParticiple = new DutchParticiple( "gekocht", "werd door mij gekocht.", { auxiliaries: [ "werd" ], type: "regular", language: "nl" } );
+		const mockParticiple = new DutchParticiple( "gekocht", "werd door mij gekocht.", {
+			auxiliaries: [ "werd" ],
+			type: "regular",
+			language: "nl",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "gekocht" );
 		expect( mockParticiple.isOnNonParticiplesList() ).toBe( false );
 		expect( mockParticiple.hasNonParticipleEnding() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 14, "nl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "nl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
 	it( "checks the properties of the Dutch participle object with an irregular passive", function() {
-		const mockParticiple = new DutchParticiple( "achtervolgd", "werd achtervolgd.", { auxiliaries: [ "werd" ], type: "irregular", language: "nl" } );
+		const mockParticiple = new DutchParticiple( "achtervolgd", "werd achtervolgd.", {
+			auxiliaries: [ "werd" ],
+			type: "irregular",
+			language: "nl",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "achtervolgd" );
 		expect( mockParticiple.isOnNonParticiplesList() ).toBe( false );
 		expect( mockParticiple.hasNonParticipleEnding() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 5, "nl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "nl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
 	it( "checks the properties of the Dutch participle object with a word from the list of non-participles", function() {
-		const mockParticiple = new DutchParticiple( "beschrijvend", "wordt beschrijvend.", { auxiliaries: [ "wordt" ], type: "regular", language: "nl" } );
+		const mockParticiple = new DutchParticiple( "beschrijvend", "wordt beschrijvend.", {
+			auxiliaries: [ "wordt" ],
+			type: "regular",
+			language: "nl",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "beschrijvend" );
 		expect( mockParticiple.isOnNonParticiplesList() ).toBe( true );
 		expect( mockParticiple.hasNonParticipleEnding() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 6, "nl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "nl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the Dutch participle object with a word from the list of non-participles", function() {
-		const mockParticiple = new DutchParticiple( "gemoedelijkheid", "wordt geen gemoedelijkheid", { auxiliaries: [ "wordt" ], type: "regular", language: "nl" } );
+		const mockParticiple = new DutchParticiple( "gemoedelijkheid", "wordt geen gemoedelijkheid", {
+			auxiliaries: [ "wordt" ],
+			type: "regular",
+			language: "nl",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "gemoedelijkheid" );
 		expect( mockParticiple.isOnNonParticiplesList() ).toBe( false );
 		expect( mockParticiple.hasNonParticipleEnding() ).toBe( true );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 11, "nl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "nl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -43,12 +59,16 @@ describe( "A test for checking the Dutch participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "geliefd" );
 		expect( mockParticiple.isOnNonParticiplesList() ).toBe( false );
 		expect( mockParticiple.hasNonParticipleEnding() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 10, "nl" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "nl" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		let mockParticiple = new DutchParticiple( "gekookt", "Het werd door hem gekookt.", { auxiliaries: [ "werd" ], type: "regular", language: "nl" } );
+		let mockParticiple = new DutchParticiple( "gekookt", "Het werd door hem gekookt.", {
+			auxiliaries: [ "werd" ],
+			type: "regular",
+			language: "nl",
+		} );
 		mockParticiple._participle = null;
 		checkException.call( mockParticiple );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );

--- a/spec/researches/english/passiveVoice/EnglishParticipleSpec.js
+++ b/spec/researches/english/passiveVoice/EnglishParticipleSpec.js
@@ -8,7 +8,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -18,7 +18,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( true );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 6, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -32,7 +32,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( true );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 16, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -46,7 +46,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 22, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -56,7 +56,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 14, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -66,7 +66,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 7, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -76,7 +76,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 10, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -89,8 +89,8 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "painted" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 24, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 24, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -104,7 +104,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 18, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -125,7 +125,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 27, "en" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -139,7 +139,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 37, "en" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -153,7 +153,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 14, "en" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 } );

--- a/spec/researches/english/passiveVoice/EnglishParticipleSpec.js
+++ b/spec/researches/english/passiveVoice/EnglishParticipleSpec.js
@@ -7,7 +7,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "fired" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 7, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
@@ -17,27 +17,35 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "wellbred" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( true );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 6, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 6, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the English participle object with a 'rid' exception", function() {
-		let mockParticiple = new EnglishParticiple( "rid", "He wants to get rid of it", { auxiliaries: [ "get" ], type: "irregular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "rid", "He wants to get rid of it", {
+			auxiliaries: [ "get" ],
+			type: "irregular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "rid" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( true );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 16, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 16, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the English participle object with a direct precedence exception", function() {
-		let mockParticiple = new EnglishParticiple( "read", "I am wiser for having read that book", { auxiliaries: [ "am" ], type: "irregular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "read", "I am wiser for having read that book", {
+			auxiliaries: [ "am" ],
+			type: "irregular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "read" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 22, "en" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 22, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
@@ -47,7 +55,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "left" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 14, "en" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 14, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
@@ -57,7 +65,7 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "left" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 7, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 7, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
@@ -67,13 +75,17 @@ describe( "A test for checking the English Participle", function() {
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 10, "en" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 10, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the English participle object with a word from the direct precedence exception list which does not directly precede the participle", function() {
-		let mockParticiple = new EnglishParticiple( "painted", "He was having his house painted", { auxiliaries: [ "was" ], type: "regular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "painted", "He was having his house painted", {
+			auxiliaries: [ "was" ],
+			type: "regular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "painted" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
@@ -83,11 +95,15 @@ describe( "A test for checking the English Participle", function() {
 	} );
 
 	it( "checks the properties of the English participle object with 'fit' that is not an exception", function() {
-		let mockParticiple = new EnglishParticiple( "fit", "The data was then fit by the optimal model", { auxiliaries: [ "was" ], type: "irregular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "fit", "The data was then fit by the optimal model", {
+			auxiliaries: [ "was" ],
+			type: "irregular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "fit" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 18, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 18, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
@@ -100,31 +116,43 @@ describe( "A test for checking the English Participle", function() {
 	} );
 
 	it( "checks the properties of the English participle object with a precedence exception when the word from the list doesn't directly precede the participle", function() {
-		let mockParticiple = new EnglishParticiple( "enjoyed", "It's something I've always enjoyed doing", { auxiliaries: [ "it's" ], type: "regular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "enjoyed", "It's something I've always enjoyed doing", {
+			auxiliaries: [ "it's" ],
+			type: "regular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "enjoyed" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 27, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 27, "en" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the English participle object with a precedence exception when the word from the list directly precedes the participle", function() {
-		let mockParticiple = new EnglishParticiple( "adopted", "Here is a list of ten beliefs I have adopted", { auxiliaries: [ "is" ], type: "regular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "adopted", "Here is a list of ten beliefs I have adopted", {
+			auxiliaries: [ "is" ],
+			type: "regular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "adopted" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 37, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 37, "en" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the English participle object with a precedence exception when the word from the list occurs after the participle", function() {
-		let mockParticiple = new EnglishParticiple( "stolen", "The money was stolen, but nobody has been able to prove it", { auxiliaries: [ "was" ], type: "irregular", language: "en" } );
+		let mockParticiple = new EnglishParticiple( "stolen", "The money was stolen, but nobody has been able to prove it", {
+			auxiliaries: [ "was" ],
+			type: "irregular",
+			language: "en",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "stolen" );
 		expect( mockParticiple.isNonVerbEndingEd() ).toBe( false );
 		expect( mockParticiple.hasRidException() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 14, "en" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "en" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 14, "en" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );

--- a/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
+++ b/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
@@ -47,9 +47,9 @@ describe( "A test for checking the French participle", function() {
 	} );
 
 	it( "checks the properties of the French participle object with a noun exception ending in é and beginning with a contracted article", function() {
-		const mockParticiple = new FrenchParticiple(
-			"l'intégrité", "Est-ce que la création de cet outil contribuera à améliorer l’intégrité scientifique ?",
-			{ auxiliaries: [ "est-ce" ], type: "regular", language: "fr" },
+		const mockParticiple = new FrenchParticiple( "l'intégrité",
+			"Est-ce que la création de cet outil contribuera à améliorer l’intégrité scientifique ?",
+			{ auxiliaries: [ "est-ce" ], type: "regular", language: "fr" }
 		);
 		expect( mockParticiple.getParticiple() ).toBe( "l'intégrité" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );

--- a/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
+++ b/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
@@ -9,7 +9,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 4, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -20,7 +20,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 13, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -31,7 +31,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -42,7 +42,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 11, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -56,7 +56,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 60, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -71,7 +71,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 17, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -86,7 +86,7 @@ describe( "A test for checking the French participle", function() {
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( true );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -94,7 +94,7 @@ describe( "A test for checking the French participle", function() {
 		// Direct precedence exception word: en.
 		const mockParticiple = new FrenchParticiple( "vue", "C'est en vue.", { auxiliaries: [ "c'est" ], type: "irregular", language: "fr" } );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 9, "fr" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -106,7 +106,7 @@ describe( "A test for checking the French participle", function() {
 			language: "fr",
 		} );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 35, "fr" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -118,7 +118,7 @@ describe( "A test for checking the French participle", function() {
 			language: "fr",
 		} );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 29, "fr" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 

--- a/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
+++ b/spec/researches/french/passiveVoice/FrenchParticipleSpec.js
@@ -1,110 +1,133 @@
-import FrenchParticiple from "../../../../src/researches/french/passiveVoice/FrenchParticiple.js";
-import checkException from "../../../../src/researches/passiveVoice/periphrastic/checkException.js";
+import FrenchParticiple from "../../../../src/researches/french/passiveVoice/FrenchParticiple";
+import checkException from "../../../../src/researches/passiveVoice/periphrastic/checkException";
 
 describe( "A test for checking the French participle", function() {
 	it( "checks the properties of the French participle object with a passive", function() {
-		var mockParticiple = new FrenchParticiple( "créée", "fut créée par moi.", { auxiliaries: [ "fut" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "créée", "fut créée par moi.", { auxiliaries: [ "fut" ], type: "regular", language: "fr" } );
 		expect( mockParticiple.getParticiple() ).toBe( "créée" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 4, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 4, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
 	it( "checks the properties of the French participle object with an adjective or verb exception ending in é", function() {
-		let mockParticiple = new FrenchParticiple( "aîné", "est le frère aîné.", { auxiliaries: [ "est" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "aîné", "est le frère aîné.", { auxiliaries: [ "est" ], type: "regular", language: "fr" } );
 		expect( mockParticiple.getParticiple() ).toBe( "aîné" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 13, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 13, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with an adjective or verb exception ending in é plus suffix", function() {
-		let mockParticiple = new FrenchParticiple( "aînée", "est la sœur aînée.", { auxiliaries: [ "est" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "aînée", "est la sœur aînée.", { auxiliaries: [ "est" ], type: "regular", language: "fr" } );
 		expect( mockParticiple.getParticiple() ).toBe( "aînée" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a noun exception ending in é", function() {
-		let mockParticiple = new FrenchParticiple( "café", "J’étais au café.", { auxiliaries: [ "j'étais" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "café", "J’étais au café.", { auxiliaries: [ "j'étais" ], type: "regular", language: "fr" } );
 		expect( mockParticiple.getParticiple() ).toBe( "café" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 11, "fr" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 11, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a noun exception ending in é and beginning with a contracted article", function() {
-		let mockParticiple = new FrenchParticiple( "l'intégrité", "Est-ce que la création de cet outil contribuera à améliorer l’intégrité scientifique ?", { auxiliaries: [ "est-ce" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple(
+			"l'intégrité", "Est-ce que la création de cet outil contribuera à améliorer l’intégrité scientifique ?",
+			{ auxiliaries: [ "est-ce" ], type: "regular", language: "fr" },
+		);
 		expect( mockParticiple.getParticiple() ).toBe( "l'intégrité" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 60, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 60, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a noun exception ending in é plus suffix", function() {
-		let mockParticiple = new FrenchParticiple( "cafés", "étaient les deux cafés du village.", { auxiliaries: [ "étaient" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "cafés", "étaient les deux cafés du village.", {
+			auxiliaries: [ "étaient" ],
+			type: "regular",
+			language: "fr",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "cafés" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( true );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( false );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 17, "fr" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 17, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with an exception from the other list ending in é", function() {
-		let mockParticiple = new FrenchParticiple( "malgré", "était triste malgré tout.", { auxiliaries: [ "était" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "malgré", "était triste malgré tout.", {
+			auxiliaries: [ "était" ],
+			type: "regular",
+			language: "fr",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "malgré" );
 		expect( mockParticiple.isOnAdjectivesVerbsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnNounsExceptionList() ).toBe( false );
 		expect( mockParticiple.isOnOthersExceptionList() ).toBe( true );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 12, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a direct precedence exception", function() {
 		// Direct precedence exception word: en.
-		let mockParticiple = new FrenchParticiple( "vue", "C'est en vue.", { auxiliaries: [ "c'est" ], type: "irregular", language: "fr" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 9, "fr" ) ).toBe( true );
+		const mockParticiple = new FrenchParticiple( "vue", "C'est en vue.", { auxiliaries: [ "c'est" ], type: "irregular", language: "fr" } );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 9, "fr" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a precedence exception (indirectly preceding)", function() {
 		// Precedence exception word: avoir (in between "n'est" and "vu").
-		let mockParticiple = new FrenchParticiple( "vu", "n'est pas possible de l'avoir déjà vu.", { auxiliaries: [ "n'est" ], type: "irregular", language: "fr" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 35, "fr" ) ).toBe( false );
+		const mockParticiple = new FrenchParticiple( "vu", "n'est pas possible de l'avoir déjà vu.", {
+			auxiliaries: [ "n'est" ],
+			type: "irregular",
+			language: "fr",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 35, "fr" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the French participle object with a precedence exception (directly preceding)", function() {
 		// Precedence exception word: avoir (in between "n'est" and "vu").
-		let mockParticiple = new FrenchParticiple( "vu", "n'est pas nécessaire d'avoir vu le premier film", { auxiliaries: [ "n'est" ], type: "irregular", language: "fr" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 29, "fr" ) ).toBe( false );
+		const mockParticiple = new FrenchParticiple( "vu", "n'est pas nécessaire d'avoir vu le premier film", {
+			auxiliaries: [ "n'est" ],
+			type: "irregular",
+			language: "fr",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "fr" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 29, "fr" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		let mockParticiple = new FrenchParticiple( "cuisiné", "Ça a été cuisiné par lui.", { auxiliaries: [ "été" ], type: "regular", language: "fr" } );
+		const mockParticiple = new FrenchParticiple( "cuisiné", "Ça a été cuisiné par lui.", {
+			auxiliaries: [ "été" ],
+			type: "regular",
+			language: "fr",
+		} );
 		mockParticiple._participle = null;
 		checkException.call( mockParticiple );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );

--- a/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
+++ b/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
@@ -22,16 +22,4 @@ describe( "A test for checking the Italian participle", function() {
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
-
-	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		let mockParticiple = new ItalianParticiple( "scritto", "è stato scritto dal mio amico.", {
-			auxiliaries: [ "stato" ],
-			type: "irregular",
-			language: "it",
-		} );
-		mockParticiple._participle = null;
-		checkException.call( mockParticiple );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( false );
-		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
-	} );
 } );

--- a/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
+++ b/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
@@ -20,6 +20,18 @@ describe( "A test for checking the Italian participle", function() {
 			language: "it",
 		} );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( true );
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	} );
+
+	it( "checks the properties of the Italian participle object with a precedence exception", function() {
+		// Direct precedence exception word: il.
+		let mockParticiple = new ItalianParticiple( "mandato", "Dovresti andare a vedere se esiste il mandato.", {
+			auxiliaries: [ "andare" ],
+			type: "irregular",
+			language: "it",
+		} );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 

--- a/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
+++ b/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
@@ -19,7 +19,7 @@ describe( "A test for checking the Italian participle", function() {
 			type: "irregular",
 			language: "it",
 		} );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 38, "it" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -31,7 +31,7 @@ describe( "A test for checking the Italian participle", function() {
 		} );
 		mockParticiple._participle = null;
 		checkException.call( mockParticiple );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 8, "it" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 } );

--- a/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
+++ b/spec/researches/italian/passiveVoice/ItalianParticipleSpec.js
@@ -22,4 +22,15 @@ describe( "A test for checking the Italian participle", function() {
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "it" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
+
+	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
+		let mockParticiple = new ItalianParticiple( "scritto", "è stato scritto dal mio amico.", {
+			auxiliaries: [ "stato" ],
+			type: "irregular",
+			language: "it",
+		} );
+		mockParticiple._participle = null;
+		checkException.call( mockParticiple );
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	} );
 } );

--- a/spec/researches/polish/passiveVoice/PolishParticipleSpec.js
+++ b/spec/researches/polish/passiveVoice/PolishParticipleSpec.js
@@ -1,6 +1,5 @@
 import PolishParticiple from "../../../../src/researches/polish/passiveVoice/PolishParticiple.js";
 import checkException from "../../../../src/researches/passiveVoice/periphrastic/checkException.js";
-import getWords from "../../../../src/stringProcessing/getWords";
 
 describe( "A test for checking the Polish participle", function() {
 	it( "checks the properties of the Polish participle object with a passive", function() {
@@ -9,10 +8,9 @@ describe( "A test for checking the Polish participle", function() {
 			type: "irregular",
 			language: "pl",
 		} );
-		const wordsInSentencePart = getWords( mockParticiple._sentencePart );
 
 		expect( mockParticiple.getParticiple() ).toBe( "napisana" );
-		expect( mockParticiple.directPrecedenceException( wordsInSentencePart, 2, "pl" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "pl" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
@@ -23,10 +21,9 @@ describe( "A test for checking the Polish participle", function() {
 			type: "irregular",
 			language: "pl",
 		} );
-		const wordsInSentencePart = getWords( mockParticiple._sentencePart );
 
 		expect( mockParticiple.getParticiple() ).toBe( "znalezione" );
-		expect( mockParticiple.directPrecedenceException( wordsInSentencePart, 3, "pl" ) ).toBe( true );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "pl" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 

--- a/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
+++ b/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
@@ -47,4 +47,15 @@ describe( "A test for checking the Spanish participle", function() {
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 53, "es" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
+
+	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
+		let mockParticiple = new SpanishParticiple( "escrito", "fue escrito por mi amiga.", {
+			auxiliaries: [ "fue" ],
+			type: "regular",
+			language: "es",
+		} );
+		mockParticiple._participle = null;
+		checkException.call( mockParticiple );
+		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
+	} );
 } );

--- a/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
+++ b/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
@@ -3,40 +3,60 @@ import checkException from "../../../../src/researches/passiveVoice/periphrastic
 
 describe( "A test for checking the Spanish participle", function() {
 	it( "checks the properties of the Spanish participle object with a passive", function() {
-		var mockParticiple = new SpanishParticiple( "escrito", "El libro fue escrito por mi amiga.", { auxiliaries: [ "fue" ], type: "irregular", language: "es" } );
+		var mockParticiple = new SpanishParticiple( "escrito", "El libro fue escrito por mi amiga.", {
+			auxiliaries: [ "fue" ],
+			type: "irregular",
+			language: "es",
+		} );
 		expect( mockParticiple.getParticiple() ).toBe( "escrito" );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( true );
 	} );
 
 	it( "checks the properties of the Spanish participle object with a direct precedence exception", function() {
 		// Direct precedence exception word: un.
-		let mockParticiple = new SpanishParticiple( "sentido", "fue un sentido monumental y grandilocuente.", { auxiliaries: [ "fue" ], type: "irregular", language: "es" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 7, "es" ) ).toBe( true );
+		let mockParticiple = new SpanishParticiple( "sentido", "fue un sentido monumental y grandilocuente.", {
+			auxiliaries: [ "fue" ],
+			type: "irregular",
+			language: "es",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( true );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 7, "es" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the Spanish participle object with a precedence exception (directly preceding)", function() {
 		// Precedence exception word: estaban.
-		let mockParticiple = new SpanishParticiple( "armados", "eran casi en su totalidad exsamuráis y estaban armados", { auxiliaries: [ "eran" ], type: "irregular", language: "es" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 47, "es" ) ).toBe( false );
+		let mockParticiple = new SpanishParticiple( "armados", "eran casi en su totalidad exsamuráis y estaban armados", {
+			auxiliaries: [ "eran" ],
+			type: "irregular",
+			language: "es",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 47, "es" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "checks the properties of the Spanish participle object with a precedence exception (indirectly preceding)", function() {
 		// Precedence exception word: estaban.
-		let mockParticiple = new SpanishParticiple( "esperado", "son famosos estaban en un programa de televisión muy esperado.", { auxiliaries: [ "son" ], type: "irregular", language: "es" } );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 53, "es" ) ).toBe( false );
+		let mockParticiple = new SpanishParticiple( "esperado", "son famosos estaban en un programa de televisión muy esperado.", {
+			auxiliaries: [ "son" ],
+			type: "irregular",
+			language: "es",
+		} );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 53, "es" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
 	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		let mockParticiple = new SpanishParticiple( "escrito", "fue escrito por mi amiga.", { auxiliaries: [ "fue" ], type: "regular", language: "es" } );
+		let mockParticiple = new SpanishParticiple( "escrito", "fue escrito por mi amiga.", {
+			auxiliaries: [ "fue" ],
+			type: "regular",
+			language: "es",
+		} );
 		mockParticiple._participle = null;
 		checkException.call( mockParticiple );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, 4, "es" ) ).toBe( false );
+		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 4, "es" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );

--- a/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
+++ b/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
@@ -47,17 +47,4 @@ describe( "A test for checking the Spanish participle", function() {
 		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 53, "es" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
-
-	it( "ensures that the sentence part is not set to passive if the participle is empty.", function() {
-		let mockParticiple = new SpanishParticiple( "escrito", "fue escrito por mi amiga.", {
-			auxiliaries: [ "fue" ],
-			type: "regular",
-			language: "es",
-		} );
-		mockParticiple._participle = null;
-		checkException.call( mockParticiple );
-		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 4, "es" ) ).toBe( false );
-		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
-	} );
 } );

--- a/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
+++ b/spec/researches/spanish/passiveVoice/SpanishParticipleSpec.js
@@ -20,7 +20,7 @@ describe( "A test for checking the Spanish participle", function() {
 			language: "es",
 		} );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( true );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 7, "es" ) ).toBe( false );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -32,7 +32,7 @@ describe( "A test for checking the Spanish participle", function() {
 			language: "es",
 		} );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 47, "es" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 
@@ -44,7 +44,7 @@ describe( "A test for checking the Spanish participle", function() {
 			language: "es",
 		} );
 		expect( mockParticiple.directPrecedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( false );
-		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, 53, "es" ) ).toBe( true );
+		expect( mockParticiple.precedenceException( mockParticiple._sentencePart, mockParticiple._participle, "es" ) ).toBe( true );
 		expect( mockParticiple.determinesSentencePartIsPassive() ).toBe( false );
 	} );
 

--- a/spec/values/ParticipleSpec.js
+++ b/spec/values/ParticipleSpec.js
@@ -57,6 +57,12 @@ describe( "A test for checking the Participle", function() {
 		} ).toThrowError( "The participle should not be empty." );
 	} );
 
+	it( "throws an error when the participle is not a string.", function() {
+		expect( function() {
+			new Participle( null, "Wir werden geschlossen haben.", { auxiliaries: [ "werden" ], type: [ "irregular" ] } );
+		} ).toThrowError( "The participle should be a string." );
+	} );
+
 	it( "throws an error when the sentence part is empty.", function() {
 		expect( function() {
 			new Participle( "geschlossen", "", { auxiliaries: [ "werden" ], type: [ "irregular" ] } );

--- a/src/researches/dutch/passiveVoice/DutchParticiple.js
+++ b/src/researches/dutch/passiveVoice/DutchParticiple.js
@@ -3,7 +3,7 @@ import { includes } from "lodash-es";
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import nonParticiples from "./nonParticiples";
-import directPrecedenceException from "../../../stringProcessing/directPrecedenceException";
+import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
 
 /**
  * Creates an Participle object for the Dutch language.
@@ -29,12 +29,12 @@ require( "util" ).inherits( DutchParticiple, Participle );
  */
 DutchParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
-	const participleIndex = sentencePart.indexOf( this.getParticiple() );
+	const participle = this.getParticiple();
 	const language = this.getLanguage();
 
 	return ! this.isOnNonParticiplesList() &&
 		! this.hasNonParticipleEnding() &&
-		! this.directPrecedenceException( sentencePart, participleIndex, language );
+		! this.directPrecedenceException( sentencePart, participle, language );
 };
 
 /**

--- a/src/researches/english/passiveVoice/EnglishParticiple.js
+++ b/src/researches/english/passiveVoice/EnglishParticiple.js
@@ -2,7 +2,7 @@ import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import nonVerbsEndingEdFactory from "./non-verb-ending-ed.js";
 const nonVerbsEndingEd = nonVerbsEndingEdFactory();
-import directPrecedenceException from "../../../stringProcessing/directPrecedenceException";
+import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
 import precedenceException from "../../../stringProcessing/precedenceException";
 
 import { includes } from "lodash-es";
@@ -35,12 +35,13 @@ require( "util" ).inherits( EnglishParticiple, Participle );
  */
 EnglishParticiple.prototype.isPassive = function() {
 	let sentencePart = this.getSentencePart();
-	let participleIndex = sentencePart.indexOf( this.getParticiple() );
+	const participle = this.getParticiple();
+	let participleIndex = sentencePart.indexOf( participle );
 	let language = this.getLanguage();
 
 	return 	! this.isNonVerbEndingEd() &&
 		! this.hasRidException() &&
-		! this.directPrecedenceException( sentencePart, participleIndex, language ) &&
+		! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.precedenceException( sentencePart, participleIndex, language );
 };
 

--- a/src/researches/english/passiveVoice/EnglishParticiple.js
+++ b/src/researches/english/passiveVoice/EnglishParticiple.js
@@ -3,7 +3,7 @@ import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import nonVerbsEndingEdFactory from "./non-verb-ending-ed.js";
 const nonVerbsEndingEd = nonVerbsEndingEdFactory();
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import precedenceException from "../../../stringProcessing/precedenceException";
+import precedenceException from "../../../stringProcessing/precedenceExceptionWithoutRegex";
 
 import { includes } from "lodash-es";
 import { isEmpty } from "lodash-es";
@@ -36,13 +36,12 @@ require( "util" ).inherits( EnglishParticiple, Participle );
 EnglishParticiple.prototype.isPassive = function() {
 	let sentencePart = this.getSentencePart();
 	const participle = this.getParticiple();
-	let participleIndex = sentencePart.indexOf( participle );
 	let language = this.getLanguage();
 
 	return 	! this.isNonVerbEndingEd() &&
 		! this.hasRidException() &&
 		! this.directPrecedenceException( sentencePart, participle, language ) &&
-		! this.precedenceException( sentencePart, participleIndex, language );
+		! this.precedenceException( sentencePart, participle, language );
 };
 
 /**

--- a/src/researches/french/functionWords.js
+++ b/src/researches/french/functionWords.js
@@ -95,7 +95,7 @@ let otherAuxiliaries = [ "a", "a-t-elle", "a-t-il", "a-t-on", "ai", "ai-je", "ai
 	"n'allait", "n'allions", "n'alliez", "n'allaient", "n'iras", "n'ira", "n'irons", "n'irez", "n'iront", "qu'a" ];
 
 let otherAuxiliariesInfinitive = [ "avoir", "aller", "venir", "devoir", "pouvoir", "sembler", "paraître", "paraitre", "mettre", "finir",
-	"d'avoir", "d'aller", "n'avoir" ];
+	"d'avoir", "d'aller", "n'avoir", "l'avoir" ];
 
 let copula = [ "suis", "es", "est", "est-ce", "n'est", "sommes", "êtes", "sont", "suis-je", "es-tu", "est-il", "est-elle", "est-on", "sommes-nous",
 	"êtes-vous", "sont-ils", "sont-elles", "étais", "était", "étions", "étiez", "étaient", "serai", "seras", "sera", "serons", "serez", "seront",

--- a/src/researches/french/passiveVoice/FrenchParticiple.js
+++ b/src/researches/french/passiveVoice/FrenchParticiple.js
@@ -49,20 +49,20 @@ var checkIrregular = function() {
  */
 FrenchParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
-	const wordsInSentencePart = getWords( sentencePart );
-	const participleIndex = wordsInSentencePart.indexOf( this.getParticiple() );
+	const participle = this.getParticiple();
+	const participleIndex = sentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
 	// Only check precedence exceptions for irregular participles.
 	if ( checkIrregular.call( this ) ) {
-		return ! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
+		return ! this.directPrecedenceException( sentencePart, participle, language ) &&
 			! this.precedenceException( sentencePart, participleIndex, language );
 	}
 	// Check precedence exceptions and exception lists for regular participles.
 	return ! this.isOnAdjectivesVerbsExceptionList() &&
 		! this.isOnNounsExceptionList() &&
 		! this.isOnOthersExceptionList() &&
-		! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
+		! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.precedenceException( sentencePart, participleIndex, language );
 };
 

--- a/src/researches/french/passiveVoice/FrenchParticiple.js
+++ b/src/researches/french/passiveVoice/FrenchParticiple.js
@@ -1,7 +1,6 @@
 import { forEach, includes, memoize } from "lodash-es";
 
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import getWords from "../../../stringProcessing/getWords";
 import precedenceException from "../../../stringProcessing/precedenceException";
 import Participle from "../../../values/Participle";
 import checkException from "../../passiveVoice/periphrastic/checkException";

--- a/src/researches/french/passiveVoice/FrenchParticiple.js
+++ b/src/researches/french/passiveVoice/FrenchParticiple.js
@@ -1,7 +1,7 @@
 import { forEach, includes, memoize } from "lodash-es";
 
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import precedenceException from "../../../stringProcessing/precedenceException";
+import precedenceException from "../../../stringProcessing/precedenceExceptionWithoutRegex";
 import Participle from "../../../values/Participle";
 import checkException from "../../passiveVoice/periphrastic/checkException";
 import exceptionsParticiplesFactory from "./exceptionsParticiples";
@@ -49,20 +49,19 @@ var checkIrregular = function() {
 FrenchParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
 	const participle = this.getParticiple();
-	const participleIndex = sentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
 	// Only check precedence exceptions for irregular participles.
 	if ( checkIrregular.call( this ) ) {
 		return ! this.directPrecedenceException( sentencePart, participle, language ) &&
-			! this.precedenceException( sentencePart, participleIndex, language );
+			! this.precedenceException( sentencePart, participle, language );
 	}
 	// Check precedence exceptions and exception lists for regular participles.
 	return ! this.isOnAdjectivesVerbsExceptionList() &&
 		! this.isOnNounsExceptionList() &&
 		! this.isOnOthersExceptionList() &&
 		! this.directPrecedenceException( sentencePart, participle, language ) &&
-		! this.precedenceException( sentencePart, participleIndex, language );
+		! this.precedenceException( sentencePart, participle, language );
 };
 
 /**

--- a/src/researches/italian/passiveVoice/ItalianParticiple.js
+++ b/src/researches/italian/passiveVoice/ItalianParticiple.js
@@ -1,6 +1,6 @@
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
-import directPrecedenceException from "../../../stringProcessing/directPrecedenceException";
+import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
 import precedenceException from "../../../stringProcessing/precedenceException";
 
 
@@ -28,10 +28,11 @@ require( "util" ).inherits( ItalianParticiple, Participle );
  */
 ItalianParticiple.prototype.isPassive = function() {
 	let sentencePart = this.getSentencePart();
-	let participleIndex = sentencePart.indexOf( this.getParticiple() );
+	const participle = this.getParticiple();
+	let participleIndex = sentencePart.indexOf( participle );
 	let language = this.getLanguage();
 
-	return ! this.directPrecedenceException( sentencePart, participleIndex, language ) &&
+	return ! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.precedenceException( sentencePart, participleIndex, language );
 };
 

--- a/src/researches/italian/passiveVoice/ItalianParticiple.js
+++ b/src/researches/italian/passiveVoice/ItalianParticiple.js
@@ -1,7 +1,7 @@
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import precedenceException from "../../../stringProcessing/precedenceException";
+import precedenceException from "../../../stringProcessing/precedenceExceptionWithoutRegex";
 
 
 /**
@@ -29,11 +29,10 @@ require( "util" ).inherits( ItalianParticiple, Participle );
 ItalianParticiple.prototype.isPassive = function() {
 	let sentencePart = this.getSentencePart();
 	const participle = this.getParticiple();
-	let participleIndex = sentencePart.indexOf( participle );
 	let language = this.getLanguage();
 
 	return ! this.directPrecedenceException( sentencePart, participle, language ) &&
-		! this.precedenceException( sentencePart, participleIndex, language );
+		! this.precedenceException( sentencePart, participle, language );
 };
 
 ItalianParticiple.prototype.directPrecedenceException = directPrecedenceException;

--- a/src/researches/polish/passiveVoice/PolishParticiple.js
+++ b/src/researches/polish/passiveVoice/PolishParticiple.js
@@ -1,7 +1,6 @@
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import getWords from "../../../stringProcessing/getWords";
 import nonDirectPrecedenceException from "../../passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/nonDirectParticiplePrecedenceException";
 
 /**
@@ -30,12 +29,9 @@ PolishParticiple.prototype.isPassive = function() {
 	const sentencePart = this.getSentencePart();
 	const participle = this.getParticiple();
 	const auxiliaries = this.getAuxiliaries();
-
-	const wordsInSentencePart = getWords( sentencePart );
-	const participleIndex = wordsInSentencePart.indexOf( this.getParticiple() );
 	const language = this.getLanguage();
 
-	return ! this.directPrecedenceException( wordsInSentencePart, participleIndex, language ) &&
+	return ! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.nonDirectPrecedenceException( sentencePart, participle, auxiliaries, language );
 };
 

--- a/src/researches/spanish/passiveVoice/SpanishParticiple.js
+++ b/src/researches/spanish/passiveVoice/SpanishParticiple.js
@@ -1,6 +1,6 @@
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
-import directPrecedenceException from "../../../stringProcessing/directPrecedenceException";
+import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
 import precedenceException from "../../../stringProcessing/precedenceException";
 
 
@@ -28,10 +28,11 @@ require( "util" ).inherits( SpanishParticiple, Participle );
  */
 SpanishParticiple.prototype.isPassive = function() {
 	let sentencePart = this.getSentencePart();
-	let participleIndex = sentencePart.indexOf( this.getParticiple() );
+	const participle = this.getParticiple();
+	let participleIndex = sentencePart.indexOf( participle );
 	let language = this.getLanguage();
 
-	return ! this.directPrecedenceException( sentencePart, participleIndex, language ) &&
+	return ! this.directPrecedenceException( sentencePart, participle, language ) &&
 		! this.precedenceException( sentencePart, participleIndex, language );
 };
 

--- a/src/researches/spanish/passiveVoice/SpanishParticiple.js
+++ b/src/researches/spanish/passiveVoice/SpanishParticiple.js
@@ -1,7 +1,7 @@
 import Participle from "../../../values/Participle.js";
 import checkException from "../../passiveVoice/periphrastic/checkException.js";
 import directPrecedenceException from "../../../stringProcessing/directPrecedenceExceptionWithoutRegex";
-import precedenceException from "../../../stringProcessing/precedenceException";
+import precedenceException from "../../../stringProcessing/precedenceExceptionWithoutRegex";
 
 
 /**
@@ -29,11 +29,10 @@ require( "util" ).inherits( SpanishParticiple, Participle );
 SpanishParticiple.prototype.isPassive = function() {
 	let sentencePart = this.getSentencePart();
 	const participle = this.getParticiple();
-	let participleIndex = sentencePart.indexOf( participle );
 	let language = this.getLanguage();
 
 	return ! this.directPrecedenceException( sentencePart, participle, language ) &&
-		! this.precedenceException( sentencePart, participleIndex, language );
+		! this.precedenceException( sentencePart, participle, language );
 };
 
 SpanishParticiple.prototype.directPrecedenceException = directPrecedenceException;

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -1,31 +1,50 @@
-import cannotDirectlyPrecedePassiveParticiplePolishFactory from "../researches/polish/functionWords.js";
-const cannotDirectlyPrecedePassiveParticiplePolish = cannotDirectlyPrecedePassiveParticiplePolishFactory().cannotDirectlyPrecedePassiveParticiple;
+import { get } from "lodash-es";
+import functionWordsDutchFactory from "../researches/dutch/functionWords";
+import functionWordsEnglishFactory from "../researches/english/functionWords";
+import functionWordsFrenchFactory from "../researches/french/functionWords";
+import functionWordsItalianFactory from "../researches/italian/functionWords";
+import functionWordsPolishFactory from "../researches/polish/functionWords";
+import functionWordsSpanishFactory from "../researches/spanish/functionWords";
+import getWords from "../stringProcessing/getWords";
+
+const cannotDirectlyPrecedePassiveParticiples = {
+	nl: functionWordsDutchFactory().cannotDirectlyPrecedePassiveParticiple,
+	en: functionWordsEnglishFactory().cannotDirectlyPrecedePassiveParticiple,
+	fr: functionWordsFrenchFactory().cannotDirectlyPrecedePassiveParticiple,
+	it: functionWordsItalianFactory().cannotDirectlyPrecedePassiveParticiple,
+	pl: functionWordsPolishFactory().cannotDirectlyPrecedePassiveParticiple,
+	es: functionWordsSpanishFactory().cannotDirectlyPrecedePassiveParticiple,
+};
 
 /**
  * Checks whether the participle is directly preceded by a word from the direct precedence exception list.
  * If this is the case, the sentence part is not passive.
  *
- * @param {string[]} wordsInSentencePart The words in the sentence part that contains the participle.
- * @param {number}   participleIndex     The index of the participle.
- * @param {string}   language            The language of the participle.
+ * @param {string} sentencePart The sentence part that contains the participle.
+ * @param {string} participle   The participle.
+ * @param {string} language     The language of the participle.
  *
  * @returns {boolean} Returns true if a word from the direct precedence exception list is directly preceding
- * the participle, otherwise returns false.
+ *                    the participle, otherwise returns false.
  */
-export default function( wordsInSentencePart, participleIndex, language ) {
-	// If the participle is the first word, there can't be a word before that.
-	if ( participleIndex === 0 ) {
+export default function( sentencePart, participle, language ) {
+	// Break the sentence part up into words.
+	const wordsInSentencePart = getWords( sentencePart );
+
+	// Search the participle in the word list.
+	const participleIndex = wordsInSentencePart.indexOf( participle );
+
+	// If there is no participle found in the word list, this can not be an exception either.
+	if ( participleIndex === -1 ) {
 		return false;
 	}
+
 	const wordPrecedingParticiple = wordsInSentencePart[ participleIndex - 1 ];
 
-	let directPrecedenceExceptions = [];
-	switch ( language ) {
-		case "pl":
-			directPrecedenceExceptions = cannotDirectlyPrecedePassiveParticiplePolish;
-			break;
-	}
+	// Get the exceptions word list.
+	const directPrecedenceExceptions = get( cannotDirectlyPrecedePassiveParticiples, language, [] );
 
+	// Check if the word preceding the participle is in the exceptions list.
 	for ( let i = 0; i < directPrecedenceExceptions.length; i++ ) {
 		if ( directPrecedenceExceptions[ i ].includes( wordPrecedingParticiple ) ) {
 			return true;

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -1,4 +1,4 @@
-import { get } from "lodash-es";
+import { get, includes } from "lodash-es";
 import functionWordsDutchFactory from "../researches/dutch/functionWords";
 import functionWordsEnglishFactory from "../researches/english/functionWords";
 import functionWordsFrenchFactory from "../researches/french/functionWords";
@@ -45,11 +45,5 @@ export default function( sentencePart, participle, language ) {
 	const directPrecedenceExceptions = get( cannotDirectlyPrecedePassiveParticiples, language, [] );
 
 	// Check if the word preceding the participle is in the exceptions list.
-	for ( let i = 0; i < directPrecedenceExceptions.length; i++ ) {
-		if ( directPrecedenceExceptions[ i ].includes( wordPrecedingParticiple ) ) {
-			return true;
-		}
-	}
-
-	return false;
+	return includes( directPrecedenceExceptions, wordPrecedingParticiple );
 }

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -34,8 +34,13 @@ export default function( sentencePart, participle, language ) {
 	// Search the participle in the word list.
 	const participleIndex = wordsInSentencePart.indexOf( participle );
 
-	// If there is no participle found in the word list, this can not be an exception either.
-	if ( participleIndex === -1 ) {
+	/*
+	 * There can be no exception in the following situations:
+	 *
+	 * -1 The participle is not found.
+	 *  0 There is no word before the participle.
+	 */
+	if ( participleIndex < 1 ) {
 		return false;
 	}
 

--- a/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/directPrecedenceExceptionWithoutRegex.js
@@ -28,11 +28,11 @@ const cannotDirectlyPrecedePassiveParticiples = {
  *                    the participle, otherwise returns false.
  */
 export default function( sentencePart, participle, language ) {
-	// Break the sentence part up into words.
-	const wordsInSentencePart = getWords( sentencePart );
+	// Break the sentence part up into words and convert to lower case.
+	const wordsInSentencePart = getWords( sentencePart ).map( word => word.toLowerCase() );
 
 	// Search the participle in the word list.
-	const participleIndex = wordsInSentencePart.indexOf( participle );
+	const participleIndex = wordsInSentencePart.indexOf( participle.toLowerCase() );
 
 	/*
 	 * There can be no exception in the following situations:

--- a/src/stringProcessing/precedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/precedenceExceptionWithoutRegex.js
@@ -1,0 +1,54 @@
+import { get, includes } from "lodash-es";
+import functionWordsEnglishFactory from "../researches/english/functionWords";
+import functionWordsFrenchFactory from "../researches/french/functionWords";
+import functionWordsItalianFactory from "../researches/italian/functionWords";
+import functionWordsSpanishFactory from "../researches/spanish/functionWords";
+import getWords from "../stringProcessing/getWords";
+
+const cannotBeBetweenPassiveAuxiliaryAndParticiple = {
+	en: functionWordsEnglishFactory().cannotBeBetweenPassiveAuxiliaryAndParticiple,
+	fr: functionWordsFrenchFactory().cannotBeBetweenPassiveAuxiliaryAndParticiple,
+	it: functionWordsItalianFactory().cannotBeBetweenPassiveAuxiliaryAndParticiple,
+	es: functionWordsSpanishFactory().cannotBeBetweenPassiveAuxiliaryAndParticiple,
+};
+
+/**
+ * Checks whether a word from the precedence exception list occurs anywhere in the sentence part before the participle.
+ * If this is the case, the sentence part is not passive.
+ *
+ * @param {string} sentencePart The sentence part that contains the participle.
+ * @param {number} participle   The participle.
+ * @param {string} language     The language of the participle.
+ *
+ * @returns {boolean} Returns true if a word from the precedence exception list occurs anywhere in the
+ *                    sentence part before the participle, otherwise returns false.
+ */
+export default function( sentencePart, participle, language ) {
+	// Break the sentence part up into words and convert to lower case.
+	const wordsInSentencePart = getWords( sentencePart ).map( word => word.toLowerCase() );
+
+	// Search the participle in the word list.
+	const participleIndex = wordsInSentencePart.indexOf( participle.toLowerCase() );
+
+	/*
+	 * There can be no exception in the following situations:
+	 *
+	 * -1 The participle is not found.
+	 *  0 There is no word before the participle.
+	 */
+	if ( participleIndex < 1 ) {
+		return false;
+	}
+
+	// Get the exceptions word list.
+	const precedenceExceptions = get( cannotBeBetweenPassiveAuxiliaryAndParticiple, language, [] );
+
+	// Check if the words preceding the participle are in the exceptions list.
+	for ( let i = 0; i < participleIndex; i++ ) {
+		if ( includes( precedenceExceptions, wordsInSentencePart[ i ] ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/stringProcessing/precedenceExceptionWithoutRegex.js
+++ b/src/stringProcessing/precedenceExceptionWithoutRegex.js
@@ -17,7 +17,7 @@ const cannotBeBetweenPassiveAuxiliaryAndParticiple = {
  * If this is the case, the sentence part is not passive.
  *
  * @param {string} sentencePart The sentence part that contains the participle.
- * @param {number} participle   The participle.
+ * @param {string} participle   The participle.
  * @param {string} language     The language of the participle.
  *
  * @returns {boolean} Returns true if a word from the precedence exception list occurs anywhere in the

--- a/src/values/Participle.js
+++ b/src/values/Participle.js
@@ -1,8 +1,6 @@
-import { getType } from "./../helpers/types.js";
-import { isSameType } from "./../helpers/types.js";
+import { defaults, forEach, isString } from "lodash-es";
 
-import { defaults } from "lodash-es";
-import { forEach } from "lodash-es";
+import { getType, isSameType } from "./../helpers/types";
 
 /**
  * Default attributes to be used by the Participle if they are left undefined.
@@ -59,6 +57,9 @@ var Participle = function( participle, sentencePart, attributes ) {
 Participle.prototype.setParticiple = function( participle ) {
 	if ( participle === "" ) {
 		throw Error( "The participle should not be empty." );
+	}
+	if ( ! isString( participle ) ) {
+		throw Error( "The participle should be a string." );
 	}
 	this._participle = participle;
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Chrome browser tab would crash on Windows when a French or Italian text contains sentences in passive voice. Thanks for the input @CarloCannas.

## Relevant technical choices:

* Refactor of `directPrecedenceExceptionWithoutRegex`.
  - Changed it to handle sentence parts and participle as a word to make it easier to implement in our current code.
  - Added support to the other direct precedence languages too.
  - Changed the `Participle` classes of those languages (Dutch, English, French, Italian and Spanish -- Polish already used it) to use this version instead of the regex one.
* Added `precedenceExceptionWithoutRegex`.
  - Changed the `Participle` classes that used `precedenceExpection` to use this version instead (English, French, Italian and Spanish).
* Added a string check to the `setParticiple` function of the `Participle` base class, that throws an error when trying to set any other type. This to make it even more clear non-string is not supported, as I saw tests using null as participle and still calling the `directPrecedenceException` (withoutRegex) function. Which will error. Removed these offending lines in the specs (Italian and Spanish empty tests).
* Added French function word to the list `l'avoir`. This is due to the word boundary regexes not being applied to the function words anymore. Which is very much intentional and the point of this fix. However, a side effect is there might be more cases like this that did get matched before, that no longer work.

## Test instructions

This PR can be tested by following these steps:

On Windows 10, in the Chrome browser.
* Change WP Site Language to French (Français).
* Create a new Post/Page and enter French content: `Il a été le passivé. Il a été a passivé.`. This should no longer crash the browser tab. Possibly publish and change the text. Try a bit harder to make it fail. In my tests to see the issue it was not 100% always crashing the tab.
* Change WP Site Language to Italian (Italiano).
* Create a new Post/Page and enter Italian content: `Questa pagina è stata la modificata. Questa pagina è stata sto modificata.`. This should no longer crash the browser tab. Possibly publish and change the text. Try a bit harder to make it fail. In my tests to see the issue it was not 100% always crashing the tab.

* Repeat steps in Opera browser.

Other passive voices where also touched. Please take a look if they still behave as before.

Passive voice: Direct precedence exceptions:
* Dutch
* English
* French
* ~~German~~ -- already done differently (not with a regex).
* Italian
* ~~Polish~~ -- already changed in https://github.com/Yoast/YoastSEO.js/pull/1812
* Spanish

Passive voice: Precedence exceptions:
* English
* French
* Italian
* Spanish

Hotfix version.
Related to https://github.com/Yoast/YoastSEO.js/pull/1910
