### PR TITLE
1985 word eggs is being recognized as transition word

### DIFF
--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -434,4 +434,24 @@ describe( "a test for finding transition words from a string", function() {
 
 		expect( result ).toEqual( expected );
 	} );
+
+	it( "does recognize transition words with full stops, like 'e.g.'.", function() {
+		// Non-transition word: eggs.
+		mockPaper = new Paper( "E.g. potatoes. I.e. apples." );
+		const expected = {
+			sentenceResults: [ {
+				sentence: "E.g. potatoes.",
+				transitionWords: [ "e.g." ],
+			}, {
+				sentence: "I.e. apples.",
+				transitionWords: [ "i.e." ],
+			} ],
+			totalSentences: 2,
+			transitionWordSentences: 2,
+		};
+
+		result = transitionWordsResearch( mockPaper );
+
+		expect( result ).toEqual( expected );
+	} );
 } );

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -418,4 +418,18 @@ describe( "a test for finding transition words from a string", function() {
 
 		expect( result ).toEqual( expected );
 	} );
+
+	it( "does not recognize 'eggs' as a transition word (don't ask).", function() {
+		// Non-transition word: eggs.
+		mockPaper = new Paper( "Let's bake some eggs." );
+		const expected = {
+			totalSentences: 1,
+			sentenceResults: [ ],
+			transitionWordSentences: 1,
+		};
+
+		const result = transitionWordsResearch( mockPaper );
+
+		expect( result ).toEqual( expected );
+	} );
 } );

--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -68,9 +68,11 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 2 );
 	} );
 
