### PR TITLE
Improve keyphrase in subheadings for languages without function word support

### DIFF
--- a/spec/assessments/SubHeadingsKeywordAssessmentSpec.js
+++ b/spec/assessments/SubHeadingsKeywordAssessmentSpec.js
@@ -87,7 +87,7 @@ describe( "An assessment for matching keywords in subheadings, for recalibration
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher level subheadings</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!"
 		);
 	} );
 
@@ -101,7 +101,7 @@ describe( "An assessment for matching keywords in subheadings, for recalibration
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher level subheadings</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!"
 		);
 	} );
 
@@ -115,7 +115,7 @@ describe( "An assessment for matching keywords in subheadings, for recalibration
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your higher level subheading reflects the topic of your copy. Good job!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your higher-level subheading reflects the topic of your copy. Good job!"
 		);
 	} );
 
@@ -129,7 +129,7 @@ describe( "An assessment for matching keywords in subheadings, for recalibration
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 1 of your higher level subheadings reflects the topic of your copy. Good job!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 1 of your higher-level subheadings reflects the topic of your copy. Good job!"
 		);
 	} );
 
@@ -143,7 +143,7 @@ describe( "An assessment for matching keywords in subheadings, for recalibration
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 2 of your higher level subheadings reflect the topic of your copy. Good job!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 2 of your higher-level subheadings reflect the topic of your copy. Good job!"
 		);
 	} );
 
@@ -157,7 +157,7 @@ describe( "An assessment for matching keywords in subheadings, for recalibration
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your higher level subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your higher-level subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!"
 		);
 	} );
 

--- a/spec/researches/matchKeywordInSubheadingsSpec.js
+++ b/spec/researches/matchKeywordInSubheadingsSpec.js
@@ -118,7 +118,7 @@ describe( "a test for matching keywords in subheadings", function() {
 	} );
 } );
 
-describe( "Matching keyphrase in subeadings with recalibration enabled", () => {
+describe( "Matching keyphrase in subheadings with recalibration enabled", () => {
 	beforeEach( () => {
 		process.env.YOAST_RECALIBRATION = "enabled";
 	} );
@@ -139,5 +139,21 @@ describe( "Matching keyphrase in subeadings with recalibration enabled", () => {
 		// Would be 3 if the h4 was counted too.
 		expect( result.count ).toBe( 2 );
 		expect( result.propertyIsEnumerable( 0 ) );
+	} );
+
+	it( "matching is stricter with languages that do not support function words", () => {
+		const paper = new Paper( "<h2>So ’n groot hond</h2>", {
+			keyword: "So ’n groot huis",
+			locale: "af",
+		} );
+		const researcher = Factory.buildMockResearcher( {
+			keyphraseForms: [ [ "So" ], [ "’n" ], [ "groot" ], [ "huis" ], [ "hond" ] ],
+			synonymsForms: [],
+		} );
+
+		expect( matchKeywordInSubheadings( paper, researcher ).matches ).toBe( 0 );
+
+		paper._attributes.locale = "en_US";
+		expect( matchKeywordInSubheadings( paper, researcher ).matches ).toBe( 1 );
 	} );
 } );

--- a/spec/researches/matchKeywordInSubheadingsSpec.js
+++ b/spec/researches/matchKeywordInSubheadingsSpec.js
@@ -141,6 +141,7 @@ describe( "Matching keyphrase in subheadings with recalibration enabled", () => 
 	} );
 
 	it( "matching is stricter with languages that do not support function words", () => {
+		// There is no function word support for Afrikaans.
 		const paper = new Paper( "<h2>So ’n groot hond</h2>", {
 			keyword: "So ’n groot huis",
 			locale: "af",
@@ -150,9 +151,12 @@ describe( "Matching keyphrase in subheadings with recalibration enabled", () => 
 			synonymsForms: [],
 		} );
 
+		// All the words should match and since hond !== huis the expected result is 0.
 		expect( matchKeywordInSubheadings( paper, researcher ).matches ).toBe( 0 );
 
+		// There is function word support for English.
 		paper._attributes.locale = "en_US";
+		// More than 50% should match. With 1 of the 4 words mismatching the expected result is 1.
 		expect( matchKeywordInSubheadings( paper, researcher ).matches ).toBe( 1 );
 	} );
 } );

--- a/src/assessments/seo/SubHeadingsKeywordAssessment.js
+++ b/src/assessments/seo/SubHeadingsKeywordAssessment.js
@@ -188,9 +188,9 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks whether there is only one higher level subheading and this subheading includes the keyphrase.
+	 * Checks whether there is only one higher-level subheading and this subheading includes the keyphrase.
 	 *
-	 * @returns {boolean} Returns true if there is exactly one higher level subheading and this
+	 * @returns {boolean} Returns true if there is exactly one higher-level subheading and this
 	 * subheading has a keyphrase match.
 	 */
 	isOneOfOne() {
@@ -228,7 +228,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your higher level subheadings%3$s!",
+						"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your higher-level subheadings%3$s!",
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -244,7 +244,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%3$s: More than 75%% of your higher level subheadings reflect the topic of your copy. " +
+						"%1$sKeyphrase in subheading%3$s: More than 75%% of your higher-level subheadings reflect the topic of your copy. " +
 						"That's too much. %2$sDon't over-optimize%3$s!",
 					),
 					this._config.urlTitle,
@@ -262,7 +262,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					%3$d expands to the number of subheadings containing the keyphrase. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%2$s: Your higher level subheading reflects the topic of your copy. Good job!",
+						"%1$sKeyphrase in subheading%2$s: Your higher-level subheading reflects the topic of your copy. Good job!",
 						this._subHeadings.matches,
 					),
 					this._config.urlTitle,
