### PR TITLE
Recalibrate text images

### DIFF
--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -154,6 +154,25 @@ describe( "An image count assessment for regular analysis", function() {
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
 	} );
 
+	it( "assesses 6 images, with a keyword and alt-tag set to keyword for all 6 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 6,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 6,
+				withAltNonKeyword: 0,
+			},
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
+	} );
+
 	it( "assesses 6 images, with a keyword and alt-tag set to keyword for 1 image, alt-tag set to non-keyword for 1 image and 4 images without alt tags", function() {
 		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
 			keyword: "Sample",

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -20,7 +20,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -37,7 +37,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -54,7 +54,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 1,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -71,7 +71,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 4,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -90,7 +90,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -109,7 +109,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 4,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -128,7 +128,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -147,7 +147,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -166,7 +166,7 @@ describe( "An image count assessment for regular analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -189,7 +189,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -206,7 +206,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -223,7 +223,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 1,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -240,7 +240,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 4,
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -259,7 +259,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -278,7 +278,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 0,
 				withAltNonKeyword: 4,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -297,7 +297,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -316,7 +316,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -335,7 +335,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 2,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -354,7 +354,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 6,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -373,7 +373,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 4,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -392,7 +392,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 2,
 				withAltNonKeyword: 1,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -411,7 +411,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 4,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -430,7 +430,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 5,
 				withAltNonKeyword: 0,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -449,7 +449,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 				withAlt: 0,
 				withAltKeyword: 1,
 				withAltNonKeyword: 3,
-			}
+			},
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -229,7 +229,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes that reflect the topic of your text. <a href='https://yoa.st/33d' target='_blank'>Add your keyphrase or synonyms to the alt tags of relevant images</a>!" );
 	} );
 
 	it( "assesses a single image, without a keyword, but with an alt-tag set", function() {
@@ -282,7 +282,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes that reflect the topic of your text. <a href='https://yoa.st/33d' target='_blank'>Add your keyphrase or synonyms to the alt tags of relevant images</a>!" );
 	} );
 
 	it( "assesses four images, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
@@ -301,7 +301,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes that reflect the topic of your text. <a href='https://yoa.st/33d' target='_blank'>Add your keyphrase or synonyms to the alt tags of relevant images</a>!" );
 	} );
 
 	it( "assesses a single image, with a keyword and alt-tag set to keyword", function() {
@@ -320,7 +320,8 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: The image on this page contains an alt attribute with at least half of the words from the keyphrase. Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
+			"Good job!" );
 	} );
 
 	it( "assesses two images, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
@@ -339,7 +340,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 2 images on this page, 1 has an alt attribute with at least half of the words from the keyphrase. Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
 	} );
 
 	it( "assesses 6 images, with a keyword and alt-tag set to keyword for 2 images, alt-tag set to non-keyword for 1 image and 3 images without alt tags", function() {
@@ -358,7 +359,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, 2 have alt attributes with at least half of the words from the keyphrase. Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
 	} );
 
 	it( "assesses 6 images, with a keyword and alt-tag set to keyword for all 6 images", function() {
@@ -377,7 +378,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, 6 have alt attributes with at least half of the words from the keyphrase. That's a bit much. <a href='https://yoa.st/33d' target='_blank'>Only include the focus keyphrase when it really fits the image</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, 6 have alt attributes with words from your keyphrase or synonyms. That's a bit much. <a href='https://yoa.st/33d' target='_blank'>Only include the keyphrase or its synonyms when it really fits the image</a>." );
 	} );
 
 	it( "assesses 6 images, with a keyword and alt-tag set to keyword for only 1 image", function() {
@@ -396,7 +397,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, only 1 has an alt attribute with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, only 1 has an alt attribute that reflects the topic of your text. <a href='https://yoa.st/33d' target='_blank'>Add your keyphrase or synonyms to the alt tags of more relevant images</a>!" );
 	} );
 
 	it( "assesses 5 images, with a keyword and alt-tag set to keyword for 2 images, alt-tag set to non-keyword for 1 image and 2 images without alt tags", function() {
@@ -415,7 +416,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 2 have alt attributes with at least half of the words from the keyphrase. Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
 	} );
 
 	it( "assesses 5 images, with a keyword and alt-tag set to keyword for 4 images", function() {
@@ -434,7 +435,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 4 have alt attributes with at least half of the words from the keyphrase. Good job!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
 	} );
 
 	it( "assesses 5 images, with a keyword and alt-tag set to keyword for all 5 images", function() {
@@ -453,7 +454,7 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 5 have alt attributes with at least half of the words from the keyphrase. That's a bit much. <a href='https://yoa.st/33d' target='_blank'>Only include the focus keyphrase when it really fits the image</a>." );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 5 have alt attributes with words from your keyphrase or synonyms. That's a bit much. <a href='https://yoa.st/33d' target='_blank'>Only include the keyphrase or its synonyms when it really fits the image</a>." );
 	} );
 
 	it( "assesses 5 images, with a keyword and alt-tag set to keyword for only 1 image", function() {
@@ -472,6 +473,6 @@ describe( "An image count assessment for Recalibration analysis", function() {
 		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, only 1 has an alt attribute with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, only 1 has an alt attribute that reflects the topic of your text. <a href='https://yoa.st/33d' target='_blank'>Add your keyphrase or synonyms to the alt tags of more relevant images</a>!" );
 	} );
 } );

--- a/spec/assessments/textImagesSpec.js
+++ b/spec/assessments/textImagesSpec.js
@@ -5,11 +5,23 @@ var i18n = Factory.buildJed();
 
 const imageCountAssessment = new ImageCountAssessment();
 