-	it( "returns 2 when a two-part transition word is found in two sentences, and an additional transition word is found in one of them. (English)", function() {
+	it( "returns 2 when a two-part transition word is found in two sentences, " +
+		"and an additional transition word is found in one of them. (English)", function() {
 		// Transition words: either...or, if ...then, as soon as.
-		mockPaper = new Paper( "I will either tell you a story about a boy, or read you a novel. If you want, then I will start as soon as you're ready.", { locale: "en_US" } );
+		mockPaper = new Paper( "I will either tell you a story about a boy, or read you a novel. " +
+			"If you want, then I will start as soon as you're ready.", { locale: "en_US" } );
 		result = transitionWordsResearch( mockPaper );
 		expect( result.totalSentences ).toBe( 2 );
 		expect( result.transitionWordSentences ).toBe( 2 );
@@ -414,7 +416,7 @@ describe( "a test for finding transition words from a string", function() {
 			transitionWordSentences: 1,
 		};
 
-		const result = transitionWordsResearch( mockPaper );
+		result = transitionWordsResearch( mockPaper );
 
 		expect( result ).toEqual( expected );
 	} );
@@ -425,10 +427,10 @@ describe( "a test for finding transition words from a string", function() {
 		const expected = {
 			totalSentences: 1,
 			sentenceResults: [ ],
-			transitionWordSentences: 1,
+			transitionWordSentences: 0,
 		};
 
-		const result = transitionWordsResearch( mockPaper );
+		result = transitionWordsResearch( mockPaper );
 
 		expect( result ).toEqual( expected );
 	} );

--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -4,7 +4,6 @@ import { normalizeSingle as normalizeSingleQuotes } from "../stringProcessing/qu
 import getTransitionWords from "../helpers/getTransitionWords.js";
 import { isWordInSentence as matchWordInSentence } from "../stringProcessing/matchWordInSentence.js";
 
-import { forEach } from "lodash-es";
 import { flattenDeep } from "lodash-es";
 import { escapeRegExp } from "lodash-es";
 
@@ -34,9 +33,9 @@ function getRegexFromDoubleArray( twoPartTransitionWords ) {
  * @param {Array} twoPartTransitionWords The array containing two-part transition words.
  * @returns {Array} The found transitional words.
  */
-var matchTwoPartTransitionWords = function( sentence, twoPartTransitionWords ) {
+const matchTwoPartTransitionWords = function( sentence, twoPartTransitionWords ) {
 	sentence = normalizeSingleQuotes( sentence );
-	var twoPartTransitionWordsRegex = getRegexFromDoubleArray( twoPartTransitionWords );
+	const twoPartTransitionWordsRegex = getRegexFromDoubleArray( twoPartTransitionWords );
 	return sentence.match( twoPartTransitionWordsRegex );
 };
 
@@ -59,11 +58,11 @@ const matchTransitionWords = function( sentence, transitionWords ) {
  * @param {Object} transitionWords The object containing both transition words and two part transition words.
  * @returns {Array} Array of sentence objects containing the complete sentence and the transition words.
  */
-var checkSentencesForTransitionWords = function( sentences, transitionWords ) {
-	var results = [];
+const checkSentencesForTransitionWords = function( sentences, transitionWords ) {
+	const results = [];
 
-	forEach( sentences, function( sentence ) {
-		var twoPartMatches = matchTwoPartTransitionWords( sentence, transitionWords.twoPartTransitionWords() );
+	sentences.forEach( sentence => {
+		const twoPartMatches = matchTwoPartTransitionWords( sentence, transitionWords.twoPartTransitionWords() );
 
 		if ( twoPartMatches !== null ) {
 			results.push( {
@@ -74,7 +73,7 @@ var checkSentencesForTransitionWords = function( sentences, transitionWords ) {
 			return;
 		}
 
-		var transitionWordMatches = matchTransitionWords( sentence, transitionWords.transitionWords );
+		const transitionWordMatches = matchTransitionWords( sentence, transitionWords.transitionWords );
 
 		if ( transitionWordMatches.length !== 0 ) {
 			results.push( {
@@ -98,10 +97,10 @@ var checkSentencesForTransitionWords = function( sentences, transitionWords ) {
  * and the total number of sentences containing one or more transition words.
  */
 export default function( paper ) {
-	var locale = paper.getLocale();
-	var transitionWords = getTransitionWords( locale );
-	var sentences = getSentences( paper.getText() );
-	var sentenceResults = checkSentencesForTransitionWords( sentences, transitionWords );
+	const locale = paper.getLocale();
+	const transitionWords = getTransitionWords( locale );
+	const sentences = getSentences( paper.getText() );
+	const sentenceResults = checkSentencesForTransitionWords( sentences, transitionWords );
 
 	return {
 		totalSentences: sentences.length,

--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -48,6 +48,7 @@ const matchTwoPartTransitionWords = function( sentence, twoPartTransitionWords )
  */
 const matchTransitionWords = function( sentence, transitionWords ) {
 	sentence = normalizeSingleQuotes( sentence );
+	// Escape regex in transition words, since we use regex characters like in abbreviations ("e.g.").
 	return transitionWords.filter( word => matchWordInSentence( escapeRegExp( word ), sentence ) );
 };
 

--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -7,6 +7,7 @@ import { isWordInSentence as matchWordInSentence } from "../stringProcessing/mat
 import { forEach } from "lodash-es";
 import { filter } from "lodash-es";
 import { flattenDeep } from "lodash-es";
+import { escapeRegExp } from "lodash-es";
 
 let regexFromDoubleArray = null;
 let regexFromDoubleArrayCacheKey = "";
@@ -51,7 +52,8 @@ var matchTransitionWords = function( sentence, transitionWords ) {
 	sentence = normalizeSingleQuotes( sentence );
 
 	var matchedTransitionWords = filter( transitionWords, function( word ) {
-		return matchWordInSentence( word, sentence );
+		// Escape regex since we use punctuation marks (like in abbreviations: e.g. "e.g.").
+		return matchWordInSentence( escapeRegExp( word ), sentence );
 	} );
 
 	return matchedTransitionWords;

--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -5,7 +5,6 @@ import getTransitionWords from "../helpers/getTransitionWords.js";
 import { isWordInSentence as matchWordInSentence } from "../stringProcessing/matchWordInSentence.js";
 
 import { forEach } from "lodash-es";
-import { filter } from "lodash-es";
 import { flattenDeep } from "lodash-es";
 import { escapeRegExp } from "lodash-es";
 
@@ -48,15 +47,9 @@ var matchTwoPartTransitionWords = function( sentence, twoPartTransitionWords ) {
  * @param {Array} transitionWords The array containing transition words.
  * @returns {Array} The found transitional words.
  */
-var matchTransitionWords = function( sentence, transitionWords ) {
+const matchTransitionWords = function( sentence, transitionWords ) {
 	sentence = normalizeSingleQuotes( sentence );
-
-	var matchedTransitionWords = filter( transitionWords, function( word ) {
-		// Escape regex since we use punctuation marks (like in abbreviations: e.g. "e.g.").
-		return matchWordInSentence( escapeRegExp( word ), sentence );
-	} );
-
-	return matchedTransitionWords;
+	return transitionWords.filter( word => matchWordInSentence( escapeRegExp( word ), sentence ) );
 };
 
 /**

--- a/src/researches/findTransitionWords.js
+++ b/src/researches/findTransitionWords.js
@@ -5,7 +5,6 @@ import getTransitionWords from "../helpers/getTransitionWords.js";
 import { isWordInSentence as matchWordInSentence } from "../stringProcessing/matchWordInSentence.js";
 
 import { flattenDeep } from "lodash-es";
-import { escapeRegExp } from "lodash-es";
 
 let regexFromDoubleArray = null;
 let regexFromDoubleArrayCacheKey = "";
@@ -48,8 +47,7 @@ const matchTwoPartTransitionWords = function( sentence, twoPartTransitionWords )
  */
 const matchTransitionWords = function( sentence, transitionWords ) {
 	sentence = normalizeSingleQuotes( sentence );
-	// Escape regex in transition words, since we use regex characters like in abbreviations ("e.g.").
-	return transitionWords.filter( word => matchWordInSentence( escapeRegExp( word ), sentence ) );
+	return transitionWords.filter( word => matchWordInSentence( word, sentence ) );
 };
 
 /**

--- a/src/stringProcessing/matchWordInSentence.js
+++ b/src/stringProcessing/matchWordInSentence.js
@@ -9,7 +9,7 @@ import addWordBoundary from "./addWordboundary.js";
  * @param {string} character The character to look for.
  * @returns {boolean} Whether or not the character is present in the list of word boundaries.
  */
-var characterInBoundary = function( character ) {
+const characterInBoundary = function( character ) {
 	return includes( wordBoundaries, character );
 };
 
@@ -20,14 +20,14 @@ var characterInBoundary = function( character ) {
  * @param {string} sentence The sentence to look through.
  * @returns {boolean} Whether or not the word is present in the sentence.
  */
-var isWordInSentence = function( word, sentence ) {
+const isWordInSentence = function( word, sentence ) {
 	// To ensure proper matching, make everything lowercase.
 	word = word.toLocaleLowerCase();
 	sentence = sentence.toLocaleLowerCase();
 
 	// Escape regex in word, since we use regex characters like in abbreviations ("e.g.").
-	var wordWithBoundaries = addWordBoundary( escapeRegExp( word ) );
-	var occurrenceStart = sentence.search( new RegExp( wordWithBoundaries, "ig" ) );
+	const wordWithBoundaries = addWordBoundary( escapeRegExp( word ) );
+	let occurrenceStart = sentence.search( new RegExp( wordWithBoundaries, "ig" ) );
 	// Return false if no match has been found.
 	if ( occurrenceStart === -1 ) {
 		return false;
@@ -41,11 +41,11 @@ var isWordInSentence = function( word, sentence ) {
 	if ( occurrenceStart > 0 ) {
 		occurrenceStart += 1;
 	}
-	var occurrenceEnd = occurrenceStart + word.length;
+	const occurrenceEnd = occurrenceStart + word.length;
 
 	// Check if the previous and next character are word boundaries to determine if a complete word was detected
-	var previousCharacter = characterInBoundary( sentence[ occurrenceStart - 1 ] ) || occurrenceStart === 0;
-	var nextCharacter = characterInBoundary( sentence[ occurrenceEnd ] ) || occurrenceEnd === sentence.length;
+	const previousCharacter = characterInBoundary( sentence[ occurrenceStart - 1 ] ) || occurrenceStart === 0;
+	const nextCharacter = characterInBoundary( sentence[ occurrenceEnd ] ) || occurrenceEnd === sentence.length;
 
 	return ( ( previousCharacter ) && ( nextCharacter ) );
 };
@@ -56,6 +56,6 @@ export {
 };
 
 export default {
-	characterInBoundary: characterInBoundary,
-	isWordInSentence: isWordInSentence,
+	characterInBoundary,
+	isWordInSentence,
 };

--- a/src/stringProcessing/matchWordInSentence.js
+++ b/src/stringProcessing/matchWordInSentence.js
@@ -1,6 +1,6 @@
 import wordBoundariesFactory from "../config/wordBoundaries.js";
 const wordBoundaries = wordBoundariesFactory();
-import { includes } from "lodash-es";
+import { escapeRegExp, includes } from "lodash-es";
 import addWordBoundary from "./addWordboundary.js";
 
 /**
@@ -25,7 +25,8 @@ var isWordInSentence = function( word, sentence ) {
 	word = word.toLocaleLowerCase();
 	sentence = sentence.toLocaleLowerCase();
 
-	var wordWithBoundaries = addWordBoundary( word );
+	// Escape regex in word, since we use regex characters like in abbreviations ("e.g.").
+	var wordWithBoundaries = addWordBoundary( escapeRegExp( word ) );
 	var occurrenceStart = sentence.search( new RegExp( wordWithBoundaries, "ig" ) );
 	// Return false if no match has been found.
 	if ( occurrenceStart === -1 ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The word 'eggs' is not recognized as a transition word anymore.

## Relevant technical choices:

* Refactored some code a bit to use 'new' javascript features like `const`,`let`, `array.filter` etc.

## Test instructions

This PR can be tested by following these steps:

* Make a new blog post.
* Enter a sentence with the word `eggs`, e.g. `We bake some eggs for breakfast.`
* Make sure that `eggs` is not recognized as a transition word in the readability analysis.
    * e.g. the feedback is:
`Transition words: None of the sentences contain transition words. Use some.`, 
instead of `Transition words: Well done!`

Fixes #1985 
