### PR TITLE
Fix reference to empty self

### DIFF
--- a/src/helpers/shortlinker/singleton.js
+++ b/src/helpers/shortlinker/singleton.js
@@ -1,8 +1,16 @@
 import Shortlinker from "./Shortlinker";
 
-// Expose global variable.
-self.yoast = self.yoast || {};
-self.yoast.shortlinker = null;
+// Set global scope.
+let globalScope;
+
+if ( typeof window === "undefined" ) {
+	globalScope = self;
+} else {
+	globalScope = window;
+}
+
+globalScope.yoast = globalScope.yoast || {};
+globalScope.yoast.shortlinker = null;
 
 /**
  * Retrieves the Shortlinker instance.
@@ -10,10 +18,10 @@ self.yoast.shortlinker = null;
  * @returns {Shortlinker} The Shortlinker.
  */
 function getShortlinker() {
-	if ( self.yoast.shortlinker === null ) {
-		self.yoast.shortlinker = new Shortlinker();
+	if ( globalScope.yoast.shortlinker === null ) {
+		globalScope.yoast.shortlinker = new Shortlinker();
 	}
-	return self.yoast.shortlinker;
+	return globalScope.yoast.shortlinker;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where the Yoast SEO analysis would error if used together with the DelightfulDownloads plugin.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Check if regular operations are performed without error in Classic and Gutenberg:
  * Making a new post / page, saving
  * Opening / editing an existing post
  * Check if Yoast SEO analysis makes sense
* Install the [DelightfulDownloads plugin](https://wordpress.org/plugins/delightful-downloads/) and activate it
* Check if the regular operations are still performed without error in Classic and Gutenberg.

Fixes #1917 Fixes https://github.com/Yoast/wordpress-seo/issues/11403