### PR TITLE
1939 taxonomy assessor should use normal text length assessment

### DIFF
--- a/spec/assessments/taxonomyTextLengthRecalibrationSpec.js
+++ b/spec/assessments/taxonomyTextLengthRecalibrationSpec.js
@@ -12,7 +12,7 @@ describe( "A taxonomy page text length assessment, with the recalibration logic 
 		const mockPaper = new Paper( "sample" );
 		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
 
-		expect( result.getScore() ).toEqual( - 20 );
+		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 1 word. " +
 			"This is far below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );
@@ -21,7 +21,7 @@ describe( "A taxonomy page text length assessment, with the recalibration logic 
 		const mockPaper = new Paper( "sample" );
 		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
 
-		expect( result.getScore() ).toEqual( - 20 );
+		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 5 words. " +
 			"This is far below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );
@@ -30,7 +30,7 @@ describe( "A taxonomy page text length assessment, with the recalibration logic 
 		const mockPaper = new Paper( "sample" );
 		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 51 ), i18n );
 
-		expect( result.getScore() ).toEqual( - 10 );
+		expect( result.getScore() ).toEqual( -10 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 51 words. " +
 			"This is far below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
 	} );

--- a/spec/assessments/taxonomyTextLengthRecalibrationSpec.js
+++ b/spec/assessments/taxonomyTextLengthRecalibrationSpec.js
@@ -1,11 +1,11 @@
 import Paper from "../../src/values/Paper.js";
 import Factory from "../specHelpers/factory.js";
-import TaxonomyAssessor from "../../src/taxonomyAssessor";
+import { getTextLengthAssessment } from "../../src/taxonomyAssessor";
 
 const i18n = Factory.buildJed();
 
 // Get the assessment used for the recalibration.
-const assessment = TaxonomyAssessor.prototype.getTextLengthAssessment( true );
+const assessment = getTextLengthAssessment( true );
 
 describe( "A taxonomy page text length assessment, with the recalibration logic applied.", function() {
 	it( "assesses a single word", function() {

--- a/spec/assessments/taxonomyTextLengthRecalibrationSpec.js
+++ b/spec/assessments/taxonomyTextLengthRecalibrationSpec.js
@@ -1,0 +1,63 @@
+import Paper from "../../src/values/Paper.js";
+import Factory from "../specHelpers/factory.js";
+import TaxonomyAssessor from "../../src/taxonomyAssessor";
+
+const i18n = Factory.buildJed();
+
+// Get the assessment used for the recalibration.
+const assessment = TaxonomyAssessor.prototype.getTextLengthAssessment( true );
+
+describe( "A taxonomy page text length assessment, with the recalibration logic applied.", function() {
+	it( "assesses a single word", function() {
+		const mockPaper = new Paper( "sample" );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
+
+		expect( result.getScore() ).toEqual( - 20 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 1 word. " +
+			"This is far below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "assesses a couple of words", function() {
+		const mockPaper = new Paper( "sample" );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
+
+		expect( result.getScore() ).toEqual( - 20 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 5 words. " +
+			"This is far below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "assesses words far below the minimum.", function() {
+		const mockPaper = new Paper( "sample" );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 51 ), i18n );
+
+		expect( result.getScore() ).toEqual( - 10 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 51 words. " +
+			"This is far below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "assesses words below the minimum.", function() {
+		const mockPaper = new Paper( "sample" );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 101 ), i18n );
+
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 101 words. " +
+			"This is below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "assesses words slightly below the minimum.", function() {
+		const mockPaper = new Paper( "sample" );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 201 ), i18n );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 201 words. " +
+			"This is slightly below the recommended minimum of 250 words. <a href='https://yoa.st/34k' target='_blank'>Add a bit more copy</a>." );
+	} );
+
+	it( "assesses words above the minimum.", function() {
+		const mockPaper = new Paper( "sample" );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 251 ), i18n );
+
+		expect( result.getScore() ).toEqual( 9 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 251 words. Good job!" );
+	} );
+} );

--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -14,7 +14,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 		] );
 	} );
@@ -27,7 +27,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 		] );
 	} );
@@ -41,7 +41,7 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 		] );
 	} );
@@ -54,7 +54,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 			"functionWordsInKeyphrase",
 		] );
@@ -69,7 +69,7 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleKeyword",
 			"titleWidth",
 		] );
@@ -83,7 +83,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 		] );
 	} );
@@ -97,7 +97,7 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 			"urlKeyword",
 		] );
@@ -113,7 +113,7 @@ describe( "running assessments in the assessor", function() {
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 		] );
 	} );
