### PR TITLE
Add singleH1Assessment, remove urlLength and urlStopwords in Recalibration

### DIFF
--- a/spec/SEOAssessorSpec.js
+++ b/spec/SEOAssessorSpec.js
@@ -4,9 +4,14 @@ import factory from "./specHelpers/factory.js";
 import getResults from "./specHelpers/getAssessorResults";
 const i18n = factory.buildJed();
 
-const assessor = new Assessor( i18n );
+describe( "running assessments in the assessor for regular analysis", function() {
+	let assessor;
 
-describe( "running assessments in the assessor", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+		assessor = new Assessor( i18n );
+	} );
+
 	it( "runs assessments without any specific requirements", function() {
 		assessor.assess( new Paper( "" ) );
 		const AssessmentResults = assessor.getValidResults();
@@ -22,6 +27,22 @@ describe( "running assessments in the assessor", function() {
 
 	it( "additionally runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "runs the same set of assessments if the text contains two H1s", function() {
+		assessor.assess( new Paper( "<h1>First title</h1> text text <h1>Second title</h1>" ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 
@@ -103,8 +124,227 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a text and a url", function() {
-		assessor.assess( new Paper( "text", { url: "sample url" } ) );
+	it( "additionally runs assessments that require a text and a super-long url with stop words", function() {
+		assessor.assess( new Paper( "text", { url: "a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"urlLength",
+			"urlStopWords",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", url: "sample-url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"urlKeyword",
+		] );
+	} );
+
+	// These specifications will additionally trigger the largest keyword distance assessment.
+	it( "additionally runs assessments that require a long enough text and two keyword occurrences", function() {
+		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and one keyword occurrence and one synonym occurrence", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas synonym." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+} );
+
+describe( "running assessments in the assessor for recalibration analysis", function() {
+	let assessor;
+
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+		assessor = new Assessor( i18n );
+	} );
+
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs singleH1assessment if the text contains two H1s", function() {
+		assessor.assess( new Paper( "<h1>First title</h1><h1>Second title</h1>" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"singleH1",
+		] );
+	} );
+
+	it( "additionally runs assessments only require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
+	it( "additionally runs assessments that require text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
+		const text = "a ".repeat( 200 );
+		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a super-long url with stop words", function() {
+		assessor.assess( new Paper( "text", { url: "a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url" } ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 

--- a/spec/assessments/SingleH1AssessmentSpec.js
+++ b/spec/assessments/SingleH1AssessmentSpec.js
@@ -30,7 +30,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 2 } ] ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>. H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
+		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
 	} );
 
 	it( "returns a bad score and appropriate feedback when there are multiple one superfluous (i.e., non-title) H1s in the body of the text", function() {
@@ -41,7 +41,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 		] ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>. H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
+		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
 	} );
 } );
 

--- a/spec/assessments/SingleH1AssessmentSpec.js
+++ b/spec/assessments/SingleH1AssessmentSpec.js
@@ -1,0 +1,95 @@
+import SingleH1Assessment from "../../src/assessments/seo/SingleH1Assessment.js";
+import Paper from "../../src/values/Paper.js";
+import Factory from "../specHelpers/factory.js";
+const i18n = Factory.buildJed();
+import Mark from "../../src/values/Mark.js";
+
+const h1Assessment = new SingleH1Assessment();
+
+describe( "An assessment to check whether there is more than one H1 in the text", function() {
+	it( "returns the default result when the paper doesn't contain an H1", function() {
+		const mockPaper = new Paper( "<p>a paragraph</p>" );
+		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 0 );
+		expect( assessment.getText() ).toEqual( "" );
+		expect( assessment.hasScore() ).toEqual( false );
+	} );
+
+	it( "returns the default result when there's an H1 at the beginning of the body", function() {
+		const mockPaper = new Paper( "<h1>heading</h1><p>a paragraph</p>" );
+		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 0 } ] ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 0 );
+		expect( assessment.getText() ).toEqual( "" );
+		expect( assessment.hasScore() ).toEqual( false );
+	} );
+
+	it( "returns a bad score and appropriate feedback when there is one superfluous (i.e., non-title) H1s in the body of the text", function() {
+		const mockPaper = new Paper( "<p>a paragraph</p><h1>heading</h1>" );
+		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 2 } ] ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 1 );
+		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>. H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
+	} );
+
+	it( "returns a bad score and appropriate feedback when there are multiple one superfluous (i.e., non-title) H1s in the body of the text", function() {
+		const mockPaper = new Paper( "<p>a paragraph</p><h1>heading 1</h1><p>a paragraph</p><h1>heading 2</h1>" );
+		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ tag: "h1", content: "heading 1", position: 2 },
+			{ tag: "h1", content: "heading 2", position: 4 },
+		] ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 1 );
+		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>. H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
+	} );
+} );
+
+describe( "A test for marking incorrect H1s in the body", function() {
+	it( "returns markers for incorrect H1s in the body", function() {
+		const mockPaper = new Paper( "<p>a paragraph</p><h1>heading</h1>" );
+		const assessment = h1Assessment;
+		assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 2 } ] ), i18n );
+
+		const expected = [
+			new Mark( { original: "<h1>heading</h1>",
+				marked: "<h1><yoastmark class='yoast-text-mark'>heading</yoastmark></h1>" } ),
+		];
+
+		expect( assessment.getMarks() ).toEqual( expected );
+	} );
+
+	it( "doesn't return markers for H1s in the first position of the body", function() {
+		const mockPaper = new Paper( "<h1>heading</h1><p>a paragraph</p>" );
+		const assessment = h1Assessment;
+		assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 0 } ] ), i18n );
+		const expected = [];
+
+		expect( assessment.getMarks() ).toEqual( expected );
+	} );
+
+	it( "doesn't return markers when there are no H1s in the body", function() {
+		const mockPaper = new Paper( "<p>a paragraph</p>" );
+		const assessment = h1Assessment;
+		assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ), i18n );
+		const expected = [];
+
+		expect( assessment.getMarks() ).toEqual( expected );
+	} );
+} );
+
+describe( "Checks if the assessment is applicable", function() {
+	it( "is applicable when there is a paper with a text", function() {
+		const mockPaper = new Paper( "text" );
+		const assessment = h1Assessment.isApplicable( mockPaper );
+
+		expect( assessment ).toBe( true );
+	} );
+
+	it( "is not applicable when there there is no text", function() {
+		const mockPaper = new Paper( "" );
+		const assessment = h1Assessment.isApplicable( mockPaper );
+
+		expect( assessment ).toBe( false );
+	} );
+} );

