### PR TITLE
1947 improve keyphrase in title assessment

### DIFF
--- a/spec/assessments/TitleKeywordAssessmentSpec.js
+++ b/spec/assessments/TitleKeywordAssessmentSpec.js
@@ -12,7 +12,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false } ),
+			Factory.buildMockResearcher( { exactMatchFound: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 2 );
@@ -30,7 +30,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: true, allWordsFound: true, position: 0, exactMatchKeyphrase: false } ),
+			Factory.buildMockResearcher( { exactMatchFound: true, allWordsFound: true, position: 0, exactMatchKeyphrase: false } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 9 );
@@ -47,7 +47,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: true, allWordsFound: true, position: 41, exactMatchKeyphrase: false } ),
+			Factory.buildMockResearcher( { exactMatchFound: true, allWordsFound: true, position: 41, exactMatchKeyphrase: false } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
@@ -65,7 +65,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: true, position: -1, exactMatchKeyphrase: false  } ),
+			Factory.buildMockResearcher( { exactMatchFound: false, allWordsFound: true, position: -1, exactMatchKeyphrase: false  } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 6 );
@@ -82,7 +82,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		} );
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
-			Factory.buildMockResearcher( { exactMatch: false, allWordsFound: false, position: 0, exactMatchKeyphrase: true } ),
+			Factory.buildMockResearcher( { exactMatchFound: false, allWordsFound: false, position: 0, exactMatchKeyphrase: true } ),
 			i18n );
 
 		expect( assessment.getScore() ).toBe( 2 );

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -299,7 +299,6 @@ describe( "Match keywords in string, regular analysis", function() {
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.allWordsFound ).toBe( false );
 	} );
-
 } );
 
 describe( "Match keywords in string, recalibrated analysis", function() {

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -72,7 +72,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 18 );
+		expect( result.position ).toBe( 10 );
 	} );
 
 	it( "returns the exact match and its position for German", function() {
@@ -300,6 +300,21 @@ describe( "Match keywords in string", function() {
 		const mockPaper = new Paper( "", {
 			keyword: "\"walking in nature\"",
 			title: "The walking in nature",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( true );
+		expect( result.allWordsFound ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns an exact match at place 0, even if the title starts with multiple function words.", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"walking in nature\"",
+			title: "The first walking in nature",
 		} );
 		const researcher = new Researcher( mockPaper );
 		researcher.addResearchData( "morphology", morphologyData );

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -4,7 +4,309 @@ import pageTitleKeyword from "../../src/researches/findKeywordInPageTitle.js";
 import Paper from "../../src/values/Paper.js";
 let result;
 
-describe( "Match keywords in string", function() {
+describe( "Match keywords in string, regular analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+	} );
+
+	it( "returns the exact match at the start of the title and its position", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "keyword",
+			title: "keyword in a string",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns the exact match and its position, keyphrase in middle", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "keyword",
+			title: "a string with a keyword and another keyword",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 16 );
+	} );
+
+	it( "returns the exact match and its position, multiple matches", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "keyword",
+			title: "”a string with a keyword and another keyword”",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 17 );
+	} );
+
+	it( "returns no match for empty keyword", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "",
+			title: "a string with words",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.allWordsFound ).toBe( false );
+	} );
+
+	it( "returns the exact match and its position for cyrillic", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "нечто",
+			title: "ст, чтобы проверить нечто Test текст, чтобы ",
+			locale: "ru_RU",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 20 );
+	} );
+
+	it( "returns the exact match and its position for German", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "äbc",
+			title: "äbc",
+			locale: "de_DE",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns no match with dash", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "focus keyword",
+			title: "focus-keyword",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.position ).toBe( -1 );
+	} );
+
+	it( "returns the exact match and its position with different cases", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "Focus Keyword",
+			title: "focus keyword",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns the exact match and its position for matches with special characters", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "$keyword",
+			title: "A title with a $keyword",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 15 );
+	} );
+
+	it( "returns the exact match and its position for Turkish", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "Istanbul",
+			title: "İstanbul and the rest of Turkey",
+			locale: "tr_TR",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns the exact match and its position for Turkish", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "İstanbul",
+			title: "İstanbul and the rest of Turkey",
+			locale: "tr_TR",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns the exact match and its position for German for two matches", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "äbc",
+			title: "äbc und abc",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns number of matches and position for German for two matches", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "äbc",
+			title: "äbc und abc",
+			locale: "de_DE",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns number of matches and position for German for two matches", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "äbc",
+			title: "äbc und Äbc",
+			locale: "de_DE",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns all-words-found match if keyphrase words were shuffled in the title", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "interesting books about computer science",
+			title: "interesting science books on my computer",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.allWordsFound ).toBe( true );
+	} );
+
+	it( "returns all-words-found match if keyphrase words were shuffled in the title and used in different forms", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "interesting books about computer science",
+			title: "interestingly, I have a science book on my computer",
+			locale: "en_EN",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.allWordsFound ).toBe( true );
+	} );
+
+	it( "returns all-words-found match if keyphrase words were shuffled in the title for French", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "chez Paul",
+			title: "Je m'appele Paul",
+			locale: "fr_FR",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.allWordsFound ).toBe( true );
+	} );
+
+	it( "returns all-words-found match if keyphrase words were shuffled in the title for Swedish", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "promenader i naturen",
+			title: "Jag gillar att ta promenader i naturen.",
+			locale: "sw_SE",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.position ).toBe( 18 );
+	} );
+
+	it( "returns an exact match at the beginning", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"Walking in the nature\"",
+			title: "Walking in the nature is awesome.",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns an exact match not at the beginning", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"Walking in the nature\"",
+			title: "My opinion: Walking in the nature is awesome.",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( true );
+		expect( result.position ).toBe( 12 );
+	} );
+
+	it( "returns an exact match not found", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"Walking in the nature\"",
+			title: "My opinion: Walking in nature is awesome.",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchKeyphrase ).toBe( true );
+		expect( result.allWordsFound ).toBe( false );
+	} );
+
+} );
+
+describe( "Match keywords in string, recalibrated analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+	} );
+
 	it( "returns the exact match and its position", function() {
 		const mockPaper = new Paper( "", {
 			keyword: "keyword",

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -19,7 +19,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -33,7 +33,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 16 );
 	} );
 
@@ -47,7 +47,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 17 );
 	} );
 