@@ -128,7 +128,7 @@ describe( "running assessments in the assessor", function() {
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
-			"taxonomyTextLength",
+			"textLength",
 			"titleWidth",
 		] );
 	} );

--- a/spec/taxonomyAssessorSpec.js
+++ b/spec/taxonomyAssessorSpec.js
@@ -14,7 +14,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 		] );
 	} );
@@ -27,7 +27,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 		] );
 	} );
@@ -41,7 +41,7 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 		] );
 	} );
@@ -54,7 +54,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 			"functionWordsInKeyphrase",
 		] );
@@ -69,7 +69,7 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleKeyword",
 			"titleWidth",
 		] );
@@ -83,7 +83,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 		] );
 	} );
@@ -97,7 +97,7 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 			"urlKeyword",
 		] );
@@ -113,7 +113,7 @@ describe( "running assessments in the assessor", function() {
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 		] );
 	} );
@@ -128,7 +128,7 @@ describe( "running assessments in the assessor", function() {
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
-			"textLength",
+			"taxonomyTextLength",
 			"titleWidth",
 		] );
 	} );

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -15,6 +15,29 @@ import urlStopWordsAssessment from "./assessments/seo/urlStopWordsAssessment";
 import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
 
 /**
+ * Returns the boundaries to use for the text length assessment.
+ *
+ * @param {boolean} useRecalibration If the recalibration boundaries should be used or not.
+ * @returns {Object} The text length assessment boundaries to use.
+ */
+const getTextLengthBoundaries = function( useRecalibration ) {
+	if ( useRecalibration ) {
+		return {
+			recommendedMinimum: 250,
+			slightlyBelowMinimum: 200,
+			belowMinimum: 100,
+			veryFarBelowMinimum: 50,
+		}
+	}
+	return {
+		recommendedMinimum: 150,
+		slightlyBelowMinimum: 125,
+		belowMinimum: 100,
+		veryFarBelowMinimum: 50,
+	}
+};
+
+/**
  * Creates the Assessor used for taxonomy pages.
  *
  * @param {object} i18n The i18n object used for translations.
@@ -24,13 +47,16 @@ const TaxonomyAssessor = function( i18n ) {
 	Assessor.call( this, i18n );
 	this.type = "TaxonomyAssessor";
 
+	// Get the text length boundaries (they are different for recalibration).
+	const textLengthBoundaries = getTextLengthBoundaries( process.env.YOAST_RECALIBRATION === "enabled" );
+
 	this._assessments = [
 		new IntroductionKeywordAssessment(),
 		new KeyphraseLengthAssessment(),
 		new KeywordDensityAssessment(),
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLengthAssessment(),
-		new TextLengthAssessment(),
+		new TextLengthAssessment( textLengthBoundaries ),
 		new TitleKeywordAssessment(),
 		new PageTitleWidthAssessment(),
 		new UrlKeywordAssessment(),

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -5,6 +5,7 @@ import KeyphraseLengthAssessment from "./assessments/seo/KeyphraseLengthAssessme
 import KeywordDensityAssessment from "./assessments/seo/KeywordDensityAssessment";
 import MetaDescriptionKeywordAssessment from "./assessments/seo/MetaDescriptionKeywordAssessment";
 import TitleKeywordAssessment from "./assessments/seo/TitleKeywordAssessment";
+import taxonomyTextLengthAssessment from "./assessments/seo/taxonomyTextLengthAssessment";
 import UrlKeywordAssessment from "./assessments/seo/UrlKeywordAssessment";
 import Assessor from "./assessor";
 import MetaDescriptionLengthAssessment from "./assessments/seo/MetaDescriptionLengthAssessment";
@@ -13,29 +14,7 @@ import PageTitleWidthAssessment from "./assessments/seo/PageTitleWidthAssessment
 import UrlLengthAssessment from "./assessments/seo/UrlLengthAssessment";
 import urlStopWordsAssessment from "./assessments/seo/urlStopWordsAssessment";
 import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphraseAssessment";
-
-/**
- * Returns the boundaries to use for the text length assessment.
- *
- * @param {boolean} useRecalibration If the recalibration boundaries should be used or not.
- * @returns {Object} The text length assessment boundaries to use.
- */
-const getTextLengthBoundaries = function( useRecalibration ) {
-	if ( useRecalibration ) {
-		return {
-			recommendedMinimum: 250,
-			slightlyBelowMinimum: 200,
-			belowMinimum: 100,
-			veryFarBelowMinimum: 50,
-		};
-	}
-	return {
-		recommendedMinimum: 150,
-		slightlyBelowMinimum: 125,
-		belowMinimum: 100,
-		veryFarBelowMinimum: 50,
-	};
-};
+import { createAnchorOpeningTag } from "./helpers/shortlinker";
 
 /**
  * Creates the Assessor used for taxonomy pages.
@@ -48,7 +27,7 @@ const TaxonomyAssessor = function( i18n ) {
 	this.type = "TaxonomyAssessor";
 
 	// Get the text length boundaries (they are different for recalibration).
-	const textLengthBoundaries = getTextLengthBoundaries( process.env.YOAST_RECALIBRATION === "enabled" );
+	const textLengthAssessment = this.getTextLengthAssessment( process.env.YOAST_RECALIBRATION === "enabled" );
 
 	this._assessments = [
 		new IntroductionKeywordAssessment(),
@@ -56,7 +35,7 @@ const TaxonomyAssessor = function( i18n ) {
 		new KeywordDensityAssessment(),
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLengthAssessment(),
-		new TextLengthAssessment( textLengthBoundaries ),
+		textLengthAssessment,
 		new TitleKeywordAssessment(),
 		new PageTitleWidthAssessment(),
 		new UrlKeywordAssessment(),
@@ -64,6 +43,27 @@ const TaxonomyAssessor = function( i18n ) {
 		urlStopWordsAssessment,
 		new FunctionWordsInKeyphrase(),
 	];
+};
+
+/**
+ * Returns the text length assessment to use, based on whether recalibration has been
+ * activated or not.
+ *
+ * @param {boolean} useRecalibration If the recalibration assessment should be used or not.
+ * @returns {Object} The text length assessment to use.
+ */
+TaxonomyAssessor.prototype.getTextLengthAssessment = function( useRecalibration ) {
+	if ( useRecalibration ) {
+		return new TextLengthAssessment( {
+			recommendedMinimum: 250,
+			slightlyBelowMinimum: 200,
+			belowMinimum: 100,
+			veryFarBelowMinimum: 50,
+			urlTitle: createAnchorOpeningTag( "https://yoa.st/34j" ),
+			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34k" ),
+		} );
+	}
+	return taxonomyTextLengthAssessment;
 };
 
 inherits( TaxonomyAssessor, Assessor );

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -27,14 +27,14 @@ const getTextLengthBoundaries = function( useRecalibration ) {
 			slightlyBelowMinimum: 200,
 			belowMinimum: 100,
 			veryFarBelowMinimum: 50,
-		}
+		};
 	}
 	return {
 		recommendedMinimum: 150,
 		slightlyBelowMinimum: 125,
 		belowMinimum: 100,
 		veryFarBelowMinimum: 50,
-	}
+	};
 };
 
 /**

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -17,6 +17,28 @@ import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphrase
 import { createAnchorOpeningTag } from "./helpers/shortlinker";
 
 /**
+ * Returns the text length assessment to use, based on whether recalibration has been
+ * activated or not.
+ *
+ * @param {boolean} useRecalibration If the recalibration assessment should be used or not.
+ * @returns {Object} The text length assessment to use.
+ */
+export const getTextLengthAssessment = function( useRecalibration ) {
+	// Export so it can be used in tests.
+	if ( useRecalibration ) {
+		return new TextLengthAssessment( {
+			recommendedMinimum: 250,
+			slightlyBelowMinimum: 200,
+			belowMinimum: 100,
+			veryFarBelowMinimum: 50,
+			urlTitle: createAnchorOpeningTag( "https://yoa.st/34j" ),
+			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34k" ),
+		} );
+	}
+	return taxonomyTextLengthAssessment;
+};
+
+/**
  * Creates the Assessor used for taxonomy pages.
  *
  * @param {object} i18n The i18n object used for translations.
@@ -27,7 +49,7 @@ const TaxonomyAssessor = function( i18n ) {
 	this.type = "TaxonomyAssessor";
 
 	// Get the text length boundaries (they are different for recalibration).
-	const textLengthAssessment = this.getTextLengthAssessment( process.env.YOAST_RECALIBRATION === "enabled" );
+	const textLengthAssessment = getTextLengthAssessment( process.env.YOAST_RECALIBRATION === "enabled" );
 
 	this._assessments = [
 		new IntroductionKeywordAssessment(),
@@ -43,27 +65,6 @@ const TaxonomyAssessor = function( i18n ) {
 		urlStopWordsAssessment,
 		new FunctionWordsInKeyphrase(),
 	];
-};
-
-/**
- * Returns the text length assessment to use, based on whether recalibration has been
- * activated or not.
- *
- * @param {boolean} useRecalibration If the recalibration assessment should be used or not.
- * @returns {Object} The text length assessment to use.
- */
-TaxonomyAssessor.prototype.getTextLengthAssessment = function( useRecalibration ) {
-	if ( useRecalibration ) {
-		return new TextLengthAssessment( {
-			recommendedMinimum: 250,
-			slightlyBelowMinimum: 200,
-			belowMinimum: 100,
-			veryFarBelowMinimum: 50,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/34j" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34k" ),
-		} );
-	}
-	return taxonomyTextLengthAssessment;
 };
 
 inherits( TaxonomyAssessor, Assessor );

