### PR TITLE
Add sentence beginnings assessment for Swedish

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,23 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 ```
 
 ## Supported languages
-|                     | English | German | Dutch | French | Spanish  | Italian | Japanese | Portuguese | Russian | Catalan | Polish |
-|---------------------|---------|--------|-------|--------|---------|---------|----------|----------|----------|----------|----------
-| Transition words    | ✅      | ✅     | ✅    | ✅      | ✅       | ✅       |          | ✅        | ✅       | ✅        | ✅        |
-| Flesch reading ease  | ✅      | ✅     | ✅    | ✅      | ✅       | ✅       | ❌<sup>2</sup>        |          | ✅        |          | ❌<sup>3</sup>
-| Passive voice       | ✅      | ✅     | ✅     | ✅     | ✅       | ✅       | ❌<sup>2</sup>        |          | ✅       |          | ✅        |
-| Sentence beginnings | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       | ❌<sup>2</sup>        |          | ✅       |          | ✅        |
-| Sentence length<sup>1</sup>     | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          |          | ✅       |          | ✅        |
-| Function words (for Internal linking and insights)      | ✅      | ✅     | ✅    | ✅     | ✅       | ✅       |          | ✅        | ✅       |          | ✅        |
+|                             | EN | DE | NL | FR | ES | IT | JA             | PT | RU | CA | PL             | SV             |
+|-----------------------------|----|----|----|----|----|----|----------------|----|----|----|----------------|----------------|
+| Transition words            | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ |                | ✅ | ✅ | ✅ | ✅             | ✅             |
+| Flesch reading ease         | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ | ❌<sup>3</sup> |    | ✅ |    | ❌<sup>4</sup> | ❌<sup>4</sup> |
+| Passive voice               | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ | ❌<sup>3</sup> |    | ✅ |    | ✅             | ✅             |
+| Sentence beginnings         | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ | ❌<sup>3</sup> |    | ✅ |    | ✅             | ✅             |
+| Sentence length<sup>1</sup> | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ |                |    | ✅ |    | ✅             | ✅             |
+| Function words<sup>2</sup>  | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ |                | ✅ | ✅ |    | ✅             | ✅             |
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
 
-<sup>2</sup> This means that this feature doesn't make sense for the specific language.
+<sup>2</sup> These are used for internal linking, insights and keyphrase-related analyses.
 
-<sup>3</sup> There is no existing Flesch reading ease formula for Polish
+<sup>3</sup> This means that this feature doesn't make sense for the specific language.
+
+<sup>4</sup> There is no existing Flesch reading ease formula for these languages.
+
 
 The following readability assessments are available for all languages: 
 - sentence length (with a default upper limit of 20 words, see<sup>1</sup> above )

--- a/README.md
+++ b/README.md
@@ -69,14 +69,20 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 ```
 
 ## Supported languages
-|                             | EN | DE | NL | FR | ES | IT | JA             | PT | RU | CA | PL             | SV             |
-|-----------------------------|----|----|----|----|----|----|----------------|----|----|----|----------------|----------------|
-| Transition words            | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ |                | ✅ | ✅ | ✅ | ✅             | ✅             |
-| Flesch reading ease         | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ | ❌<sup>3</sup> |    | ✅ |    | ❌<sup>4</sup> | ❌<sup>4</sup> |
-| Passive voice               | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ | ❌<sup>3</sup> |    | ✅ |    | ✅             | ✅             |
-| Sentence beginnings         | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ | ❌<sup>3</sup> |    | ✅ |    | ✅             | ✅             |
-| Sentence length<sup>1</sup> | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ |                |    | ✅ |    | ✅             | ✅             |
-| Function words<sup>2</sup>  | ✅ | ✅ | ✅ | ✅ | ✅  | ✅ |                | ✅ | ✅ |    | ✅             | ✅             |
+| Language   	| Transition words 	| Flesch reading ease 	| Passive voice 	| Sentence beginnings 	| Sentence length<sup>1</sup> 	| Function words<sup>2</sup> 	|
+|------------	|------------------	|---------------------	|---------------	|---------------------	|-----------------------------	|----------------------------	|
+| English    	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| German     	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Dutch      	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| French     	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Spanish    	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Italian    	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Japanese   	|                  	| ❌<sup>3</sup>       	| ❌<sup>3</sup> 	| ❌<sup>3</sup>       	|                             	|                            	|
+| Portuguese 	| ✅                	|                     	|               	|                     	|                             	| ✅                          	|
+| Russian    	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Catalan    	| ✅                	|                     	|               	|                     	|                             	|                            	|
+| Polish     	| ✅                	| ❌<sup>4</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Swedish    	| ✅                	| ❌<sup>4</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
 