@@ -61,7 +61,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( false );
 	} );
 
@@ -75,7 +75,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 20 );
 	} );
 
@@ -89,7 +89,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -103,7 +103,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.position ).toBe( -1 );
 	} );
 
@@ -116,7 +116,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -129,7 +129,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 15 );
 	} );
 
@@ -143,7 +143,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -157,7 +157,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -170,7 +170,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -184,7 +184,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -198,7 +198,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -212,7 +212,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
@@ -226,7 +226,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
@@ -240,7 +240,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
@@ -254,7 +254,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 18 );
 	} );
 
@@ -267,7 +267,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
@@ -281,7 +281,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.position ).toBe( 12 );
 	} );
@@ -295,7 +295,7 @@ describe( "Match keywords in string, regular analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.allWordsFound ).toBe( false );
 	} );
@@ -316,7 +316,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -330,8 +330,8 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 14 );
+		expect( result.exactMatchFound ).toBe( true );
+		expect( result.position ).toBe( 16 );
 	} );
 
 	it( "returns the exact match and its position", function() {
@@ -344,8 +344,8 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 14 );
+		expect( result.exactMatchFound ).toBe( true );
+		expect( result.position ).toBe( 17 );
 	} );
 
 	it( "returns no match for empty keyword", function() {
@@ -358,7 +358,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( false );
 	} );
 
@@ -372,8 +372,8 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 10 );
+		expect( result.exactMatchFound ).toBe( true );
+		expect( result.position ).toBe( 20 );
 	} );
 
 	it( "returns the exact match and its position for German", function() {
@@ -386,7 +386,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -400,7 +400,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.position ).toBe( -1 );
 	} );
 
@@ -413,7 +413,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -426,8 +426,8 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 13 );
+		expect( result.exactMatchFound ).toBe( true );
+		expect( result.position ).toBe( 15 );
 	} );
 
 	it( "returns the exact match and its position for Turkish", function() {
@@ -440,7 +440,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -454,7 +454,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -467,7 +467,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -481,7 +481,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -495,7 +495,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
 
@@ -509,7 +509,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
@@ -523,7 +523,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
@@ -537,7 +537,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 	} );
 
