### PR TITLE
Replace underscore with whitespace in URL keyphrase assessment

### DIFF
--- a/spec/researches/keywordCountInUrlSpec.js
+++ b/spec/researches/keywordCountInUrlSpec.js
@@ -177,4 +177,11 @@ describe( "test to check url for keyword", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
 	} );
+
+	it( "works with dash as word boundary un url", function() {
+		const paper = new Paper( "", { url: "cats_and_dogs", keyword: "cats and dogs" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
+	} );
 } );

--- a/spec/researches/keywordCountInUrlSpec.js
+++ b/spec/researches/keywordCountInUrlSpec.js
@@ -178,7 +178,7 @@ describe( "test to check url for keyword", function() {
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
 	} );
 
-	it( "works with dash as word boundary un url", function() {
+	it( "works with dash as word boundary in url", function() {
 		const paper = new Paper( "", { url: "cats_and_dogs", keyword: "cats and dogs" } );
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );

--- a/src/researches/keywordCountInUrl.js
+++ b/src/researches/keywordCountInUrl.js
@@ -12,7 +12,7 @@ import { findTopicFormsInString } from "./findKeywordFormsInString.js";
  */
 export default function( paper, researcher ) {
 	const topicForms = researcher.getResearch( "morphology" );
-	const slug = paper.getUrl().replace( /\-/ig, " " );
+	const slug = paper.getUrl().replace( /[-_]/ig, " " );
 
 	const keyphraseInSlug = findTopicFormsInString( topicForms, slug, false, paper.getLocale() );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds underscore to characters that are replaced with whitespace in URL in the keywordCountInURL function

## Test instructions

This PR can be tested by following these steps:

* In your local Wordpress environment, create a text with a URL that uses underscores as word boundaries (rather than dashes). 
* Enter a keyphrase that uses the same words as those in the slug
* Make sure that a green bullet is returned for the URL keyphrase assessment

Fixes #1978