--- a/spec/assessments/sentenceBeginningsSpec.js
+++ b/spec/assessments/sentenceBeginningsSpec.js
@@ -127,6 +127,16 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		expect( assessment ).toBe( true );
 	} );
 
+	it( "is not applicable for a Swedish paper without text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "sv_SE" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for a Swedish paper with text.", function() {
+		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hej", { locale: "sv_SE" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
 	it( "is not applicable for a paper with text and a non-existing locale.", function() {
 		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hello", { locale: "xx_YY" } ) );
 		expect( assessment ).toBe( false );

--- a/spec/helpers/getFirstWordExceptionsSpec.js
+++ b/spec/helpers/getFirstWordExceptionsSpec.js
@@ -33,6 +33,10 @@ describe( "a test for getting the correct first word exception array", function(
 		expect( firstWordExceptions( "pl_PL" )() ).toEqual( [ "jeden", "jedna", "jedno", "dwa", "dwie", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "dziesięć", "ta", "to", "ten", "te", "ci", "taki", "tacy", "taka", "taką", "takich", "takie", "takiego", "takiej", "takiemu", "takim", "takimi", "tamten", "tamta", "tamto", "tamci", "tamte", "tamtą", "tamtego", "tamtej", "tamtemu", "tamtych", "tamtym", "tamtymi", "tą", "tę", "tego", "tej", "temu", "tych", "tymi", "tym", "tak" ] );
 	} );
 
+	it( "returns the Swedish first word exception array in case of sv_SE locale", function() {
+		expect( firstWordExceptions( "sv_SE" )() ).toEqual( [ "ett", "det", "den", "de", "en", "två", "tre", "fyra", "fem", "sex", "sju", "åtta", "nio", "tio", "denne", "denna", "detta", "dessa" ] );
+	} );
+
 	it( "returns the English first word exception array in case of empty locale", function() {
 		expect( firstWordExceptions( "" )() ).toEqual( [ "the", "a", "an", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "this", "that", "these", "those" ] );
 	} );

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -208,6 +208,26 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with different words.", function() {
+		changePaper( { text: "Är du osäker, testa en kort fristående kurs hellre än ett program. Passar ämnet dig kan du hoppa på ett program och tillgodoräkna dig kursen.. ", locale: "sv_SE" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "är" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "passar" );
+		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with the same word.", function() {
+		changePaper( { text: "Du är lång. Du är kort.", locale: "sv_SE" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "du" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Swedish all starting with one of the exception words.", function() {
+		changePaper( { text: "Detta barn är litet. Detta barn är stort. Detta barn är lyckligt.", locale: "sv_SE" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "detta barn" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
 	it( "returns an object with English sentence beginnings in lists", function() {
 		changePaper( { text: "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "item", { locale: "en_US" } );

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -239,7 +239,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	} );
 
 	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with different words.", function() {
-		changePaper( { text: "Är du osäker, testa en kort fristående kurs hellre än ett program. Passar ämnet dig kan du hoppa på ett program och tillgodoräkna dig kursen.. ", locale: "sv_SE" } );
+		changePaper( { text: "Är du osäker, testa en kort fristående kurs hellre än ett program. Passar ämnet dig kan du hoppa på ett program och tillgodoräkna dig kursen.", locale: "sv_SE" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "är" );
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 1 );
 		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "passar" );

--- a/spec/researches/getSentenceBeginningsSpec.js
+++ b/spec/researches/getSentenceBeginningsSpec.js
@@ -85,6 +85,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for sentences in French that start with a character with a diacritic.", function() {
+		changePaper( { text: "À Paris, certaines prisons sont restées célèbres. À Paris, certaines prisons sont restées célèbres. À Paris, certaines prisons sont restées célèbres.", locale: "fr_FR" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "à" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
 	it( "returns an object with sentence beginnings and counts for two sentences in German starting with different words.", function() {
 		changePaper( { text: "Ich bin wie du. Auf wiedersehen. ", locale: "de_DE" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "ich" );
@@ -105,6 +111,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for sentences in German that start with a character with a diacritic.", function() {
+		changePaper( { text: "Österreich ist ein schönes Land. Österreich ist ein schönes Land. Österreich ist ein schönes Land.", locale: "de_DE" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "österreich" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
 	it( "returns an object with sentence beginnings and counts for two sentences in Spanish starting with different words.", function() {
 		changePaper( { text: "Vamos a la playa. Muy buenos. ", locale: "es_ES" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "vamos" );
@@ -122,6 +134,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	it( "returns an object with sentence beginnings and counts for three sentences in Spanish all starting with one of the exception words.", function() {
 		changePaper( { text: "Aquellas pequeñas cosas. Aquellas pequeñas decisiones. Aquellas pequeñas ideas.", locale: "es_ES" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "aquellas pequeñas" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for sentences in Spanish that start with a character with a diacritic.", function() {
+		changePaper( { text: "África es un gran continente. África es un gran continente. África es un gran continente.", locale: "es_ES" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "áfrica" );
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
@@ -165,6 +183,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for two sentences in Italian that start with a character with a diacritic.", function() {
+		changePaper( { text: "È freddo. È freddo.", locale: "it_IT" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "è" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 2 );
+	} );
+
 	it( "returns an object with sentence beginnings and counts for two sentences in Russian starting with the same word.", function() {
 		changePaper( { text: "Здравствуй, мир! Здравствуй, человек!", locale: "ru_RU" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "здравствуй" );
@@ -205,6 +229,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	it( "returns an object with sentence beginnings and counts for three sentences in Polish all starting with one of the exception words.", function() {
 		changePaper( { text: "To dziecko jest ładne. To dziecko jest brzydkie. To dziecko jest małe.", locale: "pl_PL" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "to dziecko" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Polish that start with a character with a diacritic.", function() {
+		changePaper( { text: "Żona mojego brata jest miła. Żona mojej siostry jest piękna. Żona moja jest najlepsza.", locale: "pl_PL" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "żona" );
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
@@ -275,5 +305,19 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	it( "returns matching sentences if there is an 'empty' sentence", function() {
 		changePaper( { text: "\"A sentence with multiple terminators!\"). Test one. Test two. Test three." } );
 		expect( getSentenceBeginnings() ).toContainEqual( { word: "test", count: 3, sentences: [ "Test one.", "Test two.", "Test three." ] } );
+	} );
+
+	it( "returns an object with three Spanish sentences starting with the same word when those words are preceded by different special characters in each sentence.", function() {
+		changePaper( { text: "¡Hola! ¡Hola? (¡Hola!)" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "hola", { locale: "es_ES" } );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in English, when the sentences start with the same special character, but with different words.", function() {
+		changePaper( { text: "(First sentence). (Second sentence).", locale: "en_US" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "first" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "second" );
+		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
 	} );
 } );

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -9,7 +9,7 @@ import Mark from "../../values/Mark";
 const maximumConsecutiveDuplicates = 2;
 
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/src/helpers/getFirstWordExceptions.js
+++ b/src/helpers/getFirstWordExceptions.js
@@ -6,6 +6,7 @@ import firstWordExceptionsDutch from "../researches/dutch/firstWordExceptions.js
 import firstWordExceptionsItalian from "../researches/italian/firstWordExceptions.js";
 import firstWordExceptionsRussian from "../researches/russian/firstWordExceptions.js";
 import firstWordExceptionsPolish from "../researches/polish/firstWordExceptions.js";
+import firstWordExceptionsSwedish from "../researches/swedish/firstWordExceptions.js";
 import getLanguage from "./getLanguage.js";
 
 /**
@@ -31,6 +32,8 @@ export default function( locale ) {
 		    return firstWordExceptionsRussian;
 		case "pl":
 			return firstWordExceptionsPolish;
+		case "sv":
+			return firstWordExceptionsSwedish;
 		default:
 		case "en":
 			return firstWordExceptionsEnglish;

--- a/src/researches/getSentenceBeginnings.js
+++ b/src/researches/getSentenceBeginnings.js
@@ -1,6 +1,5 @@
 import getWords from "../stringProcessing/getWords.js";
 import stripSpaces from "../stringProcessing/stripSpaces.js";
-import { stripFullTags as stripTags } from "../stringProcessing/stripHTMLTags.js";
 import getFirstWordExceptions from "../helpers/getFirstWordExceptions.js";
 
 import { isEmpty } from "lodash-es";
@@ -52,19 +51,6 @@ const compareFirstWords = function( sentenceBeginnings, sentences ) {
 };
 
 /**
- * Sanitizes the sentence.
- *
- * @param {string} sentence The sentence to sanitize.
- * @returns {string} The sanitized sentence.
- */
-function sanitizeSentence( sentence ) {
-	sentence = stripTags( sentence );
-	sentence = sentence.replace( /^[^A-Za-zА-Яа-я0-9]/, "" );
-
-	return sentence;
-}
-
-/**
  * Retrieves the first word from the sentence.
  *
  * @param {string} sentence The sentence to retrieve the first word from.
@@ -72,8 +58,6 @@ function sanitizeSentence( sentence ) {
  * @returns {string} The first word of the sentence.
  */
 function getSentenceBeginning( sentence, firstWordExceptions ) {
-	sentence = sanitizeSentence( sentence );
-
 	const words = getWords( stripSpaces( sentence ) );
 
 	if ( words.length === 0 ) {

--- a/src/researches/getSentenceBeginnings.js
+++ b/src/researches/getSentenceBeginnings.js
@@ -1,6 +1,7 @@
 import getWords from "../stringProcessing/getWords.js";
 import stripSpaces from "../stringProcessing/stripSpaces.js";
 import getFirstWordExceptions from "../helpers/getFirstWordExceptions.js";
+import { stripFullTags as stripTags } from "../stringProcessing/stripHTMLTags.js";
 
 import { isEmpty } from "lodash-es";
 import { forEach } from "lodash-es";
@@ -58,7 +59,7 @@ const compareFirstWords = function( sentenceBeginnings, sentences ) {
  * @returns {string} The first word of the sentence.
  */
 function getSentenceBeginning( sentence, firstWordExceptions ) {
-	const words = getWords( stripSpaces( sentence ) );
+	const words = getWords( stripTags( stripSpaces( sentence ) ) );
 
 	if ( words.length === 0 ) {
 		return "";

--- a/src/researches/swedish/firstWordExceptions.js
+++ b/src/researches/swedish/firstWordExceptions.js
@@ -1,12 +1,13 @@
 /**
- *  Returns an array with exceptions for the sentence beginning researcher.
- *  @returns {Array} The array filled with exceptions.
- *  */
+ * Returns an array with exceptions for the sentence beginning researcher.
+ *
+ * @returns {string[]} The array filled with exceptions.
+ */
 export default function() {
 	return [
-		// Indefinite articles
+		// Indefinite articles:
 		"ett",
-		// Definite articles
+		// Definite articles:
 		"det", "den", "de",
 		// Numbers 1-10:
 		"en", "två", "tre", "fyra", "fem", "sex", "sju", "åtta", "nio", "tio",

--- a/src/researches/swedish/firstWordExceptions.js
+++ b/src/researches/swedish/firstWordExceptions.js
@@ -1,0 +1,16 @@
+/**
+ *  Returns an array with exceptions for the sentence beginning researcher.
+ *  @returns {Array} The array filled with exceptions.
+ *  */
+export default function() {
+	return [
+		// Indefinite articles
+		"ett",
+		// Definite articles
+		"det", "den", "de",
+		// Numbers 1-10:
+		"en", "två", "tre", "fyra", "fem", "sex", "sju", "åtta", "nio", "tio",
+		// Demonstrative pronouns:
+		"denne", "denna", "detta", "dessa",
+	];
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds Swedish sentence beginnings assessment

## Relevant technical choices:

* The function to sanitize sentences was removed, as words already get sanitised through another function

## Test instructions

This PR can be tested by following these steps:

## Browserified

* Set locale to Swedish (sv_SE).
* Paste the same Swedish sentence multiple times (three or more)
* The sentence beginnings assessment should be negative for the repeated sentences, _unless_ they start with a word from the exception list

## WordPress

* Set locale to Swedish (sv_SE).
* Paste the same Swedish sentence multiple times (three or more)
* The sentence beginnings assessment should be negative for the repeated sentences, _unless_ they start with a word from the exception list

Fixes #1944