--- a/src/taxonomyAssessor.js
+++ b/src/taxonomyAssessor.js
@@ -8,7 +8,7 @@ import TitleKeywordAssessment from "./assessments/seo/TitleKeywordAssessment";
 import UrlKeywordAssessment from "./assessments/seo/UrlKeywordAssessment";
 import Assessor from "./assessor";
 import MetaDescriptionLengthAssessment from "./assessments/seo/MetaDescriptionLengthAssessment";
-import taxonomyTextLengthAssessment from "./assessments/seo/taxonomyTextLengthAssessment";
+import TextLengthAssessment from "./assessments/seo/TextLengthAssessment";
 import PageTitleWidthAssessment from "./assessments/seo/PageTitleWidthAssessment";
 import UrlLengthAssessment from "./assessments/seo/UrlLengthAssessment";
 import urlStopWordsAssessment from "./assessments/seo/urlStopWordsAssessment";
@@ -30,7 +30,7 @@ const TaxonomyAssessor = function( i18n ) {
 		new KeywordDensityAssessment(),
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLengthAssessment(),
-		taxonomyTextLengthAssessment,
+		new TextLengthAssessment(),
 		new TitleKeywordAssessment(),
 		new PageTitleWidthAssessment(),
 		new UrlKeywordAssessment(),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the boundaries and feedback of the text length assessment for taxonomy pages for when recalibration is enabled.

## Relevant technical choices:

* When recalibration is enabled, the `TaxonomyAssessor` uses the default `TextLengthAssessment` with new boundaries. When not, the original `TaxonomyTextLengthAssessment`. This is because the original assessment uses slightly different feedback strings as the `TextLengthAssessment` ('below' instead of 'far below').

## Test instructions

This PR can be tested by following these steps:

* Start the webpack example in the fancy new Recalibration Mode (go to `examples/webpack/` in the terminal, execute the command `yarn start-recalibration`).
* In the example, toggle the taxonomy page control to 'on'.
* The ranges and scores should look like this:

| word range | text |
|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| < 49       | _[Text Length](https://yoa.st/34j): The text contains n words. This is far below the recommended minimum of 250 words. [Add more content](https://yoa.st/34j)._ |    
| 50-99      | _[Text Length](https://yoa.st/34j): The text contains n words. This is far below the recommended minimum of 250 words. [Add more content](https://yoa.st/34j)._ |        
| 100-199   | _[Text Length](https://yoa.st/34j): The text contains n words. This is below the recommended minimum of 250 words. [Add more content](https://yoa.st/34j)._  |
| 200-249    | _[Text Length](https://yoa.st/34j): The text contains n words. This is slightly below the recommended minimum of 250 words. [Add a bit more copy](https://yoa.st/34j)._  |
| 250+       | _[Text Length](https://yoa.st/34j): The text contains n words. Good job!_ |    

* Start the webpack example in Default Mode (go to `examples/webpack/` in the terminal, execute the command `yarn`).
* In the example, toggle the taxonomy page control to 'on'.
* The ranges and score texts should look like this:

| word range | text |
|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| < 49       | _[Text Length](https://yoa.st/34j): The text contains n words. This is far below the recommended minimum of 150 words. [Add more content](https://yoa.st/34j)._ |    
| 50-99      | _[Text Length](https://yoa.st/34j): The text contains n words. This is below the recommended minimum of 150 words. [Add more content](https://yoa.st/34j)._ |        
| 100-124    | _[Text Length](https://yoa.st/34j): The text contains n words. This is below the recommended minimum of 150 words. [Add more content](https://yoa.st/34j)._  |
| 125-149    | _[Text Length](https://yoa.st/34j): The text contains n words. This is slightly below the recommended minimum of 150 words. [Add a bit more copy](https://yoa.st/34j)._  |
| 150+       | _[Text Length](https://yoa.st/34j): The text contains n words. Good job!_ |    

Fixes #1939 