--- a/spec/assessments/SingleH1AssessmentSpec.js
+++ b/spec/assessments/SingleH1AssessmentSpec.js
@@ -61,20 +61,16 @@ describe( "A test for marking incorrect H1s in the body", function() {
 
 	it( "doesn't return markers for H1s in the first position of the body", function() {
 		const mockPaper = new Paper( "<h1>heading</h1><p>a paragraph</p>" );
-		const assessment = h1Assessment;
-		assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 0 } ] ), i18n );
-		const expected = [];
+		const results = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 0 } ] ), i18n );
 
-		expect( assessment.getMarks() ).toEqual( expected );
+		expect( results._hasMarks ).toEqual( false );
 	} );
 
 	it( "doesn't return markers when there are no H1s in the body", function() {
 		const mockPaper = new Paper( "<p>a paragraph</p>" );
-		const assessment = h1Assessment;
-		assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ), i18n );
-		const expected = [];
+		const results = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ), i18n );
 
-		expect( assessment.getMarks() ).toEqual( expected );
+		expect( results._hasMarks ).toEqual( false );
 	} );
 } );
 

--- a/spec/assessments/SingleH1AssessmentSpec.js
+++ b/spec/assessments/SingleH1AssessmentSpec.js
@@ -30,7 +30,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 2 } ] ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
+		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: H1s should only be used as your main title. Find all H1s in your text that aren't your main title and <a href='https://yoa.st/3a7' target='_blank'>change them to a lower heading level</a>!" );
 	} );
 
 	it( "returns a bad score and appropriate feedback when there are multiple one superfluous (i.e., non-title) H1s in the body of the text", function() {
@@ -41,7 +41,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 		] ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 1 );
-		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: H1s should only be used as your main title. Find all H1s in your text that aren't your main title. <a href='https://yoa.st/3a7' target='_blank'>Use a lower heading level</a>!" );
+		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: H1s should only be used as your main title. Find all H1s in your text that aren't your main title and <a href='https://yoa.st/3a7' target='_blank'>change them to a lower heading level</a>!" );
 	} );
 } );
 

--- a/spec/cornerstone/SEOAssessorSpec.js
+++ b/spec/cornerstone/SEOAssessorSpec.js
@@ -4,9 +4,15 @@ import factory from "../specHelpers/factory.js";
 import getResults from "../specHelpers/getAssessorResults";
 
 const i18n = factory.buildJed();
-const assessor = new Assessor( i18n );
 
