### PR TITLE
1956 disable marker for subheading distribution assessment

### DIFF
--- a/spec/assessments/subheadingDistributionTooLongSpec.js
+++ b/spec/assessments/subheadingDistributionTooLongSpec.js
@@ -124,7 +124,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	} );
 } );
 
-describe( "A test for marking too long text segments not separated by a subheading", function() {
+describe.skip( "A test for marking too long text segments not separated by a subheading", function() {
 	it( "returns markers for too long text segments", function() {
 		const paper = new Paper( longText + subheading + veryLongText );
 		const textFragment = Factory.buildMockResearcher( [ { text: "This is a too long fragment. It contains 330 words.", wordCount: 330 }, { text: "This is another too long fragment. It contains 360 words.", wordCount: 360 } ] );

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -1,14 +1,12 @@
-import { filter, map, merge } from "lodash-es";
+import { filter, merge } from "lodash-es";
 
 import Assessment from "../../assessment";
 import { inRangeEndInclusive as inRange } from "../../helpers/inRange";
 import isTextTooLong from "../../helpers/isValueTooLong";
-import marker from "../../markers/addMark";
 import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 import { getSubheadings } from "../../stringProcessing/getSubheadings";
 import getWords from "../../stringProcessing/getWords";
 import AssessmentResult from "../../values/AssessmentResult";
-import Mark from "../../values/Mark";
 
 /**
  * Represents the assessment for calculating the text after each subheading.

--- a/src/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/src/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -61,7 +61,6 @@ class SubheadingsDistributionTooLong extends Assessment {
 			return b.wordCount - a.wordCount;
 		} );
 
-		this._tooLongTexts = this.getTooLongSubheadingTexts();
 		this._tooLongTextsNumber = this.getTooLongSubheadingTexts().length;
 
 		const assessmentResult = new AssessmentResult();
@@ -75,11 +74,6 @@ class SubheadingsDistributionTooLong extends Assessment {
 		calculatedResult.resultTextPlural = calculatedResult.resultTextPlural || "";
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-
-		if ( calculatedResult.score > 2 && calculatedResult.score < 7 ) {
-			assessmentResult.setHasMarks( true );
-			assessmentResult.setMarker( this.getMarks() );
-		}
 
 		return assessmentResult;
 	}
@@ -105,20 +99,6 @@ class SubheadingsDistributionTooLong extends Assessment {
 	hasSubheadings( paper ) {
 		const subheadings = getSubheadings( paper.getText() );
 		return subheadings.length > 0;
-	}
-
-	/**
-	 * Creates a marker for each text following a subheading that is too long.
-	 * @returns {Array} All markers for the current text.
-	 */
-	getMarks() {
-		return map( this._tooLongTexts, function( tooLongText ) {
-			const marked = marker( tooLongText.text );
-			return new Mark( {
-				original: tooLongText.text,
-				marked: marked,
-			} );
-		} );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Disables the markers for the subheading distribution assessment.

## Relevant technical choices:

* Decided to `skip` the tests testing the marking functionality of the assessment, rather than delete it. Since we want to make them work again after we have implemented the html-parser. 

## Test instructions

This PR can be tested by following these steps:

* Make a new post in WordPress.
* Add a text with two or more headers, where one header is followed by a text with more than 300 words.
* You should get the feedback: 
`Subheading distribution: 1 section of your text is longer than 300 words and is not separated by any subheadings. Add subheadings to improve readability.`
* You should **not** get the option to mark the results of the assessment.

Fixes #1956 