@@ -279,8 +279,8 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					%3$d expands to the number of subheadings containing the keyphrase. */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%2$s: %3$s of your higher level subheadings reflects the topic of your copy. Good job!",
-						"%1$sKeyphrase in subheading%2$s: %3$s of your higher level subheadings reflect the topic of your copy. Good job!",
+						"%1$sKeyphrase in subheading%2$s: %3$s of your higher-level subheadings reflects the topic of your copy. Good job!",
+						"%1$sKeyphrase in subheading%2$s: %3$s of your higher-level subheadings reflect the topic of your copy. Good job!",
 						this._subHeadings.matches,
 					),
 					this._config.urlTitle,
@@ -296,7 +296,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 				/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your higher level subheadings%3$s!",
+					"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your higher-level subheadings%3$s!",
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -1,9 +1,9 @@
+import { includes } from "lodash-es";
 import getFunctionWordsLanguages from "../helpers/getFunctionWordsLanguages";
 import getLanguage from "../helpers/getLanguage";
 import { getSubheadingContents, getSubheadingContentsTopLevel } from "../stringProcessing/getSubheadings";
 import stripSomeTags from "../stringProcessing/stripNonTextTags";
 import { findTopicFormsInString } from "./findKeywordFormsInString";
-import { includes } from "lodash-es";
 
 const functionWordLanguages = getFunctionWordsLanguages();
 

--- a/src/researches/matchKeywordInSubheadings.js
+++ b/src/researches/matchKeywordInSubheadings.js
@@ -1,6 +1,11 @@
+import getFunctionWordsLanguages from "../helpers/getFunctionWordsLanguages";
+import getLanguage from "../helpers/getLanguage";
 import { getSubheadingContents, getSubheadingContentsTopLevel } from "../stringProcessing/getSubheadings";
 import stripSomeTags from "../stringProcessing/stripNonTextTags";
 import { findTopicFormsInString } from "./findKeywordFormsInString";
+import { includes } from "lodash-es";
+
+const functionWordLanguages = getFunctionWordsLanguages();
 
 /**
  * Computes the amount of subheadings reflecting the topic.
@@ -13,11 +18,16 @@ import { findTopicFormsInString } from "./findKeywordFormsInString";
  * @returns {number} The amount of subheadings reflecting the topic.
  */
 const numberOfSubheadingsReflectingTopic = function( topicForms, subheadings, useSynonyms, locale ) {
-	return subheadings.filter(
-		subheading => {
-			return findTopicFormsInString( topicForms, subheading, useSynonyms, locale ).percentWordMatches > 50;
+	const isFunctionWordLanguage = includes( functionWordLanguages, getLanguage( locale ) );
+
+	return subheadings.filter( subheading => {
+		const matchedTopicForms = findTopicFormsInString( topicForms, subheading, useSynonyms, locale );
+
+		if ( process.env.YOAST_RECALIBRATION === "enabled" && ! isFunctionWordLanguage ) {
+			return matchedTopicForms.percentWordMatches === 100;
 		}
-	).length;
+		return matchedTopicForms.percentWordMatches > 50;
+	} ).length;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Recalibration: Stricter checking for keyphrase in subheadings for languages without function word support.

## Relevant technical choices:

* Branched from `storie/1946-limit-subheadings-assessment-to-h2-h3` see PR https://github.com/Yoast/YoastSEO.js/pull/1970 
* When recalibration is enabled and the locale is of a language that has no function word support: 100% match is required to count as a match.

## Test instructions

### Recalibrated analysis
This PR can be tested by following these steps:

* Run the development tool: `cd examples/webpack && yarn && yarn start-recalibration`.
* Use a language that we have function word support for: `en_US`.
* Add a text without subheadings.
* Add a keyphrase with multiple (content) words, e.g. `holiday homes southern Italy`.
* Add a subheading of level 2 or 3 with more than 50% but less than 100% of the keyphrase words, e.g. `holiday homes Italy`.
* Ensure the SEO feedback includes a green bullet with `Keyphrase in subheading: Your higher-level subheading reflects the topic of your copy. Good job!`.
* Switch to a locale without function word support, e.g. `af`.
* Add a text without subheadings and set a multi-word keyphrase, e.g. `so 'n groot huis`.
* Add a subheading of level 2 or 3 with more than 50% but less than 100% of the keyphrase words, e.g. `so 'n groot hond`.
* Ensure the SEO feedback includes a red bullet with `Keyphrase in subheading: Use more keyphrases or synonyms in your higher-level subheadings!`.
* Include the whole keyphrase in the subheading.
* Ensure the SEO feedback includes a green bullet with `Keyphrase in subheading: Your higher-level subheading reflects the topic of your copy. Good job!`.

### Regular analysis
* Run the development tool: `cd examples/webpack && yarn && yarn start`.
* Use a language that we have function word support for: `en_US`.
* Add a text without subheadings.
* Add a keyphrase with multiple (content) words, e.g. `holiday homes southern Italy`.
* Add a subheading of level 2 or 3 with more than 50% but less than 100% of the keyphrase words, e.g. `holiday homes Italy`.
* Ensure the SEO feedback includes a green bullet with `Keyphrase in subheading: Your subheading reflects the topic of your copy. Good job!`.
* Switch to a locale without function word support, e.g. `af`.
* Add a text without subheadings and set a multi-word keyphrase, e.g. `so 'n groot huis`.
* Add a subheading of level 2 or 3 with more than 50% but less than 100% of the keyphrase words, e.g. `so 'n groot hond`.
* Ensure the SEO feedback includes a green bullet with `Keyphrase in subheading: Your subheading reflects the topic of your copy. Good job!`.

Requires #1970 
Fixes #1966