-describe( "running assessments in the assessor", function() {
+describe( "running assessments in the assessor for regular analysis", function() {
+	let assessor;
+
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+		assessor = new Assessor( i18n );
+	} );
+
 	it( "runs assessments without any specific requirements", function() {
 		assessor.assess( new Paper( "" ) );
 		const AssessmentResults = assessor.getValidResults();
@@ -22,6 +28,22 @@ describe( "running assessments in the assessor", function() {
 
 	it( "additionally runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "returns the same set of assessments if the text contains two h1s", function() {
+		assessor.assess( new Paper( "<h1>Title1</h1><h1>Title2</h1>" ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 
@@ -85,8 +107,294 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a text and a url", function() {
-		assessor.assess( new Paper( "text", { url: "sample url" } ) );
+	it( "additionally runs assessments that require a text and a long url with stop words", function() {
+		assessor.assess( new Paper( "text", { url: "a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"urlLength",
+			"urlStopWords",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", url: "sample url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"urlKeyword",
+		] );
+	} );
+
+	// These specifications will additionally trigger the largest keyword distance assessment.
+	it( "additionally runs assessments that require a long enough text and two keyword occurrences", function() {
+		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and one keyword occurrence and one synonym occurrence", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas synonym." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	describe( "has configuration overrides", () => {
+		test( "MetaDescriptionLengthAssessment", () => {
+			const assessment = assessor.getAssessment( "metaDescriptionLength" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.tooLong ).toBe( 3 );
+			expect( assessment._config.scores.tooShort ).toBe( 3 );
+		} );
+
+		test( "SubHeadingsKeywordAssessment", () => {
+			const assessment = assessor.getAssessment( "subheadingsKeyword" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.noMatches ).toBe( 3 );
+			expect( assessment._config.scores.oneMatch ).toBe( 6 );
+			expect( assessment._config.scores.multipleMatches ).toBe( 9 );
+		} );
+
+		test( "TextImagesAssessment", () => {
+			const assessment = assessor.getAssessment( "textImages" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.noImages ).toBe( 3 );
+			expect( assessment._config.scores.withAltNonKeyword ).toBe( 3 );
+			expect( assessment._config.scores.withAlt ).toBe( 3 );
+			expect( assessment._config.scores.noAlt ).toBe( 3 );
+		} );
+
+		test( "TextLengthAssessment", () => {
+			const assessment = assessor.getAssessment( "textLength" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.recommendedMinimum ).toBe( 900 );
+			expect( assessment._config.slightlyBelowMinimum ).toBe( 400 );
+			expect( assessment._config.belowMinimum ).toBe( 300 );
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.belowMinimum ).toBe( -20 );
+			expect( assessment._config.scores.farBelowMinimum ).toBe( -20 );
+		} );
+
+		test( "OutboundLinksAssessment", () => {
+			const assessment = assessor.getAssessment( "externalLinks" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.noLinks ).toBe( 3 );
+		} );
+
+		test( "PageTitleWidthAssesment", () => {
+			const assessment = assessor.getAssessment( "titleWidth" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
+			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
+		} );
+
+		test( "UrlKeywordAssessment", () => {
+			const assessment = assessor.getAssessment( "urlKeyword" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.okay ).toBe( 3 );
+		} );
+
+		test( "UrlLengthAssessment", () => {
+			const assessment = assessor.getAssessment( "urlLength" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.tooLong ).toBe( 3 );
+		} );
+	} );
+} );
+
+describe( "running assessments in the assessor for recalibration analysis", function() {
+	let assessor;
+
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+		assessor = new Assessor( i18n );
+	} );
+
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally returns a singleH1Assessment if the text contains two h1s", function() {
+		assessor.assess( new Paper( "<h1>Title1</h1><h1>Title2</h1>" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+			"singleH1",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a keyword with function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
+		const text = "a ".repeat( 200 );
+		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a long url with stop words", function() {
+		assessor.assess( new Paper( "text", { url: "a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url" } ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 
@@ -253,15 +561,6 @@ describe( "running assessments in the assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.okay ).toBe( 3 );
-		} );
-
-		test( "UrlLengthAssessment", () => {
-			const assessment = assessor.getAssessment( "urlLength" );
-
-			expect( assessment ).toBeDefined();
-			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.tooLong ).toBe( 3 );
 		} );
 	} );
 } );

--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -7,9 +7,22 @@ describe( "Gets all H1s in the text", function() {
 		expect( h1s( mockPaper ) ).toEqual( [] );
 	} );
 
+	it( "should return one object when there is one H1", function() {
+		const mockPaper = new Paper( "<h1>first h1</h1>some content<h2>content h2</h2>" );
+		expect( h1s( mockPaper ) ).toEqual( [ { tag: "h1", content: "first h1", position: 0 } ] );
+	} );
+
 	it( "should return all H1s in the text", function() {
 		const mockPaper = new Paper( "<h1>first h1</h1><p>not an h1</p><h1>second h1</h1><h2>not an h1</h2>" );
 
+		expect( h1s( mockPaper ) ).toEqual( [
+			{ tag: "h1", content: "first h1", position: 0 },
+			{ tag: "h1", content: "second h1", position: 2 },
+		] );
+	} );
+
+	it( "should find H1 within division tags", function() {
+		const mockPaper = new Paper( "<div><h1>first h1</h1></div><div><p>blah blah</p></div><div><h1>second h1</h1></div>" );
 		expect( h1s( mockPaper ) ).toEqual( [
 			{ tag: "h1", content: "first h1", position: 0 },
 			{ tag: "h1", content: "second h1", position: 2 },

--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -1,0 +1,18 @@
+import h1s from "../../src/researches/h1s.js";
+import Paper from "../../src/values/Paper.js";
+
+describe( "Gets all H1s in the text", function() {
+	it( "should return empty when there is no H1", function() {
+		const mockPaper = new Paper( "some content<h2>content h2</h2>" );
+		expect( h1s( mockPaper ) ).toEqual( [] );
+	} );
+
+	it( "should return all H1s in the text", function() {
+		const mockPaper = new Paper( "<h1>first h1</h1><p>not an h1</p><h1>second h1</h1><h2>not an h1</h2>" );
+
+		expect( h1s( mockPaper ) ).toEqual( [
+			{ tag: "h1", content: "first h1", position: 0 },
+			{ tag: "h1", content: "second h1", position: 2 },
+		] );
+	} );
+} );

--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -2,10 +2,16 @@ import Assessor from "../src/taxonomyAssessor.js";
 import Paper from "../src/values/Paper.js";
 import factory from "./specHelpers/factory.js";
 const i18n = factory.buildJed();
-const assessor = new Assessor( i18n );
 import getResults from "./specHelpers/getAssessorResults";
 
-describe( "running assessments in the assessor", function() {
+describe( "running assessments in the assessor for regular analysis", function() {
+	let assessor;
+
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+		assessor = new Assessor( i18n );
+	} );
+
 	it( "runs assessments without any specific requirements", function() {
 		assessor.assess( new Paper( "" ) );
 		const AssessmentResults = assessor.getValidResults();
@@ -21,6 +27,19 @@ describe( "running assessments in the assessor", function() {
 
 	it( "additionally runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "runs the same set of assessments if text contains two H1s", function() {
+		assessor.assess( new Paper( "<h1>Title1</h1><h1>Title2</h1>" ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 
@@ -75,8 +94,160 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a text and a url", function() {
-		assessor.assess( new Paper( "text", { url: "www.website.com" } ) );
+	it( "additionally runs assessments that require a text and a long url with a stop word", function() {
+		assessor.assess( new Paper( "text", { url: "www.website.com/a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+			"urlLength",
+			"urlStopWords",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { url: "sample url", keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+			"urlKeyword",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a keyword and a meta description", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+} );
+
+describe( "running assessments in the assessor for recalibration analysis", function() {
+	let assessor;
+
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+		assessor = new Assessor( i18n );
+	} );
+
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally returns a singleH1assessment if text contains two H1s", function() {
+		assessor.assess( new Paper( "<h1>Title1</h1><h1>Title2</h1>" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+			"singleH1",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a keyword and a title", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", title: "title" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"taxonomyTextLength",
+			"titleKeyword",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a long url with a stop word", function() {
+		assessor.assess( new Paper( "text", { url: "www.website.com/a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test-a-test" } ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 

--- a/src/assessments/seo/SingleH1Assessment.js
+++ b/src/assessments/seo/SingleH1Assessment.js
@@ -93,7 +93,7 @@ class singleH1Assessment extends Assessment {
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sSingle title%3$s. H1s should only be used as your main title. Find all H1s in your text " +
+					"%1$sSingle title%3$s: H1s should only be used as your main title. Find all H1s in your text " +
 					"that aren't your main title. %2$sUse a lower heading level%3$s!"
 				),
 				this._config.urlTitle,

--- a/src/assessments/seo/SingleH1Assessment.js
+++ b/src/assessments/seo/SingleH1Assessment.js
@@ -1,0 +1,152 @@
+import map from "lodash/map";
+import merge from "lodash/merge";
+
+import Assessment from "../../assessment.js";
+import { createAnchorOpeningTag } from "../../helpers/shortlinker";
+import marker from "../../markers/addMark.js";
+import AssessmentResult from "../../values/AssessmentResult.js";
+import Mark from "../../values/Mark.js";
+
+/**
+ * Assessment to check whether the body of the text contains H1s in the body (except at the very beginning,
+ * where they are acceptable).
+ */
+class singleH1Assessment extends Assessment {
+	/**
+	 * Sets the identifier and the config.
+	 *
+	 * @param {Object} config The configuration to use.
+	 *
+	 * @returns {void}
+	 */
+	constructor( config = {} ) {
+		super();
+
+		const defaultConfig = {
+			scores: {
+				textContainsSuperfluousH1: 1,
+			},
+			urlTitle: createAnchorOpeningTag( "https://yoa.st/3a6" ),
+			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/3a7" ),
+		};
+
+		this.identifier = "singleH1";
+		this._config = merge( defaultConfig, config );
+	}
+
+	/**
+	 * Runs the h1 research and based on this returns an assessment result with a score.
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 * @param {Researcher} researcher The researcher used for calling the research.
+	 * @param {Object} i18n The object used for translations
+	 *
+	 * @returns {AssessmentResult} The assessment result.
+	 */
+	getResult( paper, researcher, i18n ) {
+		this._h1s = researcher.getResearch( "h1s" );
+
+		const assessmentResult = new AssessmentResult();
+
+		// Returns the default assessment result if there are no H1s in the body.
+		if ( this._h1s.length === 0 ) {
+			return assessmentResult;
+		}
+
+		/*
+		 * Removes the first H1 from the array if that H1 is in the first position of the body.
+		 * The very beginning of the body is the only position where an H1 is deemed acceptable.
+		 */
+		if ( this.firstH1AtBeginning() ) {
+			this._h1s.shift();
+		}
+
+		assessmentResult.setScore( this.calculateScore() );
+		assessmentResult.setText( this.translateScore( i18n ) );
+		assessmentResult.setHasMarks( ( this.calculateScore() < 2 ) );
+
+		return assessmentResult;
+	}
+
+	/**
+	 * Checks whether an H1 is in the first position of the body.
+	 *
+	 * @returns {boolean} Returns true if there is an H1 in the first position of the body.
+	 */
+	firstH1AtBeginning() {
+		return ( this._h1s[ 0 ].position === 0 );
+	}
+
+	/**
+	 * Checks whether there are superfluous (i.e., non-title) H1s in the text.
+	 *
+	 * @returns {boolean} Returns true if there are superfluous H1s in the text.
+	 */
+	bodyContainsSuperfluousH1s() {
+		return ( this._h1s.length >= 1 );
+	}
+
+	/**
+	 * Returns the score for the single H1 assessment.
+	 *
+	 * @returns {number} The calculated score.
+	 */
+	calculateScore() {
+		if ( this.bodyContainsSuperfluousH1s() ) {
+			return this._config.scores.textContainsSuperfluousH1;
+		}
+	}
+
+	/**
+	 * Translates the score of the single H1 assessment to a message the user can understand.
+	 *
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {string} The translated string.
+	 */
+	translateScore( i18n ) {
+		if ( this.bodyContainsSuperfluousH1s() ) {
+			return i18n.sprintf(
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext(
+					"js-text-analysis",
+					"%1$sSingle title%3$s. H1s should only be used as your main title. Find all H1s in your text " +
+					"that aren't your main title. %2$sUse a lower heading level%3$s!"
+				),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>"
+			);
+		}
+	}
+
+	/**
+	 * Marks all H1s in the body of the text (except at the very beginning,
+	 * where they are acceptable and don't need to be changed).
+	 *
+	 * @returns {Array} Array with all the marked H1s.
+	 */
+	getMarks() {
+		const h1s = this._h1s;
+
+		return map( h1s, function( h1 ) {
+			return new Mark( {
+				original: "<h1>" + h1.content + "</h1>",
+				marked: "<h1>" + marker( h1.content ) + "</h1>",
+			} );
+		} );
+	}
+
+	/**
+	 * Checks whether the paper has a text.
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 *
+	 * @returns {boolean} True when there is text.
+	 */
+	isApplicable( paper ) {
+		return paper.hasText();
+	}
+}
+
+export default singleH1Assessment;

--- a/src/assessments/seo/SingleH1Assessment.js
+++ b/src/assessments/seo/SingleH1Assessment.js
@@ -94,7 +94,7 @@ class singleH1Assessment extends Assessment {
 				i18n.dgettext(
 					"js-text-analysis",
 					"%1$sSingle title%3$s: H1s should only be used as your main title. Find all H1s in your text " +
-					"that aren't your main title. %2$sUse a lower heading level%3$s!"
+					"that aren't your main title and %2$schange them to a lower heading level%3$s!"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -19,6 +19,7 @@ import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
 import UrlLength from "../assessments/seo/UrlLengthAssessment";
 import urlStopWords from "../assessments/seo/urlStopWordsAssessment";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
 
 /**
  * Creates the Assessor
@@ -33,75 +34,142 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 	this.type = "CornerstoneSEOAssessor";
 
-	this._assessments = [
-		new IntroductionKeywordAssessment(),
-		new KeyphraseLengthAssessment(),
-		new KeywordDensityAssessment(),
-		new MetaDescriptionKeywordAssessment(),
-		new MetaDescriptionLength( {
-			scores:	{
-				tooLong: 3,
-				tooShort: 3,
-			},
-		} ),
-		new SubheadingsKeyword(
-			{
-				scores: {
-					noMatches: 3,
-					oneMatch: 6,
-					multipleMatches: 9,
+	if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+		this._assessments = [
+			new IntroductionKeywordAssessment(),
+			new KeyphraseLengthAssessment(),
+			new KeywordDensityAssessment(),
+			new MetaDescriptionKeywordAssessment(),
+			new MetaDescriptionLength( {
+				scores:	{
+					tooLong: 3,
+					tooShort: 3,
 				},
-			}
-		),
-		new TextCompetingLinksAssessment(),
-		new TextImages( {
-			scores: {
-				noImages: 3,
-				withAltNonKeyword: 3,
-				withAlt: 3,
-				noAlt: 3,
-			},
-		} ),
-		new TextLength( {
-			recommendedMinimum: 900,
-			slightlyBelowMinimum: 400,
-			belowMinimum: 300,
+			} ),
+			new SubheadingsKeyword(
+				{
+					scores: {
+						noMatches: 3,
+						oneMatch: 6,
+						multipleMatches: 9,
+					},
+				}
+			),
+			new TextCompetingLinksAssessment(),
+			new TextImages( {
+				scores: {
+					noImages: 3,
+					withAltNonKeyword: 3,
+					withAlt: 3,
+					noAlt: 3,
+				},
+			} ),
+			new TextLength( {
+				recommendedMinimum: 900,
+				slightlyBelowMinimum: 400,
+				belowMinimum: 300,
 
-			scores: {
-				belowMinimum: -20,
-				farBelowMinimum: -20,
-			},
-		} ),
-		new OutboundLinks( {
-			scores: {
-				noLinks: 3,
-			},
-		} ),
-		new TitleKeywordAssessment(),
-		new InternalLinksAssessment(),
-		new TitleWidth(
-			{
 				scores: {
-					widthTooShort: 3,
-					widthTooLong: 3,
+					belowMinimum: -20,
+					farBelowMinimum: -20,
 				},
-			}
-		),
-		new UrlKeywordAssessment(
-			{
+			} ),
+			new OutboundLinks( {
 				scores: {
-					okay: 3,
+					noLinks: 3,
 				},
-			}
-		),
-		new UrlLength( {
-			scores: {
-				tooLong: 3,
-			},
-		} ),
-		urlStopWords,
-		new FunctionWordsInKeyphrase(),
-	];
+			} ),
+			new TitleKeywordAssessment(),
+			new InternalLinksAssessment(),
+			new TitleWidth(
+				{
+					scores: {
+						widthTooShort: 3,
+						widthTooLong: 3,
+					},
+				}
+			),
+			new UrlKeywordAssessment(
+				{
+					scores: {
+						okay: 3,
+					},
+				}
+			),
+			new FunctionWordsInKeyphrase(),
+			new SingleH1Assessment(),
+		];
+	} else {
+		this._assessments = [
+			new IntroductionKeywordAssessment(),
+			new KeyphraseLengthAssessment(),
+			new KeywordDensityAssessment(),
+			new MetaDescriptionKeywordAssessment(),
+			new MetaDescriptionLength( {
+				scores:	{
+					tooLong: 3,
+					tooShort: 3,
+				},
+			} ),
+			new SubheadingsKeyword(
+				{
+					scores: {
+						noMatches: 3,
+						oneMatch: 6,
+						multipleMatches: 9,
+					},
+				}
+			),
+			new TextCompetingLinksAssessment(),
+			new TextImages( {
+				scores: {
+					noImages: 3,
+					withAltNonKeyword: 3,
+					withAlt: 3,
+					noAlt: 3,
+				},
+			} ),
+			new TextLength( {
+				recommendedMinimum: 900,
+				slightlyBelowMinimum: 400,
+				belowMinimum: 300,
+
+				scores: {
+					belowMinimum: -20,
+					farBelowMinimum: -20,
+				},
+			} ),
+			new OutboundLinks( {
+				scores: {
+					noLinks: 3,
+				},
+			} ),
+			new TitleKeywordAssessment(),
+			new InternalLinksAssessment(),
+			new TitleWidth(
+				{
+					scores: {
+						widthTooShort: 3,
+						widthTooLong: 3,
+					},
+				}
+			),
+			new UrlKeywordAssessment(
+				{
+					scores: {
+						okay: 3,
+					},
+				}
+			),
+			new UrlLength( {
+				scores: {
+					tooLong: 3,
+				},
+			} ),
+			urlStopWords,
+			new FunctionWordsInKeyphrase(),
+		];
+	}
 };
 
 inherits( CornerstoneSEOAssessor, SEOAssessor );

--- a/src/researcher.js
+++ b/src/researcher.js
@@ -45,6 +45,7 @@ const keyphraseDistribution = keyphraseDistributionResearcher;
 import { research } from "./researches/buildKeywordForms";
 const morphology = research;
 import functionWordsInKeyphrase from "./researches/functionWordsInKeyphrase";
+import h1s from "./researches/h1s";
 
 /**
  * This contains all possible, default researches.
@@ -92,6 +93,7 @@ var Researcher = function( paper ) {
 		keyphraseDistribution: keyphraseDistribution,
 		morphology: morphology,
 		functionWordsInKeyphrase: functionWordsInKeyphrase,
+		h1s: h1s,
 	};
 
 	this._data = {};

--- a/src/researches/h1s.js
+++ b/src/researches/h1s.js
@@ -1,0 +1,80 @@
+// We use an external library, which can be found here: https://github.com/fb55/htmlparser2.
+import htmlparser from "htmlparser2";
+import isEmpty from "lodash/isEmpty";
+
+/**
+ * Gets all H1s in a text, including their content and their position with regards to other HTML blocks.
+ *
+ * @param {Paper} paper The paper for which to get the H1s.
+ *
+ * @returns {Array} An array with all H1s, their content and position.
+ */
+export default function( paper ) {
+	const text = paper.getText();
+	const allHTMLBlocks = [];
+	let isH1 = false;
+	let htmlBlock = {};
+	const h1s = [];
+
+	/*
+	 * Gets the tag names for all HTML blocks. In case an HTML block is an H1, also the content is included.
+	 * The content is required for marking.
+	 */
+	const parser = new htmlparser.Parser( {
+		/**
+		 * Processes the opening h1 tags.
+		 *
+		 * @param {string} tagName The name of the tag.
+		 *
+		 * @returns {void}
+		 */
+		onopentag: function( tagName ) {
+			htmlBlock.tag = tagName;
+			if ( tagName === "h1" ) {
+				isH1 = true;
+			}
+		},
+		/**
+		 * Saves content of the H1 tags.
+		 *
+		 * @param {string} text The input text.
+		 *
+		 * @returns {void}
+		 */
+		ontext: function( text ) {
+			if ( isH1 === true ) {
+				htmlBlock.content = text;
+			}
+			if ( ! isEmpty( htmlBlock ) ) {
+				allHTMLBlocks.push( htmlBlock );
+			}
+			htmlBlock = {};
+		},
+		/**
+		 * Processes the closing h1 tags.
+		 *
+		 * @param {string} tagName The name of the tag.
+		 *
+		 * @returns {void}
+		 */
+		onclosetag: function( tagName ) {
+			if ( tagName === "h1" ) {
+				isH1 = false;
+			}
+		},
+	}, { decodeEntities: true } );
+
+	parser.write( text );
+
+	// Pushes all H1s into an array and adds their position with regards to the other HTML blocks in the body.
+	for ( let i = 0; i < allHTMLBlocks.length; i++ ) {
+		if ( allHTMLBlocks[ i ].tag !== "h1" ) {
+			continue;
+		}
+
+		allHTMLBlocks[ i ].position = i;
+		h1s.push( allHTMLBlocks[ i ] );
+	}
+
+	return h1s;
+}

--- a/src/seoAssessor.js
+++ b/src/seoAssessor.js
@@ -18,6 +18,7 @@ import TitleWidth from "./assessments/seo/PageTitleWidthAssessment";
 import UrlLength from "./assessments/seo/UrlLengthAssessment";
 import urlStopWords from "./assessments/seo/urlStopWordsAssessment";
 import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
+import SingleH1Assessment from "./assessments/seo/SingleH1Assessment";
 /**
  * Creates the Assessor
  *
@@ -31,25 +32,46 @@ const SEOAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 	this.type = "SEOAssessor";
 
-	this._assessments = [
-		new IntroductionKeywordAssessment(),
-		new KeyphraseLengthAssessment(),
-		new KeywordDensityAssessment(),
-		new MetaDescriptionKeywordAssessment(),
-		new MetaDescriptionLength(),
-		new SubheadingsKeyword(),
-		new TextCompetingLinksAssessment(),
-		new TextImages(),
-		new TextLength(),
-		new OutboundLinks(),
-		new TitleKeywordAssessment(),
-		new InternalLinksAssessment(),
-		new TitleWidth(),
-		new UrlKeywordAssessment(),
-		new UrlLength(),
-		urlStopWords,
-		new FunctionWordsInKeyphrase(),
-	];
+	if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+		this._assessments = [
+			new IntroductionKeywordAssessment(),
+			new KeyphraseLengthAssessment(),
+			new KeywordDensityAssessment(),
+			new MetaDescriptionKeywordAssessment(),
+			new MetaDescriptionLength(),
+			new SubheadingsKeyword(),
+			new TextCompetingLinksAssessment(),
+			new TextImages(),
+			new TextLength(),
+			new OutboundLinks(),
+			new TitleKeywordAssessment(),
+			new InternalLinksAssessment(),
+			new TitleWidth(),
+			new UrlKeywordAssessment(),
+			new FunctionWordsInKeyphrase(),
+			new SingleH1Assessment(),
+		];
+	} else {
+		this._assessments = [
+			new IntroductionKeywordAssessment(),
+			new KeyphraseLengthAssessment(),
+			new KeywordDensityAssessment(),
+			new MetaDescriptionKeywordAssessment(),
+			new MetaDescriptionLength(),
+			new SubheadingsKeyword(),
+			new TextCompetingLinksAssessment(),
+			new TextImages(),
+			new TextLength(),
+			new OutboundLinks(),
+			new TitleKeywordAssessment(),
+			new InternalLinksAssessment(),
+			new TitleWidth(),
+			new UrlKeywordAssessment(),
+			new UrlLength(),
+			urlStopWords,
+			new FunctionWordsInKeyphrase(),
+		];
+	}
 };
 
 inherits( SEOAssessor, Assessor );

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -13,6 +13,7 @@ import PageTitleWidthAssessment from "./assessments/seo/PageTitleWidthAssessment
 import UrlLengthAssessment from "./assessments/seo/UrlLengthAssessment";
 import urlStopWordsAssessment from "./assessments/seo/urlStopWordsAssessment";
 import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
+import SingleH1Assessment from "./assessments/seo/SingleH1Assessment";
 
 /**
  * Creates the Assessor used for taxonomy pages.
@@ -24,20 +25,36 @@ const TaxonomyAssessor = function( i18n ) {
 	Assessor.call( this, i18n );
 	this.type = "TaxonomyAssessor";
 
-	this._assessments = [
-		new IntroductionKeywordAssessment(),
-		new KeyphraseLengthAssessment(),
-		new KeywordDensityAssessment(),
-		new MetaDescriptionKeywordAssessment(),
-		new MetaDescriptionLengthAssessment(),
-		taxonomyTextLengthAssessment,
-		new TitleKeywordAssessment(),
-		new PageTitleWidthAssessment(),
-		new UrlKeywordAssessment(),
-		new UrlLengthAssessment(),
-		urlStopWordsAssessment,
-		new FunctionWordsInKeyphrase(),
-	];
+	if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+		this._assessments = [
+			new IntroductionKeywordAssessment(),
+			new KeyphraseLengthAssessment(),
+			new KeywordDensityAssessment(),
+			new MetaDescriptionKeywordAssessment(),
+			new MetaDescriptionLengthAssessment(),
+			taxonomyTextLengthAssessment,
+			new TitleKeywordAssessment(),
+			new PageTitleWidthAssessment(),
+			new UrlKeywordAssessment(),
+			new FunctionWordsInKeyphrase(),
+			new SingleH1Assessment(),
+		];
+	} else {
+		this._assessments = [
+			new IntroductionKeywordAssessment(),
+			new KeyphraseLengthAssessment(),
+			new KeywordDensityAssessment(),
+			new MetaDescriptionKeywordAssessment(),
+			new MetaDescriptionLengthAssessment(),
+			taxonomyTextLengthAssessment,
+			new TitleKeywordAssessment(),
+			new PageTitleWidthAssessment(),
+			new UrlKeywordAssessment(),
+			new UrlLengthAssessment(),
+			urlStopWordsAssessment,
+			new FunctionWordsInKeyphrase(),
+		];
+	}
 };
 
 inherits( TaxonomyAssessor, Assessor );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Deprecates two SEO assessments that check the length of the URL and whether stop words are used in the URL
* Adds an assessment that checks if the article has spurious uses of `<h1>`.

## Relevant technical choices:

* The SingleH1Assessment was transferred from the PR where it was introduced #1406. It makes use of the current HTML parser, making it run another time to pick up `<h1>` tags. @atimmer do you find it acceptable to run HTML parser in this way? Or would you suggest another solution?

## Test instructions

This PR can be tested by following these steps:

* Use the new example to compare regular and recalibration analysis.
* In the regular analysis, check if everything works as before:
  * Add a text with two H1s, no additional assessments should appear
  * Add a slug with a stop word, a urlStopWords assessment should trigger
  * Add a long slug, a urlLength assessment should trigger
* In the recalibration analysis:
  * Add a text with two H1s, a `Single title` assessment should trigger.
  * Add a text with a H1 at the beginning of the text. The `Single title` assessment shouldn't trigger.
  * Add a text with an H1 anywhere but the beginning of the title. The `Single title` should trigger.
  * Add a slug with a stop word, a urlStopWords assessment should **not** trigger
  * Add a long slug, a urlLength assessment should **not** trigger

Fixes #1926 Fixes #1927 Fixes #1928
