### PR TITLE
Recalibrate keyphrase length assessment

### DIFF
--- a/spec/assessments/KeyphraseLengthAssessmentSpec.js
+++ b/spec/assessments/KeyphraseLengthAssessmentSpec.js
@@ -3,7 +3,11 @@ import Paper from "../../src/values/Paper.js";
 import factory from "../specHelpers/factory.js";
 const i18n = factory.buildJed();
 
-describe( "the keyphrase length assessment", function() {
+describe( "the keyphrase length assessment in the regular analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "disabled";
+	} );
+
 	it( "should assess a paper without a keyword as extremely bad", function() {
 		const paper = new Paper();
 		const researcher = factory.buildMockResearcher( 0 );
@@ -58,6 +62,118 @@ describe( "the keyphrase length assessment", function() {
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
 			"The keyphrase is 5 words long. That's more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
+	} );
+
+	// These tests check whether recalibration-specific changes don't affect the regular analysis.
+	it( "should assess a paper with an 6-word keyphrase as okay for a language that doesn't support function words", function() {
+		const paper = new Paper( "", { keyword: "1 2 3 4 5 6", locale: "xx_XX" } );
+		const researcher = factory.buildMockResearcher( 6 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 6 words long. That's more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
+	} );
+
+	it( "should assess a paper with an 9-word keyphrase as bad for a language that doesn't support function words", function() {
+		const paper = new Paper( "", { keyword: "1 2 3 4 5 6 7 8 9", locale: "xx_XX" } );
+		const researcher = factory.buildMockResearcher( 9 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 9 words long. That's way more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
+	} );
+} );
+
+describe( "the keyphrase length assessment in the recalibrated analysis", function() {
+	beforeEach( () => {
+		process.env.YOAST_RECALIBRATION = "enabled";
+	} );
+
+	// These tests are the same as in the regular analysis.
+	it( "should assess a paper without a keyword as extremely bad", function() {
+		const paper = new Paper();
+		const researcher = factory.buildMockResearcher( 0 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( -999 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"No focus keyphrase was set for this page. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Set a keyphrase in order to calculate your SEO score</a>." );
+	} );
+
+	it( "should show a different feedback text when no keyphrase is set for a related keyphrase", function() {
+		const paper = new Paper();
+		const researcher = factory.buildMockResearcher( 0 );
+
+		const result = new KeyphraseLengthAssessment( { isRelatedKeyphrase: true } ).getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( -999 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"<a href='https://yoa.st/33j' target='_blank'>Set a keyphrase in order to calculate your SEO score</a>." );
+	} );
+
+	it( "should assess a paper with a keyphrase that's too long as bad", function() {
+		const paper = new Paper( "", { keyword: "keyword" } );
+		const researcher = factory.buildMockResearcher( 11 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 11 words long. That's way more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
+	} );
+
+	it( "should assess a paper with a keyphrase that's the correct length", function() {
+		const paper = new Paper( "", { keyword: "keyword" } );
+		const researcher = factory.buildMockResearcher( 3 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 9 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!" );
+	} );
+
+	it( "should assess a paper with a keyphrase that's a little longer than the correct length", function() {
+		const paper = new Paper( "", { keyword: "keyword keyword keyword keyword keyword" } );
+		const researcher = factory.buildMockResearcher( 5 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 5 words long. That's more than the recommended maximum of 4 words. " +
+			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
+	} );
+
+	// These are the recalibration-specific tests.
+	it( "should assess a paper with an 6-word keyphrase as good for a language that doesn't support function words", function() {
+		const paper = new Paper( "", { keyword: "1 2 3 4 5 6", locale: "xx_XX" } );
+		const researcher = factory.buildMockResearcher( 6 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 9 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!" );
+	} );
+
+	it( "should assess a paper with an 9-word keyphrase as okay for a language that doesn't support function words", function() {
+		const paper = new Paper( "", { keyword: "1 2 3 4 5 6 7 8 9", locale: "xx_XX" } );
+		const researcher = factory.buildMockResearcher( 9 );
+
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
+			"The keyphrase is 9 words long. That's more than the recommended maximum of 6 words. " +
 			"<a href='https://yoa.st/33j' target='_blank'>Make it shorter</a>!" );
 	} );
 } );

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -1,8 +1,8 @@
-import { isUndefined } from "lodash-es";
-import { merge } from "lodash-es";
-import { inRange } from "lodash-es";
+import { isUndefined, merge, inRange } from "lodash-es";
 
 import Assessment from "../../assessment";
+import getFunctionWordsLanguages from "../../helpers/getFunctionWordsLanguages";
+import getLanguage from "../../helpers/getLanguage";
 import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 import AssessmentResult from "../../values/AssessmentResult";
 
@@ -30,12 +30,17 @@ class KeyphraseLengthAssessment extends Assessment {
 				recommendedMaximum: 4,
 				acceptableMaximum: 8,
 			},
+			parametersNoFunctionWordSupport: {
+				recommendedMaximum: 6,
+				acceptableMaximum: 9,
+			},
 			scores: {
 				veryBad: -999,
 				bad: 3,
 				okay: 6,
 				good: 9,
 			},
+
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/33i" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/33j" ),
 			isRelatedKeyphrase: false,
@@ -57,6 +62,16 @@ class KeyphraseLengthAssessment extends Assessment {
 	getResult( paper, researcher, i18n ) {
 		this._keyphraseLength = researcher.getResearch( "keyphraseLength" );
 		const assessmentResult = new AssessmentResult();
+		this._boundaries = this._config.parameters;
+
+		if ( process.env.YOAST_RECALIBRATION === "enabled" ) {
+			const languagesWithFunctionWords = getFunctionWordsLanguages();
+
+			// Make the boundaries less strict if the language of the current paper doesn't have function word support.
+			if ( languagesWithFunctionWords.includes( getLanguage( paper.getLocale() ) ) === false ) {
+				this._boundaries = merge( {}, this._config.parameters, this._config.parametersNoFunctionWordSupport  );
+			}
+		}
 
 		const calculatedResult = this.calculateResult( i18n );
 
@@ -76,7 +91,7 @@ class KeyphraseLengthAssessment extends Assessment {
 	 * @returns {Object} Object with score and text.
 	 */
 	calculateResult( i18n ) {
-		if ( this._keyphraseLength < this._config.parameters.recommendedMinimum ) {
+		if ( this._keyphraseLength < this._boundaries.recommendedMinimum ) {
 			if ( this._config.isRelatedKeyphrase ) {
 				return {
 					score: this._config.scores.veryBad,
@@ -109,7 +124,7 @@ class KeyphraseLengthAssessment extends Assessment {
 			};
 		}
 
-		if ( inRange( this._keyphraseLength, this._config.parameters.recommendedMinimum, this._config.parameters.recommendedMaximum + 1 ) ) {
+		if ( inRange( this._keyphraseLength, this._boundaries.recommendedMinimum, this._boundaries.recommendedMaximum + 1 ) ) {
 			return {
 				score: this._config.scores.good,
 				resultText: i18n.sprintf(
@@ -124,7 +139,7 @@ class KeyphraseLengthAssessment extends Assessment {
 			};
 		}
 
-		if ( inRange( this._keyphraseLength, this._config.parameters.recommendedMaximum + 1, this._config.parameters.acceptableMaximum + 1 ) ) {
+		if ( inRange( this._keyphraseLength, this._boundaries.recommendedMaximum + 1, this._boundaries.acceptableMaximum + 1 ) ) {
 			return {
 				score: this._config.scores.okay,
 				resultText: i18n.sprintf(
@@ -139,7 +154,7 @@ class KeyphraseLengthAssessment extends Assessment {
 							"%4$sMake it shorter%5$s!"
 					),
 					this._keyphraseLength,
-					this._config.parameters.recommendedMaximum,
+					this._boundaries.recommendedMaximum,
 					this._config.urlTitle,
 					this._config.urlCallToAction,
 					"</a>"
@@ -161,7 +176,7 @@ class KeyphraseLengthAssessment extends Assessment {
 					"%4$sMake it shorter%5$s!"
 				),
 				this._keyphraseLength,
-				this._config.parameters.recommendedMaximum,
+				this._boundaries.recommendedMaximum,
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"

--- a/src/assessments/seo/KeyphraseLengthAssessment.js
+++ b/src/assessments/seo/KeyphraseLengthAssessment.js
@@ -40,7 +40,6 @@ class KeyphraseLengthAssessment extends Assessment {
 				okay: 6,
 				good: 9,
 			},
-
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/33i" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/33j" ),
 			isRelatedKeyphrase: false,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Makes the scoring scheme of the keyphrase length assessment less strict for languages that don't have function word support. This functionality is only available when the recalibration beta is switched on.

## Relevant technical choices:

* n/a

## Test instructions

This PR can be tested by following these steps:

### Regular analysis
* Start non-recalibrated version in the YoastSEO.js development tool using `yarn start`.
* Make sure your locale is set to a language for which we have function word support, e.g. `en_US`.
* Set a 4-word keyphrase, e.g. `holiday homes southern Italy`.
* Confirm that you get a green bullet and the feedback `Keyphrase length: Good job!`.
* Set a 5-word keyphrase, e.g. 'spacious holiday homes southern Italy`.
* Confirm that you get an orange bullet and the feedback `Keyphrase length: The keyphrase is 5 words long. That's more than the recommended maximum of 4 words. Make it shorter!`
* Set the locale to a language for which we don't have function word support, e.g. `dk_DK`.
* Confirm that the feedback doesn't change.
* Set the locale back to `en_US`.
* Set a 9-word keyphrase, e.g. `extraordinarily spacious family-friendly holiday homes southern Italy affordable price`.
* Confirm that you get the feedback `Keyphrase length: The keyphrase is 9 words long. That's way more than the recommended maximum of 4 words. Make it shorter!`.
* Set the locale to `dk_DK`.
* Confirm that the feedback doesn't change.

### Recalibrated analysis
* Start recalibrated version in the YoastSEO.js development tool using `yarn start-recalibration`.
* Make sure your locale is set to a language for which we have function word support, e.g. `en_US`.
* Set a 4-word keyphrase, e.g. `holiday homes southern Italy`.
* Confirm that you get a green bullet and the feedback `Keyphrase length: Good job!`.
* Set a 5-word keyphrase, e.g. 'spacious holiday homes southern Italy`.
* Confirm that you get an orange bullet and the feedback `Keyphrase length: The keyphrase is 5 words long. That's more than the recommended maximum of 4 words. Make it shorter!`
* Set the locale to a language for which we don't have function word support, e.g. `dk_DK`.
* Confirm that you get a green bullet and the feedback `Keyphrase length: Good job!`.
* Set the locale back to `en_US`.
* Set a 9-word keyphrase, e.g. `extraordinarily spacious family-friendly holiday homes southern Italy affordable price`.
* Confirm that you get the feedback `Keyphrase length: The keyphrase is 9 words long. That's way more than the recommended maximum of 4 words. Make it shorter!`.
* Set the locale to `dk_DK`.
* Confirm that you get an orange bullet and the feedback `Keyphrase length: The keyphrase is 9 words long. That's more than the recommended maximum of 6 words. Make it shorter!`.
* Add another word to the keyphrase.
* Make sure you get a red bullet and the feedback `Keyphrase length: The keyphrase is 10 words long. That's way more than the recommended maximum of 6 words. Make it shorter!`.

Fixes #1965 