-describe( "An image count assessment", function() {
+describe( "An image count assessment for regular analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+	} );
+
 	it( "assesses no images", function() {
 		var mockPaper = new Paper( "sample" );
 
-		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 0,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: No images appear on this page. <a href='https://yoa.st/33d' target='_blank'>Add some</a>!" );
@@ -19,11 +31,14 @@ describe( "An image count assessment", function() {
 		var mockPaper = new Paper( "These are just five words <img src='image.jpg' />" );
 
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 1,
-			withAlt: 0,
-			withAltKeyword: 0,
-			withAltNonKeyword: 0,
-		} ), i18n );
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 1,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
@@ -33,11 +48,31 @@ describe( "An image count assessment", function() {
 		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' />" );
 
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 1,
-			withAltKeyword: 0,
-			withAltNonKeyword: 0,
-		} ), i18n );
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 1,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses 4 images, without a keyword, but with an alt-tag set", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' /> <img src='image.jpg' alt='image2' /> <img src='image.jpg' alt='image3' /> <img src='image.jpg' alt='image4' />" );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 4,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 4,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
@@ -49,11 +84,33 @@ describe( "An image count assessment", function() {
 		} );
 
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 0,
-			withAltKeyword: 0,
-			withAltNonKeyword: 1,
-		} ), i18n );
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses four images, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' /> <img src='image.jpg' alt='image2' /> <img src='image.jpg' alt='image3' /> <img src='image.jpg' alt='image4' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 4,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 4,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
@@ -65,45 +122,337 @@ describe( "An image count assessment", function() {
 		} );
 
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 0,
-			withAltKeyword: 1,
-			withAltNonKeyword: 0,
-		} ), i18n );
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
 	} );
 
-	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
+	it( "assesses two image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
 		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
 			keyword: "Sample",
 		} );
 
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 0,
-			withAlt: 0,
-			withAltKeyword: 1,
-			withAltNonKeyword: 1,
-		} ), i18n );
+			imageCount: 2,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
 	} );
 
-	it( "assesses a single image, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
+	it( "assesses 6 images, with a keyword and alt-tag set to keyword for 1 image, alt-tag set to non-keyword for 1 image and 4 images without alt tags", function() {
 		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
 			keyword: "Sample",
 		} );
 
 		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
-			noAlt: 4,
-			withAlt: 0,
-			withAltKeyword: 1,
-			withAltNonKeyword: 1,
-		} ), i18n );
+			imageCount: 6,
+			altTagCount: {
+				noAlt: 4,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Some images on this page contain alt attributes with words from your keyphrase! Good job!" );
+	} );
+} );
+
+describe( "An image count assessment for Recalibration analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+	} );
+
+	it( "assesses no images", function() {
+		var mockPaper = new Paper( "sample" );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 0,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: No images appear on this page. <a href='https://yoa.st/33d' target='_blank'>Add some</a>!" );
+	} );
+
+	it( "assesses a single image, without a keyword and alt-tag set", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' />" );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 1,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses a single image, without a keyword, but with an alt-tag set", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' />" );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 1,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page have alt attributes, but you have not set your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses 4 images, without a keyword, but with an alt-tag set", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' /> <img src='image.jpg' alt='image2' /> <img src='image.jpg' alt='image3' /> <img src='image.jpg' alt='image4' />" );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 4,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 4,
+				withAltKeyword: 0,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page have alt attributes, but you have not set your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses a single image, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='keyword' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses four images, with a keyword and alt-tag set, but with a non-keyword alt-tag", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' /> <img src='image.jpg' alt='image2' /> <img src='image.jpg' alt='image3' /> <img src='image.jpg' alt='image4' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 4,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 0,
+				withAltNonKeyword: 4,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses a single image, with a keyword and alt-tag set to keyword", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 1,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: The image on this page contains an alt attribute with at least half of the words from the keyphrase. Good job!" );
+	} );
+
+	it( "assesses two images, with a keyword and alt-tag set to keyword for 1 of 2 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 2,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 2 images on this page, 1 has an alt attribute with at least half of the words from the keyphrase. Good job!" );
+	} );
+
+	it( "assesses 6 images, with a keyword and alt-tag set to keyword for 2 images, alt-tag set to non-keyword for 1 image and 3 images without alt tags", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 6,
+			altTagCount: {
+				noAlt: 3,
+				withAlt: 0,
+				withAltKeyword: 2,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, 2 have alt attributes with at least half of the words from the keyphrase. Good job!" );
+	} );
+
+	it( "assesses 6 images, with a keyword and alt-tag set to keyword for all 6 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 6,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 6,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, 6 have alt attributes with at least half of the words from the keyphrase. That's a bit much. <a href='https://yoa.st/33d' target='_blank'>Only include the focus keyphrase when it really fits the image</a>." );
+	} );
+
+	it( "assesses 6 images, with a keyword and alt-tag set to keyword for only 1 image", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 6,
+			altTagCount: {
+				noAlt: 1,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 4,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 6 images on this page, only 1 has an alt attribute with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
+	} );
+
+	it( "assesses 5 images, with a keyword and alt-tag set to keyword for 2 images, alt-tag set to non-keyword for 1 image and 2 images without alt tags", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 5,
+			altTagCount: {
+				noAlt: 2,
+				withAlt: 0,
+				withAltKeyword: 2,
+				withAltNonKeyword: 1,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 2 have alt attributes with at least half of the words from the keyphrase. Good job!" );
+	} );
+
+	it( "assesses 5 images, with a keyword and alt-tag set to keyword for 4 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 5,
+			altTagCount: {
+				noAlt: 1,
+				withAlt: 0,
+				withAltKeyword: 4,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 4 have alt attributes with at least half of the words from the keyphrase. Good job!" );
+	} );
+
+	it( "assesses 5 images, with a keyword and alt-tag set to keyword for all 5 images", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 5,
+			altTagCount: {
+				noAlt: 0,
+				withAlt: 0,
+				withAltKeyword: 5,
+				withAltNonKeyword: 0,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, 5 have alt attributes with at least half of the words from the keyphrase. That's a bit much. <a href='https://yoa.st/33d' target='_blank'>Only include the focus keyphrase when it really fits the image</a>." );
+	} );
+
+	it( "assesses 5 images, with a keyword and alt-tag set to keyword for only 1 image", function() {
+		var mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='sample' />", {
+			keyword: "Sample",
+		} );
+
+		var assessment = imageCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( {
+			imageCount: 5,
+			altTagCount: {
+				noAlt: 1,
+				withAlt: 0,
+				withAltKeyword: 1,
+				withAltNonKeyword: 3,
+			}
+		}, true ), i18n );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Out of 5 images on this page, only 1 has an alt attribute with at least half of the words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!" );
 	} );
 } );

--- a/spec/researches/imageAltTagsSpec.js
+++ b/spec/researches/imageAltTagsSpec.js
@@ -3,7 +3,304 @@ import morphologyData from "../../premium-configuration/data/morphologyData.json
 import altTagCountFunction from "../../src/researches/imageAltTags";
 import Paper from "../../src/values/Paper";
 
