### PR TITLE
Add a function to collect all languages that have function word support

### DIFF
--- a/spec/helpers/getFunctionWordsLanguagesSpec.js
+++ b/spec/helpers/getFunctionWordsLanguagesSpec.js
@@ -1,0 +1,7 @@
+import getFunctionWordsLanguages from "../../src/helpers/getFunctionWordsLanguages";
+
+describe( "Checks which languages have function word support in YoastSEO.js", function() {
+	it( "returns an array of languages that have function word support", function() {
+		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl" ] );
+	} );
+} );

--- a/src/helpers/getFunctionWordsLanguages.js
+++ b/src/helpers/getFunctionWordsLanguages.js
@@ -1,0 +1,12 @@
+import getFunctionWords from "./getFunctionWords";
+
+/**
+ * Checks which languages have function words support inside YoastSEO.js
+ *
+ * @returns {Array} A list of languages that have function words support.
+ */
+export default function() {
+	const functionWords = getFunctionWords();
+
+	return Object.keys( functionWords );
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Implements a function that checks for which languages we have a function words support inside YoastSEO.js.

## Test instructions

This PR can be tested by following these steps:

* Add a fake language with fake function words to the `/src/helpers/getFunctionWords.js` and check if  `yarn test` fails on this language.
