### PR TITLE
Add recalibration functionality Outbound links assessment

### DIFF
--- a/spec/assessments/outboundLinksSpec.js
+++ b/spec/assessments/outboundLinksSpec.js
@@ -5,13 +5,17 @@ var i18n = factory.buildJed();
 
 const linkStatisticAssessment = new OutboundLinksAssessment();
 
-describe( "An assessor running the linkStatistics", function() {
-	var attributes = {
-		keyword: "keyword",
-		url: "http://example.com",
-	};
+var attributes = {
+	keyword: "keyword",
+	url: "http://example.com",
+};
 
-	it( "Tests a paper with some do-follow outbound links and no no-follow outbound links", function() {
+describe( "Tests outbound links assessment in regular analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+	} );
+
+	it( "Returns the right result when there are only do-follow outbound links", function() {
 		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
 
 		var mockResult = { externalDofollow: 1,
@@ -25,15 +29,37 @@ describe( "An assessor running the linkStatistics", function() {
 			otherTotal: 0,
 			total: 1,
 			totalKeyword: 0,
+			totalNaKeyword: 0 };
+
+		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!" );
+	} );
+
+	it( "Tests a paper with some do-follow outbound links and some no-follow outbound links", function() {
+		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
+
+		var mockResult = { externalDofollow: 1,
+			externalNofollow: 1,
+			externalTotal: 2,
+			internalDofollow: 0,
+			internalNofollow: 0,
+			internalTotal: 0,
+			otherDofollow: 0,
+			otherNofollow: 0,
+			otherTotal: 0,
+			total: 2,
+			totalKeyword: 0,
 			totalNaKeyword: 1 };
 
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 8 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: There are both nofollowed and normal outbound links on this page. Good job!" );
 	} );
 
-	it( "Tests a paper with some no-folow outbound links and no do-follow outbound links", function() {
+	it( "Tests a paper with some no-follow outbound links and no do-follow outbound links", function() {
 		const mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
 
 		var mockResult = { externalDofollow: 0,
@@ -55,7 +81,43 @@ describe( "An assessor running the linkStatistics", function() {
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: All outbound links on this page are nofollowed. <a href='https://yoa.st/34g' target='_blank'>Add some normal links</a>." );
 	} );
 
-	it( "Returns the right result when there are normal as well as nofollowed outbound links", function() {
+	it( "Tests a paper without outbound links", function() {
+		var mockPaper = new Paper( "" );
+		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!" );
+	} );
+} );
+
+describe( "Tests outbound links assessment in recalibration analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+	} );
+
+	it( "Returns the right result when there are only do-follow outbound links", function() {
+		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
+
+		var mockResult = { externalDofollow: 1,
+			externalNofollow: 0,
+			externalTotal: 1,
+			internalDofollow: 0,
+			internalNofollow: 0,
+			internalTotal: 0,
+			otherDofollow: 0,
+			otherNofollow: 0,
+			otherTotal: 0,
+			total: 1,
+			totalKeyword: 0,
+			totalNaKeyword: 0 };
+
+		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!" );
+	} );
+
+	it( "Tests a paper with some do-follow outbound links and some no-follow outbound links", function() {
 		var mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt=''>keyword link </a>"  );
 
 		var mockResult = { externalDofollow: 1,
@@ -69,7 +131,7 @@ describe( "An assessor running the linkStatistics", function() {
 			otherTotal: 0,
 			total: 2,
 			totalKeyword: 0,
-			totalNaKeyword: 2 };
+			totalNaKeyword: 1 };
 
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
 
@@ -77,11 +139,33 @@ describe( "An assessor running the linkStatistics", function() {
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: There are both nofollowed and normal outbound links on this page. Good job!" );
 	} );
 
+	it( "Tests a paper with some no-follow outbound links and no do-follow outbound links", function() {
+		const mockPaper = new Paper( "a test with a <a href='http://yoast.com' alt='' rel='nofollow'> link </a>", attributes );
+
+		var mockResult = { externalDofollow: 0,
+			externalNofollow: 1,
+			externalTotal: 1,
+			internalDofollow: 0,
+			internalNofollow: 0,
+			internalTotal: 0,
+			otherDofollow: 0,
+			otherNofollow: 0,
+			otherTotal: 0,
+			total: 1,
+			totalKeyword: 0,
+			totalNaKeyword: 0 };
+
+		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 7 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: All outbound links on this page are nofollowed. <a href='https://yoa.st/34g' target='_blank'>Add some normal links</a>." );
+	} );
+
 	it( "Tests a paper without outbound links", function() {
 		var mockPaper = new Paper( "" );
 		var assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
 
-		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!" );
 	} );
 } );

--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -89,7 +89,7 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 716 words. Good job!",
 	},
 	externalLinks: {
-		score: 8,
+		score: 9,
 		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
 	},
 	internalLinks: {

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -78,7 +78,7 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 908 words. Good job!",
 	},
 	externalLinks: {
-		score: 8,
+		score: 9,
 		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
 	},
 	internalLinks: {

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -72,7 +72,7 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 529 words. Good job!",
 	},
 	externalLinks: {
-		score: 8,
+		score: 9,
 		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
 	},
 	internalLinks: {

--- a/src/assessments/seo/OutboundLinksAssessment.js
+++ b/src/assessments/seo/OutboundLinksAssessment.js
@@ -20,9 +20,10 @@ export default class OutboundLinksAssessment extends Assessment {
 
 		const defaultConfig = {
 			scores: {
-				noLinks: 6,
+				noLinksRegular: 6,
+				noLinksRecalibration: 3,
 				allNofollowed: 7,
-				moreNoFollowed: 8,
+				someNoFollowed: 8,
 				allFollowed: 9,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/34f" ),
@@ -72,18 +73,22 @@ export default class OutboundLinksAssessment extends Assessment {
 	 */
 	calculateScore( linkStatistics ) {
 		if ( linkStatistics.externalTotal === 0 ) {
-			return this._config.scores.noLinks;
+			if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+				return this._config.scores.noLinksRecalibration;
+			}
+
+			return this._config.scores.noLinksRegular;
 		}
 
 		if ( linkStatistics.externalNofollow === linkStatistics.externalTotal ) {
 			return this._config.scores.allNofollowed;
 		}
 
-		if ( linkStatistics.externalNofollow < linkStatistics.externalTotal ) {
-			return this._config.scores.moreNoFollowed;
+		if ( linkStatistics.externalDofollow < linkStatistics.externalTotal ) {
+			return this._config.scores.someNoFollowed;
 		}
 
-		if ( linkStatistics.externalDofollow === linkStatistics.total ) {
+		if ( linkStatistics.externalDofollow === linkStatistics.externalTotal ) {
 			return this._config.scores.allFollowed;
 		}
 
@@ -133,7 +138,7 @@ export default class OutboundLinksAssessment extends Assessment {
 			);
 		}
 
-		if ( linkStatistics.externalNofollow < linkStatistics.externalTotal ) {
+		if ( linkStatistics.externalDofollow < linkStatistics.externalTotal ) {
 			return i18n.sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%2$s: " +


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the scoring schema of the outbound links assessment so that with absent outbound links the returned score gives a red bullet
* Fixes a bug where the text with all followed external links and some internal links would receive a score 8 instead of 9 (it was not user-facing, because both scores (8 and 9) return a green bullet).

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Use the new fancy example with the possibility to switch between recalibrated and non-recalibrated versions of the analysis
* Start non-recalibrated version using `yarn start`. Check if
  * If no external links are added, you get an orange bullet
  * If some external nofollow links are added, you get an orange bullet.
  * If more external follow links are added, you get a green bullet.
  * If only follow external links are present, you get a green bullet.
* Start a recalibrated version using `yarn start-recalibration`. Check if
  * If no external links are added, you get a **red** bullet
  * If some external nofollow links are added, you get an orange bullet.
  * If more external follow links are added, you get a green bullet.
  * If only follow external links are present, you get a green bullet.

Fixes #1929