-describe( "Counts images in an text", function() {
+describe( "Counts images in an text in regular analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+	} );
+
+	it( "returns an empty object with all alt-counts as zero", function() {
+		const paper = new Paper( "string", { keyword: "keyword", synonyms: "synonym, another synonym" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 0 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltKeyword as 1 when the keyword is set and present (1-word keyword)", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword", synonyms: "synonym, another synonym" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltKeyword as 1 when the keyword is set and present by 50% (2-word keyword)", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword keyphrase", synonyms: "synonym, another synonym" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltKeyword as 1 when the keyword is set and present by 33% (3-word keyword)", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword keyphrase synonym", synonyms: "synonym, another synonym" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAlt as 1 when there's an alt-tag, but no keyword is set", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 1 );
+		expect( stringToCheck.withAltKeyword ).toBe( 0 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltNonKeyword as 1 when the keyword is set, but not present in the alt-tag", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "sample" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 0 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "returns object with the noAlt as 1 when the alt-tag is empty", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='' />", { keyword: "keyword" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 1 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 0 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the noAlt as 1 when the alt-tag is missing", function() {
+		const paper = new Paper( "string <img src='http://plaatje' />", { keyword: "keyword" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 1 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 0 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with a combination of present and missing alt-tags", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='' />", { keyword: "keyword" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 1 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltKeyword as 1 when the keyword is set and present and has a $", function() {
+		const paper = new Paper( "string <img src='http://img' alt='$keyword' />", { keyword: "$keyword" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with a combination of present and missing alt-tags with keyphrase and synonym words in it", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='something empty' /> " +
+			"string <img src='http://plaatje' alt='synonym' /> <img src='http://plaatje' alt='' /> " +
+			"string <img src='http://plaatje' alt='test' /> <img src='http://plaatje' alt='' /> " +
+			"string <img src='http://plaatje' alt='paper interesting' /> <img src='http://plaatje' alt='paper' />", {
+			keyword: "keyword",
+			synonyms: "synonym, test, interesting paper",
+		} );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 2 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 5 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "returns object with a combination of present and missing alt-tags with \"keyphrase\" and synonym words in it", function() {
+		const paper = new Paper(
+			"string <img src='http://plaatje' alt='keyword' /> <img src='http://plaatje' alt='something empty' /> " +
+			"string <img src='http://plaatje' alt='synonym' /> <img src='http://plaatje' alt='' /> " +
+			"string <img src='http://plaatje' alt='keyword in quotes' /> <img src='http://plaatje' alt='' /> " +
+			"string <img src='http://plaatje' alt='paper interesting' /> <img src='http://plaatje' alt='paper' />", {
+				keyword: "\"keyword in quotes\"",
+				synonyms: "synonym, test, interesting paper",
+			}
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 2 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 2 );
+	} );
+
+	it( "returns object with a combination of present and missing alt-tags with \"keyphrase\" and synonym words in it", function() {
+		const paper = new Paper(
+			"string <img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='synonym and test' /> " +
+			"string <img src='http://plaatje' alt='synonyms' /> " +
+			"<img src='http://plaatje' alt='' /> " +
+			"string <img src='http://plaatje' alt='keyword in quotes' /> " +
+			"<img src='http://plaatje' alt='interestingly enough, it is a paper' /> " +
+			"string <img src='http://plaatje' alt='paper interesting test synonyms' /> " +
+			"<img src='http://plaatje' alt='papering' />", {
+				keyword: "\"keyword in quotes\"",
+				synonyms: "synonym, test, interesting paper",
+			}
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 1 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 6 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "does not apply EN morphology to search in other languages", function() {
+		const paper = new Paper(
+			"string <img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='synonym and test' /> " +
+			"string <img src='http://plaatje' alt='synonyms' /> " +
+			"string <img src='http://plaatje' alt='keyword in quotes' /> " +
+			"<img src='http://plaatje' alt='interestingly enough, it is a paper' /> " +
+			"string <img src='http://plaatje' alt='paper interesting test synonyms' /> " +
+			"<img src='http://plaatje' alt='papering' />", {
+				keyword: "keyword",
+				synonyms: "synonym, test, interesting paper",
+				locale: "fr_FR",
+			}
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 5 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 2 );
+	} );
+
+	it( "Applied English morphology", function() {
+		const paper = new Paper(
+			"<div class=\"floatright\">" +
+			"<a class=\"image\" " +
+			"title=\"Vue du Kibo depuis le sud en juin 2009.\" " +
+			"href=\"https://commons.wikimedia.org/wiki/File:Mount_Kilimanjaro.jpg?uselang=fr\">" +
+			"<img class=\"alignnone\" src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Mount_Kilimanjaro.jpg/150px-Mount_Kilimanjaro.jpg\" " +
+			"alt=\"Vue du Kilimandjaros depuis le sud en juin 2009.\" width=\"150\" height=\"67\" data-file-width=\"2673\" data-file-height=\"1200\" />" +
+			"</a>" +
+			"</div>\n" +
+			"\tLe <b><a title=\"Kilimandjaro\" href=\"https://fr.wikipedia.org/wiki/Kilimandjaro\">Kilimandjaro</a></b> ou <b>Kilimanjaro</b> est une <a title=\"Montagne\" href=\"https://fr.wikipedia.org/wiki/Montagne\">montagne</a> située dans le Nord-Est de la <a title=\"Tanzanie\" href=\"https://fr.wikipedia.org/wiki/Tanzanie\">Tanzanie</a>et composée de trois <a title=\"Volcan\" href=\"https://fr.wikipedia.org/wiki/Volcan\">volcans</a> éteints : le Shira à l'ouest, culminant à 3 962 mètres d'altitude, le Mawenzi à l'est, s'élevant à 5 149 mètres d'altitude, et le Kibo, le plus récent <a title=\"Géologie\" href=\"https://fr.wikipedia.org/wiki/G%C3%A9ologie\">géologiquement</a>, situé entre les deux autres et dont le pic Uhuru à 5 891,8 mètres d'altitude constitue le <a title=\"Point culminant\" href=\"https://fr.wikipedia.org/wiki/Point_culminant\">point culminant</a> de l'<a title=\"Afrique\" href=\"https://fr.wikipedia.org/wiki/Afrique\">Afrique</a>. Outre cette caractéristique, le Kilimandjaro est connu pour sa <a title=\"Calotte glaciaire\" href=\"https://fr.wikipedia.org/wiki/Calotte_glaciaire\">calotte glaciaire</a> sommitale en <a title=\"Recul des glaciers depuis 1850\" href=\"https://fr.wikipedia.org/\n", {
+				keyword: "Kilimandjaro",
+			}
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "Tests for multi-word keyphrases", function() {
+		const paper = new Paper(
+			"<img src='http://plaatje' alt='keyword and keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword and keyphrase and more' /> " +
+			"<img src='http://plaatje' alt='key' /> ",
+			{ keyword: "keyword keyphrase" }
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "Tests for multi-word keyphrases", function() {
+		const paper = new Paper(
+			"<img src='http://plaatje' alt='keyword and keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword and keyphrase and more' /> " +
+			"<img src='http://plaatje' alt='key' /> ",
+			{ keyword: "keyword keyphrase synonym" }
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "Tests for multi-word keyphrases with morphology", function() {
+		const paper = new Paper(
+			"<img src='http://plaatje' alt='keywords and keyphrases' /> " +
+			"<img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword and keyphrases and more' /> " +
+			"<img src='http://plaatje' alt='key' /> ",
+			{ keyword: "keyword keyphrase synonym" }
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+} );
+
+describe( "Counts images in an text in Recalibration", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+	} );
+
 	it( "returns an empty object with all alt-counts as zero", function() {
 		const paper = new Paper( "string", { keyword: "keyword", synonyms: "synonym, another synonym" } );
 		const researcher = new Researcher( paper );

--- a/spec/researches/imageAltTagsSpec.js
+++ b/spec/researches/imageAltTagsSpec.js
@@ -16,7 +16,7 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
 	} );
 
-	 it( "returns object with the withAltKeyword as 1 when the keyword is set and present", function() {
+	 it( "returns object with the withAltKeyword as 1 when the keyword is set and present (1-word keyword)", function() {
 		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword", synonyms: "synonym, another synonym" } );
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
@@ -26,6 +26,30 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAlt ).toBe( 0 );
 		expect( stringToCheck.withAltKeyword ).toBe( 1 );
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltKeyword as 1 when the keyword is set and present by 50% (2-word keyword)", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword keyphrase", synonyms: "synonym, another synonym" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 1 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
+	} );
+
+	it( "returns object with the withAltKeyword as 0 when the keyword is set and present by 33% (3-word keyword)", function() {
+		const paper = new Paper( "string <img src='http://plaatje' alt='keyword' />", { keyword: "keyword keyphrase synonym", synonyms: "synonym, another synonym" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 0 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
 	} );
 
 	it( "returns object with the withAlt as 1 when there's an alt-tag, but no keyword is set", function() {

--- a/spec/researches/imageAltTagsSpec.js
+++ b/spec/researches/imageAltTagsSpec.js
@@ -233,4 +233,61 @@ describe( "Counts images in an text", function() {
 		expect( stringToCheck.withAltKeyword ).toBe( 1 );
 		expect( stringToCheck.withAltNonKeyword ).toBe( 0 );
 	} );
+
+	it( "Tests for multi-word keyphrases", function() {
+		const paper = new Paper(
+			"<img src='http://plaatje' alt='keyword and keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword and keyphrase and more' /> " +
+			"<img src='http://plaatje' alt='key' /> ",
+			{ keyword: "keyword keyphrase" }
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 4 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
+	} );
+
+	it( "Tests for multi-word keyphrases", function() {
+		const paper = new Paper(
+			"<img src='http://plaatje' alt='keyword and keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword and keyphrase and more' /> " +
+			"<img src='http://plaatje' alt='key' /> ",
+			{ keyword: "keyword keyphrase synonym" }
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 2 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 3 );
+	} );
+
+	it( "Tests for multi-word keyphrases with morphology", function() {
+		const paper = new Paper(
+			"<img src='http://plaatje' alt='keywords and keyphrases' /> " +
+			"<img src='http://plaatje' alt='keyword' /> " +
+			"<img src='http://plaatje' alt='keyphrase' /> " +
+			"<img src='http://plaatje' alt='keyword and keyphrases and more' /> " +
+			"<img src='http://plaatje' alt='key' /> ",
+			{ keyword: "keyword keyphrase synonym" }
+		);
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const stringToCheck = altTagCountFunction( paper, researcher );
+
+		expect( stringToCheck.noAlt ).toBe( 0 );
+		expect( stringToCheck.withAlt ).toBe( 0 );
+		expect( stringToCheck.withAltKeyword ).toBe( 2 );
+		expect( stringToCheck.withAltNonKeyword ).toBe( 3 );
+	} );
 } );

--- a/src/assessments/seo/TextImagesAssessment.js
+++ b/src/assessments/seo/TextImagesAssessment.js
@@ -199,7 +199,7 @@ export default class TextImagesAssessment extends Assessment {
 	/**
 	 * Checks whether the only image has an alt-tag with the keyphrase (needed to return a nice feedback).
 	 *
-	 * @returns {boolean} Returns true if the number of alt tags with keywords is within the recommended range.
+	 * @returns {boolean} Returns true if the only image has an alt-tag with the keyphrase.
 	 */
 	hasOneImageWithKeyword() {
 		return ( this.imageCount === 1 && this.altProperties.withAltKeyword === 1 );

--- a/src/assessments/seo/TextImagesAssessment.js
+++ b/src/assessments/seo/TextImagesAssessment.js
@@ -197,15 +197,6 @@ export default class TextImagesAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks whether the only image has an alt-tag with the keyphrase (needed to return a nice feedback).
-	 *
-	 * @returns {boolean} Returns true if the only image has an alt-tag with the keyphrase.
-	 */
-	hasOneImageWithKeyword() {
-		return ( this.imageCount === 1 && this.altProperties.withAltKeyword === 1 );
-	}
-
-	/**
 	 * Checks whether there is a sufficient number of alt tags with keywords. This check is applicable when there are
 	 * 5 or more images.
 	 *
@@ -269,7 +260,8 @@ export default class TextImagesAssessment extends Assessment {
 					i18n.dgettext(
 						"js-text-analysis",
 						"%1$sImage alt attributes%3$s: " +
-						"Images on this page do not have alt attributes with at least half of the words from your keyphrase. %2$sFix that%3$s!"
+						"Images on this page do not have alt attributes that reflect the topic of your text. " +
+						"%2$sAdd your keyphrase or synonyms to the alt tags of relevant images%3$s!"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -288,12 +280,12 @@ export default class TextImagesAssessment extends Assessment {
 					 * %5$s expands to the anchor end tag. */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d has an alt attribute with " +
-						"at least half of the words from your keyphrase. " +
-						"%4$sFix that%5$s!",
-						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d have alt attributes with " +
-						"at least half of the words from your keyphrase. " +
-						"%4$sFix that%5$s!",
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d has an alt attribute that " +
+						"reflects the topic of your text. " +
+						"%4$sAdd your keyphrase or synonyms to the alt tags of more relevant images%5$s!",
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d have alt attributes that " +
+						"reflect the topic of your text. " +
+						"%4$sAdd your keyphrase or synonyms to the alt tags of more relevant images%5$s!",
 						this.altProperties.withAltKeyword,
 					),
 					this.altProperties.withAltKeyword,
@@ -305,7 +297,11 @@ export default class TextImagesAssessment extends Assessment {
 			};
 		}
 
-		if ( this.hasOneImageWithKeyword() ) {
+		/*
+		 * The hasGoodNumberOfMatches check needs to be made before the check for too many matches because of the special rule for
+		 * exactly 5 matches.
+		 */
+		if ( this.hasGoodNumberOfMatches() ) {
 			return {
 				score: this._config.scoresRecalibration.withAltGoodNumberOfKeywordMatches,
 				resultText: i18n.sprintf(
@@ -313,36 +309,8 @@ export default class TextImagesAssessment extends Assessment {
 					 * %2$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sImage alt attributes%2$s: The image on this page contains an alt attribute with at least half " +
-						"of the words from the keyphrase. Good job!",
+						"%1$sImage alt attributes%2$s: Good job!",
 					),
-					this._config.urlTitle,
-					"</a>"
-				),
-			};
-		}
-
-		/*
-		 * This check needs to be made before the check for too many matches because of the special rule for
-		 * exactly 5 matches.
-		 */
-		if ( this.hasGoodNumberOfMatches() ) {
-			return {
-				score: this._config.scoresRecalibration.withAltGoodNumberOfKeywordMatches,
-				resultText: i18n.sprintf(
-					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
-                     * %2$d expands to the total number of images, %3$s expands to a link on yoast.com,
-					 * %4$s expands to the anchor end tag. */
-					i18n.dngettext(
-						"js-text-analysis",
-						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d has an alt attribute with at " +
-						"least half of the words from the keyphrase. Good job!",
-						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d have alt attributes with at " +
-						"least half of the words from the keyphrase. Good job!",
-						this.altProperties.withAltKeyword
-					),
-					this.altProperties.withAltKeyword,
-					this.imageCount,
 					this._config.urlTitle,
 					"</a>"
 				),
@@ -358,9 +326,9 @@ export default class TextImagesAssessment extends Assessment {
 					 * %5$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, %1$d have alt attributes with at " +
-						"least half of the words from the keyphrase. " +
-						"That's a bit much. %4$sOnly include the focus keyphrase when it really fits the image%5$s.",
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, %1$d have alt attributes with " +
+						"words from your keyphrase or synonyms. " +
+						"That's a bit much. %4$sOnly include the keyphrase or its synonyms when it really fits the image%5$s.",
 					),
 					this.altProperties.withAltKeyword,
 					this.imageCount,
@@ -377,7 +345,8 @@ export default class TextImagesAssessment extends Assessment {
 			resultText: i18n.sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
-					"Images on this page do not have alt attributes with words from your keyphrase. %2$sFix that%3$s!" ),
+					"Images on this page do not have alt attributes that reflect the topic of your text. " +
+					"%2$sAdd your keyphrase or synonyms to the alt tags of relevant images%3$s!" ),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"

--- a/src/assessments/seo/TextImagesAssessment.js
+++ b/src/assessments/seo/TextImagesAssessment.js
@@ -288,9 +288,11 @@ export default class TextImagesAssessment extends Assessment {
 					 * %5$s expands to the anchor end tag. */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d has an alt attribute with at least half of the words from your keyphrase. " +
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d has an alt attribute with " +
+						"at least half of the words from your keyphrase. " +
 						"%4$sFix that%5$s!",
-						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d have alt attributes with at least half of the words from your keyphrase. " +
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d have alt attributes with " +
+						"at least half of the words from your keyphrase. " +
 						"%4$sFix that%5$s!",
 						this.altProperties.withAltKeyword,
 					),
@@ -311,7 +313,8 @@ export default class TextImagesAssessment extends Assessment {
 					 * %2$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sImage alt attributes%2$s: The image on this page contains an alt attribute with at least half of the words from the keyphrase. Good job!",
+						"%1$sImage alt attributes%2$s: The image on this page contains an alt attribute with at least half " +
+						"of the words from the keyphrase. Good job!",
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -332,8 +335,10 @@ export default class TextImagesAssessment extends Assessment {
 					 * %4$s expands to the anchor end tag. */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d has an alt attribute with at least half of the words from the keyphrase. Good job!",
-						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d have alt attributes with at least half of the words from the keyphrase. Good job!",
+						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d has an alt attribute with at " +
+						"least half of the words from the keyphrase. Good job!",
+						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d have alt attributes with at " +
+						"least half of the words from the keyphrase. Good job!",
 						this.altProperties.withAltKeyword
 					),
 					this.altProperties.withAltKeyword,
@@ -353,7 +358,8 @@ export default class TextImagesAssessment extends Assessment {
 					 * %5$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, %1$d have alt attributes with at least half of the words from the keyphrase. " +
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, %1$d have alt attributes with at " +
+						"least half of the words from the keyphrase. " +
 						"That's a bit much. %4$sOnly include the focus keyphrase when it really fits the image%5$s.",
 					),
 					this.altProperties.withAltKeyword,

--- a/src/assessments/seo/TextImagesAssessment.js
+++ b/src/assessments/seo/TextImagesAssessment.js
@@ -1,6 +1,7 @@
 import { merge } from "lodash-es";
 
 import Assessment from "../../assessment";
+import { inRangeStartEndInclusive } from "../../helpers/inRange.js";
 import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 import AssessmentResult from "../../values/AssessmentResult";
 
@@ -19,9 +20,22 @@ export default class TextImagesAssessment extends Assessment {
 		super();
 
 		const defaultConfig = {
-			scores: {
+			parametersRecalibration: {
+				lowerBoundary: 0.3,
+				upperBoundary: 0.75,
+			},
+			scoresRegular: {
 				noImages: 3,
 				withAltKeyword: 9,
+				withAltNonKeyword: 6,
+				withAlt: 6,
+				noAlt: 6,
+			},
+			scoresRecalibration: {
+				noImages: 3,
+				withAltGoodNumberOfKeywordMatches: 9,
+				withAltTooFewKeywordMatches: 6,
+				withAltTooManyKeywordMatches: 6,
 				withAltNonKeyword: 6,
 				withAlt: 6,
 				noAlt: 6,
@@ -44,12 +58,20 @@ export default class TextImagesAssessment extends Assessment {
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher, i18n ) {
+		this.imageCount = researcher.getResearch( "imageCount" );
+		this.altProperties = researcher.getResearch( "altTagCount" );
+
+		let calculatedScore;
+		if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+			this._minNumberOfKeywordMatches = Math.ceil( this.imageCount * this._config.parametersRecalibration.lowerBoundary );
+			this._maxNumberOfKeywordMatches = Math.floor( this.imageCount * this._config.parametersRecalibration.upperBoundary );
+
+			calculatedScore = this.calculateResultRecalibration( i18n );
+		} else {
+			calculatedScore = this.calculateResultRegular( i18n );
+		}
+
 		const assessmentResult = new AssessmentResult();
-		const imageCount = researcher.getResearch( "imageCount" );
-		const altProperties = researcher.getResearch( "altTagCount" );
-
-		const calculatedScore = this.calculateResult( imageCount, altProperties, i18n );
-
 		assessmentResult.setScore( calculatedScore.score );
 		assessmentResult.setText( calculatedScore.resultText );
 
@@ -70,16 +92,14 @@ export default class TextImagesAssessment extends Assessment {
 	/**
 	 * Calculate the score and the feedback string based on the current image count and current image alt-tag count.
 	 *
-	 * @param {number} imageCount The amount of images to be checked against.
-	 * @param {Object} altProperties An object containing the various alt-tags.
 	 * @param {Jed} i18n The object used for translations.
 	 *
 	 * @returns {Object} The calculated score and the feedback string.
 	 */
-	calculateResult( imageCount, altProperties, i18n ) {
-		if ( imageCount === 0 ) {
+	calculateResultRegular( i18n ) {
+		if ( this.imageCount === 0 ) {
 			return {
-				score: this._config.scores.noImages,
+				score: this._config.scoresRegular.noImages,
 				resultText: i18n.sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: No images appear on this page. %2$sAdd some%3$s!" ),
@@ -91,9 +111,9 @@ export default class TextImagesAssessment extends Assessment {
 		}
 
 		// Has alt-tag and keywords
-		if ( altProperties.withAltKeyword > 0 ) {
+		if ( this.altProperties.withAltKeyword > 0 ) {
 			return {
-				score: this._config.scores.withAltKeyword,
+				score: this._config.scoresRegular.withAltKeyword,
 				resultText: i18n.sprintf(
 					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%2$s: " +
@@ -105,9 +125,9 @@ export default class TextImagesAssessment extends Assessment {
 		}
 
 		// Has alt-tag, but no keywords and it's not okay
-		if ( altProperties.withAltNonKeyword > 0 ) {
+		if ( this.altProperties.withAltNonKeyword > 0 ) {
 			return {
-				score: this._config.scores.withAltNonKeyword,
+				score: this._config.scoresRegular.withAltNonKeyword,
 				resultText: i18n.sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
@@ -120,9 +140,9 @@ export default class TextImagesAssessment extends Assessment {
 		}
 
 		// Has alt-tag, but no keyword is set
-		if ( altProperties.withAlt > 0 ) {
+		if ( this.altProperties.withAlt > 0 ) {
 			return {
-				score: this._config.scores.withAlt,
+				score: this._config.scoresRegular.withAlt,
 				resultText: i18n.sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
@@ -135,9 +155,9 @@ export default class TextImagesAssessment extends Assessment {
 		}
 
 		// Has no alt-tag
-		if ( altProperties.noAlt > 0 ) {
+		if ( this.altProperties.noAlt > 0 ) {
 			return {
-				score: this._config.scores.noAlt,
+				score: this._config.scoresRegular.noAlt,
 				resultText: i18n.sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
@@ -149,5 +169,213 @@ export default class TextImagesAssessment extends Assessment {
 			};
 		}
 		return null;
+	}
+
+	/**
+	 * Checks whether there are too few alt tags with keywords. This check is applicable when there are
+	 * 5 or more images.
+	 *
+	 * @returns {boolean} Returns true if there are at least 5 images and the number of alt tags
+	 * with keywords is under the specified recommended minimum.
+	 */
+	hasTooFewMatches() {
+		return this.imageCount > 4 && this.altProperties.withAltKeyword > 0 &&
+			this.altProperties.withAltKeyword < this._minNumberOfKeywordMatches;
+	}
+
+	/**
+	 * Checks whether there is a sufficient number of alt tags with keywords. There are different recommended
+	 * ranges for less than 5 keywords, exactly 5 keywords, and more than 5 keywords.
+	 *
+	 * @returns {boolean} Returns true if the number of alt tags with keywords is within the recommended range.
+	 */
+	hasGoodNumberOfMatches() {
+		return ( ( this.imageCount < 5 && this.altProperties.withAltKeyword > 0 ) ||
+			( this.imageCount === 5 && inRangeStartEndInclusive( this.altProperties.withAltKeyword, 2, 4 ) ) ||
+			( this.imageCount > 4 &&
+				inRangeStartEndInclusive( this.altProperties.withAltKeyword, this._minNumberOfKeywordMatches, this._maxNumberOfKeywordMatches ) ) );
+	}
+
+	/**
+	 * Checks whether the only image has an alt-tag with the keyphrase (needed to return a nice feedback).
+	 *
+	 * @returns {boolean} Returns true if the number of alt tags with keywords is within the recommended range.
+	 */
+	hasOneImageWithKeyword() {
+		return ( this.imageCount === 1 && this.altProperties.withAltKeyword === 1 );
+	}
+
+	/**
+	 * Checks whether there is a sufficient number of alt tags with keywords. This check is applicable when there are
+	 * 5 or more images.
+	 *
+	 * @returns {boolean} Returns true if there are at least 5 images and the number of alt tags with keywords
+	 * is within the recommended range.
+	 */
+	hasTooManyMatches() {
+		return this.imageCount > 4 && this.altProperties.withAltKeyword > this._maxNumberOfKeywordMatches;
+	}
+
+
+	/**
+	 * Calculate the result based on the current image count and current image alt-tag count.
+	 *
+	 * @param {Object} i18n The object used for translations.
+	 *
+	 * @returns {Object} The calculated result.
+	 */
+	calculateResultRecalibration( i18n ) {
+		// No images.
+		if ( this.imageCount === 0 ) {
+			return {
+				score: this._config.scoresRecalibration.noImages,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%1$sImage alt attributes%3$s: No images appear on this page. %2$sAdd some%3$s!"
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
+		// Has alt-tags, but no keyword is set.
+		if ( this.altProperties.withAlt > 0 ) {
+			return {
+				score: this._config.scoresRecalibration.withAlt,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%1$sImage alt attributes%3$s: " +
+						"Images on this page have alt attributes, but you have not set your keyphrase. %2$sFix that%3$s!"
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
+		// Has alt-tags, but no keywords while a keyword is set.
+		if ( this.altProperties.withAltNonKeyword > 0 && this.altProperties.withAltKeyword === 0 ) {
+			return {
+				score: this._config.scoresRecalibration.withAltNonKeyword,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%1$sImage alt attributes%3$s: " +
+						"Images on this page do not have alt attributes with at least half of the words from your keyphrase. %2$sFix that%3$s!"
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
+		// Image count ≥5, has alt-tags with too few keywords.
+		if ( this.hasTooFewMatches() ) {
+			return {
+				score: this._config.scoresRecalibration.withAltTooFewKeywordMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
+					 * %2$d expands to the total number of images, %3$s and %4$s expand to links on yoast.com,
+					 * %5$s expands to the anchor end tag. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d has an alt attribute with at least half of the words from your keyphrase. " +
+						"%4$sFix that%5$s!",
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d have alt attributes with at least half of the words from your keyphrase. " +
+						"%4$sFix that%5$s!",
+						this.altProperties.withAltKeyword,
+					),
+					this.altProperties.withAltKeyword,
+					this.imageCount,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
+		if ( this.hasOneImageWithKeyword() ) {
+			return {
+				score: this._config.scoresRecalibration.withAltGoodNumberOfKeywordMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$s expands to a link on yoast.com,
+					 * %2$s expands to the anchor end tag. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%1$sImage alt attributes%2$s: The image on this page contains an alt attribute with at least half of the words from the keyphrase. Good job!",
+					),
+					this._config.urlTitle,
+					"</a>"
+				),
+			};
+		}
+
+		/*
+		 * This check needs to be made before the check for too many matches because of the special rule for
+		 * exactly 5 matches.
+		 */
+		if ( this.hasGoodNumberOfMatches() ) {
+			return {
+				score: this._config.scoresRecalibration.withAltGoodNumberOfKeywordMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
+                     * %2$d expands to the total number of images, %3$s expands to a link on yoast.com,
+					 * %4$s expands to the anchor end tag. */
+					i18n.dngettext(
+						"js-text-analysis",
+						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d has an alt attribute with at least half of the words from the keyphrase. Good job!",
+						"%3$sImage alt attributes%4$s: Out of %2$d images on this page, %1$d have alt attributes with at least half of the words from the keyphrase. Good job!",
+						this.altProperties.withAltKeyword
+					),
+					this.altProperties.withAltKeyword,
+					this.imageCount,
+					this._config.urlTitle,
+					"</a>"
+				),
+			};
+		}
+
+		if ( this.hasTooManyMatches() ) {
+			return {
+				score: this._config.scoresRecalibration.withAltTooManyKeywordMatches,
+				resultText: i18n.sprintf(
+					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
+                     * %2$d expands to the total number of images, %3$s and %4$s expand to a link on yoast.com,
+					 * %5$s expands to the anchor end tag. */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, %1$d have alt attributes with at least half of the words from the keyphrase. " +
+						"That's a bit much. %4$sOnly include the focus keyphrase when it really fits the image%5$s.",
+					),
+					this.altProperties.withAltKeyword,
+					this.imageCount,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
+		// Images, but no alt tags.
+		return {
+			score: this._config.scoresRecalibration.noAlt,
+			resultText: i18n.sprintf(
+				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+				i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
+					"Images on this page do not have alt attributes with words from your keyphrase. %2$sFix that%3$s!" ),
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>"
+			),
+		};
 	}
 }

--- a/src/researches/imageAltTags.js
+++ b/src/researches/imageAltTags.js
@@ -40,7 +40,13 @@ const matchAltProperties = function( imageMatches, topicForms, locale ) {
 
 		const keywordMatchedInAltTag = findTopicFormsInString( topicForms, alttag, true, locale );
 
-		if ( keywordMatchedInAltTag.percentWordMatches < 50 && alttag !== "" ) {
+		if ( keywordMatchedInAltTag.countWordMatches === 0 && alttag !== "" && ( ! ( process.env.YOAST_RECALIBRATION === "enabled" ) ) ) {
+			// Match for keywords?
+			altProperties.withAltNonKeyword++;
+			continue;
+		}
+
+		if ( keywordMatchedInAltTag.percentWordMatches < 50 && alttag !== "" && ( process.env.YOAST_RECALIBRATION === "enabled" ) ) {
 			// Match for keywords?
 			altProperties.withAltNonKeyword++;
 			continue;

--- a/src/researches/imageAltTags.js
+++ b/src/researches/imageAltTags.js
@@ -40,7 +40,7 @@ const matchAltProperties = function( imageMatches, topicForms, locale ) {
 
 		const keywordMatchedInAltTag = findTopicFormsInString( topicForms, alttag, true, locale );
 
-		if ( keywordMatchedInAltTag.countWordMatches === 0 && alttag !== "" ) {
+		if ( keywordMatchedInAltTag.percentWordMatches < 50 && alttag !== "" ) {
 			// Match for keywords?
 			altProperties.withAltNonKeyword++;
 			continue;

--- a/src/researches/imageAltTags.js
+++ b/src/researches/imageAltTags.js
@@ -7,6 +7,20 @@ import { findTopicFormsInString } from "../researches/findKeywordFormsInString";
 import { isEmpty } from "lodash-es";
 
 /**
+ * Checks if a match was found based on different criteria in recalibration and in regular analysis.
+ *
+ * @param {Object} matchResult The object with the count and percent of words from the keyphrase that were matched.
+ *
+ * @returns {boolean} Whether a match was found or not.
+ */
+const matchFound = function( matchResult ) {
+	if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+		return matchResult.percentWordMatches >= 50;
+	}
+	return matchResult.countWordMatches > 0;
+};
+
+/**
  * Matches the alt-tags in the images found in the text.
  * Returns an object with the totals and different alt-tags.
  *
@@ -33,29 +47,19 @@ const matchAltProperties = function( imageMatches, topicForms, locale ) {
 		}
 
 		// If no keyword is set, but the alt-tag is
-		if ( isEmpty( topicForms.keyphraseForms ) && alttag !== "" ) {
+		if ( isEmpty( topicForms.keyphraseForms ) ) {
 			altProperties.withAlt++;
 			continue;
 		}
 
+		// If the keyword is matched in the alt tag
 		const keywordMatchedInAltTag = findTopicFormsInString( topicForms, alttag, true, locale );
-
-		if ( keywordMatchedInAltTag.countWordMatches === 0 && alttag !== "" && ( ! ( process.env.YOAST_RECALIBRATION === "enabled" ) ) ) {
-			// Match for keywords?
-			altProperties.withAltNonKeyword++;
-			continue;
-		}
-
-		if ( keywordMatchedInAltTag.percentWordMatches < 50 && alttag !== "" && ( process.env.YOAST_RECALIBRATION === "enabled" ) ) {
-			// Match for keywords?
-			altProperties.withAltNonKeyword++;
-			continue;
-		}
-
-		if ( keywordMatchedInAltTag.countWordMatches > 0 ) {
+		if ( matchFound( keywordMatchedInAltTag ) ) {
 			altProperties.withAltKeyword++;
 			continue;
 		}
+
+		altProperties.withAltNonKeyword++;
 	}
 
 	return altProperties;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Implements a recalibrated version of the assessment that checks whether the keyphrase is used in the alt-tags of images, so that if more than 4 images are added to the article, between 30 and 70% of them contain the keyphrase.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

###  Regular analysis
* Start a regular analysis example `yarn start`
* Add a text without images > Red: `Image alt attributes: No images appear on this page. Add some!`
* Add an image without alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Add an empty alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Add an alt-tag with some text > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Set a keyphrase and repeat the previous three tests > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Use a 1-word keyphrase and add this word to the alt-tag > Green `Image alt attributes: Some images on this page contain alt attributes with words from your keyphrase! Good job!`
* Add 2 more (content) words to the keyphrase without changing the alt-tag > Green `Image alt attributes: Some images on this page contain alt attributes with words from your keyphrase! Good job!`
* Copy the image and paste it 5 more times. > Green `Image alt attributes: Some images on this page contain alt attributes with words from your keyphrase! Good job!`
* Remove alt-tags in all images but one > Green `Image alt attributes: Some images on this page contain alt attributes with words from your keyphrase! Good job!`
* Remove alt-tags in the last image > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
###  Recalibration analysis
* Start a regular analysis example `yarn start-recalibration`
* Add a text without images > Red: `Image alt attributes: No images appear on this page. Add some!`
* Add an image without alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Add an empty alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Add an alt-tag with some text > Orange `Image alt attributes: Images on this page have alt attributes, but you have not set your keyphrase. Fix that!`
* Set a keyphrase
* Add an image without alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Add an empty alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with words from your keyphrase. Fix that!`
* Add an alt-tag with some text > Orange `Image alt attributes: Images on this page do not have alt attributes with at least half of the words from your keyphrase. Fix that!`
* Use a 1-word keyphrase and add this word to the alt-tag > Green `Image alt attributes: The image on this page contains an alt attribute with at least half of the words from the keyphrase. Good job!`
* Add 1 more (content) word to the keyphrase without changing the alt-tag > Green `Image alt attributes: The image on this page contains an alt attribute with at least half of the words from the keyphrase. Good job!`
* Add 1 more (content) word to the keyphrase without changing the alt-tag > Orange `Image alt attributes: Images on this page do not have alt attributes with at least half of the words from your keyphrase. Fix that!`
* Duplicate the image and use the at least half of the keyphrase words in one of alt-tags, but not in the other. > Green `Image alt attributes: Out of 2 images on this page, 1 has an alt attribute with at least half of the words from the keyphrase. Good job!`
* Duplicate the images. > Green `Image alt attributes: Out of 4 images on this page, 2 have an alt attribute with at least half of the words from the keyphrase. Good job!`
* Add one more image with or without an alt-tag. > Green `Image alt attributes: Out of 5 images on this page, 2 have an alt attribute with at least half of the words from the keyphrase. Good job!`
* Remove the alt-tag on one of the images where two words from the keyphrase were matched > Orange `Image alt attributes: Out of 5 images on this page, only 1 has an alt attribute with at least half of the words from your keyphrase. Fix that!`
* Add alt-tags with keyphrase words to 4 out of 5 images. > Green `Image alt attributes: Out of 5 images on this page, 4 have an alt attribute with at least half of the words from the keyphrase. Good job!`
* Add alt-tags with keyphrase words to the 5th image. > Orange `Image alt attributes: Out of 5 images on this page, 5 have alt attributes with at least half of the words from the keyphrase. That's a bit much. Only include the focus keyphrase when it really fits the image.`
* Add one more image without an alt-tag. > Orange `Image alt attributes: Out of 6 images on this page, 5 have alt attributes with at least half of the words from the keyphrase. That's a bit much. Only include the focus keyphrase when it really fits the image.`
* Add one more image with an alt-tag that does not contain half of the words from the keyphrase. > Green `Image alt attributes: Out of 7 images on this page, 5 have alt attributes with at least half of the words from the keyphrase. Good job!`
* Remove alt-tags or keyphrase words from the alt-tags of 3 images > Orange `Image alt attributes: Out of 7 images on this page, only 2 have alt attributes with at least half of the words from your keyphrase. Fix that!`

 
Fixes #1938 