@@ -551,7 +551,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.position ).toBe( 18 );
 	} );
 
@@ -564,7 +564,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );
@@ -578,9 +578,9 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
-		expect( result.position ).toBe( 9 );
+		expect( result.position ).toBe( 12 );
 	} );
 
 	it( "returns an exact match not found", function() {
@@ -592,7 +592,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( false );
+		expect( result.exactMatchFound ).toBe( false );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.allWordsFound ).toBe( false );
 	} );
@@ -606,7 +606,7 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.allWordsFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
@@ -621,8 +621,23 @@ describe( "Match keywords in string, recalibrated analysis", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 
 		result = pageTitleKeyword( mockPaper, researcher );
-		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchFound ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
+		expect( result.allWordsFound ).toBe( true );
+		expect( result.position ).toBe( 0 );
+	} );
+
+	it( "returns an exact match at place 0, even if the title and the keyphrase start with (multiple) function words.", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "the very walking in nature",
+			title: "First thing, the very walking in nature",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatchFound ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( false );
 		expect( result.allWordsFound ).toBe( true );
 		expect( result.position ).toBe( 0 );
 	} );

--- a/spec/researches/findKeywordInPageTitleSpec.js
+++ b/spec/researches/findKeywordInPageTitleSpec.js
@@ -30,7 +30,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 16 );
+		expect( result.position ).toBe( 14 );
 	} );
 
 	it( "returns the exact match and its position", function() {
@@ -44,7 +44,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 17 );
+		expect( result.position ).toBe( 14 );
 	} );
 
 	it( "returns no match for empty keyword", function() {
@@ -72,7 +72,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 20 );
+		expect( result.position ).toBe( 18 );
 	} );
 
 	it( "returns the exact match and its position for German", function() {
@@ -126,7 +126,7 @@ describe( "Match keywords in string", function() {
 
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
-		expect( result.position ).toBe( 15 );
+		expect( result.position ).toBe( 13 );
 	} );
 
 	it( "returns the exact match and its position for Turkish", function() {
@@ -279,7 +279,7 @@ describe( "Match keywords in string", function() {
 		result = pageTitleKeyword( mockPaper, researcher );
 		expect( result.exactMatch ).toBe( true );
 		expect( result.exactMatchKeyphrase ).toBe( true );
-		expect( result.position ).toBe( 12 );
+		expect( result.position ).toBe( 9 );
 	} );
 
 	it( "returns an exact match not found", function() {
@@ -294,6 +294,21 @@ describe( "Match keywords in string", function() {
 		expect( result.exactMatch ).toBe( false );
 		expect( result.exactMatchKeyphrase ).toBe( true );
 		expect( result.allWordsFound ).toBe( false );
+	} );
+
+	it( "returns an exact match at place 0, even if the title starts with a function word.", function() {
+		const mockPaper = new Paper( "", {
+			keyword: "\"walking in nature\"",
+			title: "The walking in nature",
+		} );
+		const researcher = new Researcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		result = pageTitleKeyword( mockPaper, researcher );
+		expect( result.exactMatch ).toBe( true );
+		expect( result.exactMatchKeyphrase ).toBe( true );
+		expect( result.allWordsFound ).toBe( true );
+		expect( result.position ).toBe( 0 );
 	} );
 } );
 

--- a/src/assessments/seo/TitleKeywordAssessment.js
+++ b/src/assessments/seo/TitleKeywordAssessment.js
@@ -84,12 +84,12 @@ class TitleKeywordAssessment extends Assessment {
 	 * @returns {Object} Object with score and text.
 	 */
 	calculateResult( i18n, keyword ) {
-		const exactMatch = this._keywordMatches.exactMatch;
+		const exactMatchFound = this._keywordMatches.exactMatchFound;
 		const position = this._keywordMatches.position;
 		const allWordsFound = this._keywordMatches.allWordsFound;
 		const exactMatchKeyphrase = this._keywordMatches.exactMatchKeyphrase;
 
-		if ( exactMatch === true ) {
+		if ( exactMatchFound === true ) {
 			if ( position === 0 ) {
 				return {
 					score: this._config.scores.good,

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -81,7 +81,10 @@ const adjustPosition = function( title, position, locale ) {
 	// Strip all function words from the beginning of the title.
 	const titleBeforeKeyword = title.substr( 0, position );
 	if ( stripFunctionWordsFromStart( functionWords.all, titleBeforeKeyword ) ) {
-		// Update the position (such that "the keyword" is still counted as position 0).
+		/*
+		 * Return position 0 if there are no words left in the title before the keyword after filtering
+		 * the function words (such that "keyword" in "the keyword" is still counted as position 0).
+ 		 */
 		return 0;
 	}
 

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -26,8 +26,8 @@ const stripFunctionWordsFromStart = function( functionWords, str ) {
 	// Strip all function words from the start of the title string.
 	for ( let i = 0; i < titleWords.length; i++ ) {
 		const word = titleWords[ i ];
-		// If this word is a function word, strip it from the title.
-		// Else, break since there are no words to strip from the beginning.
+		/* If this word is a function word, strip it from the title.
+		   Else, break since there are no words to strip from the beginning.*/
 		if ( functionWords.includes( word ) ) {
 			const regex = new RegExp( "^(" + addWordboundary( word ) + ")" );
 			strippedTitle = strippedTitle.replace( regex, "" );

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -1,7 +1,7 @@
 /** @module analyses/findKeywordInPageTitle */
 
 import wordMatch from "../stringProcessing/matchTextWithWord.js";
-const findTopicFormsInString = require( "./findKeywordFormsInString.js" ).findTopicFormsInString;
+import { findTopicFormsInString } from "./findKeywordFormsInString.js";
 
 import getFunctionWordsFactory from "../helpers/getFunctionWords";
 
@@ -81,7 +81,7 @@ export default function( paper, researcher ) {
 				const strippedTitle = stripFunctionWordsFromStart( functionWords.all, title );
 				// Match the keyphrase with the stripped title.
 				const strippedTitleMatch = wordMatch( strippedTitle, keyword, locale );
-				// Update the position (such that beginning is still 0).
+				// Update the position (such that "the keyword" is still counted as position 0).
 				result.position = strippedTitleMatch.position;
 			}
 		}

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -12,10 +12,6 @@ import getLanguage from "../helpers/getLanguage";
 
 const getFunctionWords = getFunctionWordsFactory();
 
-const findPositionExcludingFunctionWords = function( title, keyword, locale ) {
-
-};
-
 /**
  * Counts the occurrences of the keyword in the page title. Returns the result that contains information on
  * (1) whether the exact match of the keyphrase was used in the title,

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -32,6 +32,64 @@ const stripFunctionWordsFromStart = function( functionWords, str ) {
 };
 
 /**
+ * Checks if exact match functionality is requested by enclosing the keyphrase in double quotation marks.
+ *
+ * @param {string} keyword The keyword to check.
+ *
+ * @returns {Object} Whether the exact match funcionality is requested and the keyword stripped from double quotes.
+ */
+const processExactMatchRequest = function( keyword ) {
+	const exactMatchRequest = { exactMatchRequested: false, keyword: keyword };
+
+	// Check if morphology is suppressed. If so, strip the quotation marks from the keyphrase.
+	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
+	if ( includes( doubleQuotes, keyword[ 0 ] ) && includes( doubleQuotes, keyword[ keyword.length - 1 ] ) ) {
+		exactMatchRequest.keyword = keyword.substring( 1, keyword.length - 1 );
+		exactMatchRequest.exactMatchRequested = true;
+	}
+
+	return exactMatchRequest;
+};
+
+/**
+ * Checks whether an exact match of the keyphrase is found in the title.
+ *
+ * @param {string} title The title of the paper.
+ * @param {number} position The position of the keyphrase in the title.
+ * @param {string} locale The locale of the paper.
+ *
+ * @returns {number} Potentially adjusted position of the keyphrase in the title.
+ */
+const adjustPosition = function( title, position, locale ) {
+	// Don't do anything if position if already 0.
+	if ( position === 0 ) {
+		return position;
+	}
+
+	// Don't do anything for non-recalibration.
+	if ( ! ( process.env.YOAST_RECALIBRATION === "enabled" ) ) {
+		return position;
+	}
+
+	// Don't do anything if no function words exist for this locale.
+	const language = getLanguage( locale );
+	const functionWords = get( getFunctionWords, [ language ], [] );
+	if ( isUndefined( functionWords.all ) ) {
+		return position;
+	}
+
+	// Strip all function words from the beginning of the title.
+	const titleBeforeKeyword = title.substr( 0, position );
+	if ( stripFunctionWordsFromStart( functionWords.all, titleBeforeKeyword ) ) {
+		// Update the position (such that "the keyword" is still counted as position 0).
+		return 0;
+	}
+
+	return position;
+};
+
+
+/**
  * Counts the occurrences of the keyword in the page title. Returns the result that contains information on
  * (1) whether the exact match of the keyphrase was used in the title,
  * (2) whether all (content) words from the keyphrase were found in the title,
@@ -49,37 +107,20 @@ export default function( paper, researcher ) {
 
 	const result = { exactMatchFound: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false  };
 
-	// First check if morphology is suppressed. If so, strip the quotation marks from the keyphrase.
-	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
-	if ( includes( doubleQuotes, keyword[ 0 ] ) && includes( doubleQuotes, keyword[ keyword.length - 1 ] ) ) {
-		keyword = keyword.substring( 1, keyword.length - 1 );
+	// Check if the keyphrase is enclosed in double quotation marks to ensure that only exact matches are processed.
+	const exactMatchRequest = processExactMatchRequest( keyword );
+	if ( exactMatchRequest.exactMatchRequested ) {
+		keyword = exactMatchRequest.keyword;
 		result.exactMatchKeyphrase = true;
 	}
 
-	// Check 1: Is the exact match of the keyphrase found in the title?
+	// Check if the exact match of the keyphrase found in the title.
 	const keywordMatched = wordMatch( title, keyword, locale );
 
 	if ( keywordMatched.count > 0 ) {
 		result.exactMatchFound = true;
 		result.allWordsFound = true;
-		result.position = keywordMatched.position;
-
-		if ( process.env.YOAST_RECALIBRATION === "enabled" && ! ( result.position === 0 ) ) {
-			const language = getLanguage( locale );
-			// If function words exist for this language...
-			const functionWords = get( getFunctionWords, [ language ], [] );
-			if ( ! isUndefined( functionWords.all ) ) {
-				const titleBeforeKeyword = title.substr( 0, result.position );
-
-				// Strip all function words from the beginning of the title.
-				const onlyFunctionWordsBeforeKeyword = stripFunctionWordsFromStart( functionWords.all, titleBeforeKeyword );
-
-				if ( onlyFunctionWordsBeforeKeyword ) {
-					// Update the position (such that "the keyword" is still counted as position 0).
-					result.position = 0;
-				}
-			}
-		}
+		result.position = adjustPosition( title, keywordMatched.position, locale );
 
 		return result;
 	}

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -67,15 +67,17 @@ export default function( paper, researcher ) {
 		result.position = keywordMatched.position;
 		const language = getLanguage( locale );
 
-		// If function words exist for this language...
-		const functionWords = get( getFunctionWords, [ language ], [] );
-		if ( ! isUndefined( functionWords.all ) ) {
-			// Strip all function words from the beginning of the title.
-			const strippedTitle = stripFunctionWordsFromStart( functionWords.all, title );
-			// Match the keyphrase with the stripped title.
-			const strippedTitleMatch = wordMatch( strippedTitle, keyword, locale );
-			// Update the position (such that beginning is still 0).
-			result.position = strippedTitleMatch.position;
+		if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+			// If function words exist for this language...
+			const functionWords = get( getFunctionWords, [ language ], [] );
+			if ( ! isUndefined( functionWords.all ) ) {
+				// Strip all function words from the beginning of the title.
+				const strippedTitle = stripFunctionWordsFromStart( functionWords.all, title );
+				// Match the keyphrase with the stripped title.
+				const strippedTitleMatch = wordMatch( strippedTitle, keyword, locale );
+				// Update the position (such that beginning is still 0).
+				result.position = strippedTitleMatch.position;
+			}
 		}
 
 		return result;

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -3,7 +3,18 @@
 import wordMatch from "../stringProcessing/matchTextWithWord.js";
 const findTopicFormsInString = require( "./findKeywordFormsInString.js" ).findTopicFormsInString;
 
-import { escapeRegExp, includes } from "lodash-es";
+import getFunctionWordsFactory from "../helpers/getFunctionWords";
+
+import { escapeRegExp, get, includes, isUndefined } from "lodash-es";
+import createRegexFromArray from "../stringProcessing/createRegexFromArray";
+import stripSpaces from "../stringProcessing/stripSpaces";
+import getLanguage from "../helpers/getLanguage";
+
+const getFunctionWords = getFunctionWordsFactory();
+
+const findPositionExcludingFunctionWords = function( title, keyword, locale ) {
+
+};
 
 /**
  * Counts the occurrences of the keyword in the page title. Returns the result that contains information on
@@ -37,6 +48,20 @@ export default function( paper, researcher ) {
 		result.exactMatch = true;
 		result.allWordsFound = true;
 		result.position = keywordMatched.position;
+
+		const language = getLanguage( locale );
+
+		// Strip function words from the beginning of the title.
+		const functionWords = get( getFunctionWords, [ language ], [] );
+		if ( ! isUndefined( functionWords ) ) {
+			const functionWordsRegex = createRegexFromArray( functionWords.all, false, "start" );
+			const strippedTitle = escapeRegExp( stripSpaces( title.replace( functionWordsRegex, "" ) ) );
+
+			// If nothing has been stripped, return the old result, otherwise return the new one.
+			if ( strippedTitle.length !== title.length ) {
+				result.position = strippedTitle.toLocaleLowerCase().indexOf( keyword.toLocaleLowerCase() );
+			}
+		}
 
 		return result;
 	}

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -8,6 +8,7 @@ import getFunctionWordsFactory from "../helpers/getFunctionWords";
 import { escapeRegExp, get, includes, isUndefined } from "lodash-es";
 import getLanguage from "../helpers/getLanguage";
 import addWordboundary from "../stringProcessing/addWordboundary";
+import getWords from "../stringProcessing/getWords";
 
 const getFunctionWords = getFunctionWordsFactory();
 
@@ -18,19 +19,24 @@ const getFunctionWords = getFunctionWordsFactory();
  * @returns {string} The given string with the function words stripped.
  */
 const stripFunctionWordsFromStart = function( functionWords, str ) {
+	str = str.toLocaleLowerCase();
 	let strippedTitle = str.toLocaleLowerCase();
-	// Try to strip each function word from the start of the str.
-	functionWords.forEach( word => {
-		const regex = new RegExp( "^" + addWordboundary( word.toLocaleLowerCase() ) );
-		strippedTitle = strippedTitle.replace( regex, "" );
-	} );
+	const titleWords = getWords( str );
 
-	// Nothing has been stripped, no function words found at the start.
-	if ( strippedTitle.length === str.length ) {
-		return strippedTitle;
+	// Strip all function words from the start of the title string.
+	for ( let i = 0; i < titleWords.length; i++ ) {
+		const word = titleWords[ i ];
+		// If this word is a function word, strip it from the title.
+		// Else, break since there are no words to strip from the beginning.
+		if ( functionWords.includes( word ) ) {
+			const regex = new RegExp( "^(" + addWordboundary( word ) + ")" );
+			strippedTitle = strippedTitle.replace( regex, "" );
+		} else {
+			break;
+		}
 	}
-	// Recursively call function until all function words have been stripped from the start.
-	return stripFunctionWordsFromStart( functionWords, strippedTitle );
+
+	return strippedTitle;
 };
 
 /**

--- a/src/researches/findKeywordInPageTitle.js
+++ b/src/researches/findKeywordInPageTitle.js
@@ -5,38 +5,30 @@ import { findTopicFormsInString } from "./findKeywordFormsInString.js";
 
 import getFunctionWordsFactory from "../helpers/getFunctionWords";
 
-import { escapeRegExp, get, includes, isUndefined } from "lodash-es";
+import { escapeRegExp, filter, get, includes, isEmpty, isUndefined } from "lodash-es";
 import getLanguage from "../helpers/getLanguage";
-import addWordboundary from "../stringProcessing/addWordboundary";
 import getWords from "../stringProcessing/getWords";
 
 const getFunctionWords = getFunctionWordsFactory();
 
 /**
  * Strips all function words from the start of the given string.
+ *
  * @param {string[]} functionWords The array of function words to strip from the start.
  * @param {string} str The string from which to strip the function words.
- * @returns {string} The given string with the function words stripped.
+ *
+ * @returns {boolean} Whether the string consists of function words only.
  */
 const stripFunctionWordsFromStart = function( functionWords, str ) {
 	str = str.toLocaleLowerCase();
-	let strippedTitle = str.toLocaleLowerCase();
-	const titleWords = getWords( str );
+	let titleWords = getWords( str.toLocaleLowerCase() );
 
-	// Strip all function words from the start of the title string.
-	for ( let i = 0; i < titleWords.length; i++ ) {
-		const word = titleWords[ i ];
-		/* If this word is a function word, strip it from the title.
-		   Else, break since there are no words to strip from the beginning.*/
-		if ( functionWords.includes( word ) ) {
-			const regex = new RegExp( "^(" + addWordboundary( word ) + ")" );
-			strippedTitle = strippedTitle.replace( regex, "" );
-		} else {
-			break;
-		}
-	}
+	// Strip all function words from the start of the string.
+	titleWords = filter( titleWords, function( word ) {
+		return ( ! includes( functionWords, word.trim().toLocaleLowerCase() ) );
+	} );
 
-	return strippedTitle;
+	return isEmpty( titleWords );
 };
 
 /**
@@ -55,7 +47,7 @@ export default function( paper, researcher ) {
 	const title = paper.getTitle();
 	const locale = paper.getLocale();
 
-	const result = { exactMatch: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false  };
+	const result = { exactMatchFound: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false  };
 
 	// First check if morphology is suppressed. If so, strip the quotation marks from the keyphrase.
 	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
@@ -68,21 +60,24 @@ export default function( paper, researcher ) {
 	const keywordMatched = wordMatch( title, keyword, locale );
 
 	if ( keywordMatched.count > 0 ) {
-		result.exactMatch = true;
+		result.exactMatchFound = true;
 		result.allWordsFound = true;
 		result.position = keywordMatched.position;
-		const language = getLanguage( locale );
 
-		if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+		if ( process.env.YOAST_RECALIBRATION === "enabled" && ! ( result.position === 0 ) ) {
+			const language = getLanguage( locale );
 			// If function words exist for this language...
 			const functionWords = get( getFunctionWords, [ language ], [] );
 			if ( ! isUndefined( functionWords.all ) ) {
+				const titleBeforeKeyword = title.substr( 0, result.position );
+
 				// Strip all function words from the beginning of the title.
-				const strippedTitle = stripFunctionWordsFromStart( functionWords.all, title );
-				// Match the keyphrase with the stripped title.
-				const strippedTitleMatch = wordMatch( strippedTitle, keyword, locale );
-				// Update the position (such that "the keyword" is still counted as position 0).
-				result.position = strippedTitleMatch.position;
+				const onlyFunctionWordsBeforeKeyword = stripFunctionWordsFromStart( functionWords.all, titleBeforeKeyword );
+
+				if ( onlyFunctionWordsBeforeKeyword ) {
+					// Update the position (such that "the keyword" is still counted as position 0).
+					result.position = 0;
+				}
 			}
 		}
 

--- a/src/stringProcessing/createRegexFromArray.js
+++ b/src/stringProcessing/createRegexFromArray.js
@@ -8,11 +8,10 @@ import { map } from "lodash-es";
  * Creates a regex of combined strings from the input array.
  *
  * @param {array} array The array with strings
- * @param {boolean} [disableWordBoundary] Boolean indicating whether or not to disable word boundaries
- * @param {"all"|"start"|"end"} [matchType="all"] If the regex should match either the entire string, the start or the end.
+ * @param {boolean} [disableWordBoundary] Boolean indicating whether or not to disable word boundaries.
  * @returns {RegExp} regex The regex created from the array.
  */
-export default function( array, disableWordBoundary, matchType = "all" ) {
+export default function( array, disableWordBoundary ) {
 	var regexString;
 	var _disableWordBoundary = disableWordBoundary || false;
 
@@ -24,17 +23,6 @@ export default function( array, disableWordBoundary, matchType = "all" ) {
 	} );
 
 	regexString = "(" + boundedArray.join( ")|(" ) + ")";
-
-	switch ( matchType ) {
-		case "start" :
-			regexString = "^(" + regexString + ")";
-			break;
-		case "end" :
-			regexString = "(" + regexString + ")$";
-			break;
-		default:
-			break;
-	}
 
 	return new RegExp( regexString, "ig" );
 }

--- a/src/stringProcessing/createRegexFromArray.js
+++ b/src/stringProcessing/createRegexFromArray.js
@@ -9,9 +9,10 @@ import { map } from "lodash-es";
  *
  * @param {array} array The array with strings
  * @param {boolean} [disableWordBoundary] Boolean indicating whether or not to disable word boundaries
+ * @param {"all"|"start"|"end"} [matchType="all"] If the regex should match either the entire string, the start or the end.
  * @returns {RegExp} regex The regex created from the array.
  */
-export default function( array, disableWordBoundary ) {
+export default function( array, disableWordBoundary, matchType = "all" ) {
 	var regexString;
 	var _disableWordBoundary = disableWordBoundary || false;
 
@@ -23,6 +24,17 @@ export default function( array, disableWordBoundary ) {
 	} );
 
 	regexString = "(" + boundedArray.join( ")|(" ) + ")";
+
+	switch ( matchType ) {
+		case "start" :
+			regexString = "^(" + regexString + ")";
+			break;
+		case "end" :
+			regexString = "(" + regexString + ")$";
+			break;
+		default:
+			break;
+	}
 
 	return new RegExp( regexString, "ig" );
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* In the "keyphrase in title" assessment, function words preceding the exact match keyphrase are ignored when determining the position of the keyphrase in the title. 

## Relevant technical choices:

N/A

## Test instructions

This PR can be tested by following these steps:

* Start the webpack example in default mode (cd to `examples/webpack` and run `yarn start` in the terminal) and check that the behaviour of the assessment [did not change](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#8-page-title-keyword-assessment).
* Start the webpack example in recalibration mode (cd to `examples/webpack` and run `yarn start-recalibration` in the terminal).
* In the **SEO Title** text input, enter (keyphrase = _Keyphrase research_):

| Description | Example |Feedback |
|:---------|:----------|:------|
| Keyphrase at the start of the title. | _Keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!_ |
| Keyphrase in the middle, preceded by one function word. | _Your keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!_ |
| Keyphrase in the middle, preceded by multiple function words. | _Your first keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!_ |
| Keyphrase in the middle, preceded by multiple function words plus a content word. | _Your sentence and first keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears in the SEO title, but not at the beginning. Try to move it to the beginning._ |
| Partial keyphrase in the title. | _Your sentence and first keyword research is awesome!_ | _Keyphrase in title: Not all the words from your keyphrase "Keyphrase research" appear in the SEO title. Try to use the exact match of your keyphrase in the SEO title._ |

* In the **SEO Title** text input, enter (keyphrase = _your keyphrase research_):

| Description | Example |Feedback |
|:---------|:----------|:------|
| Keyphrase at the start of the title. | _Your keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!_ |
| Keyphrase in the middle, preceded by one function word. | _And your keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!_ |
| Keyphrase in the middle, preceded by multiple function words. | _First off, your keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears at the beginning of the SEO title. Good job!_ |
| Keyphrase in the middle, preceded by multiple function words plus a content word. | _And sentence and your keyphrase research is awesome!_ | _Keyphrase in title: The exact match of the keyphrase appears in the SEO title, but not at the beginning. Try to move it to the beginning._ |
| Partial keyphrase in the title. | _Your sentence and first keyword research is awesome!_ | _Keyphrase in title: Not all the words from your keyphrase "Your keyphrase research" appear in the SEO title. Try to use the exact match of your keyphrase in the SEO title._ |

Fixes #1947 
