### PR TITLE
Add the grunt task shell:pull-premium-configuration

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -23,6 +23,7 @@ check:
   - 'shell:get-current-branch'
   - 'shell:clone-premium-configuration'
   - 'shell:checkout-premium-configuration'
+  - 'shell:pull-premium-configuration'
 # Default task
 default:
   - check

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -58,7 +58,11 @@ module.exports = function( grunt ) {
 			command: function() {
 				const commands = [];
 
-				const branch = process.env.CI ? process.env.TRAVIS_BRANCH : grunt.config.get( "currentBranch" );
+				// Whitespace within the commands results into unexpected tokens.
+				const branch = ( process.env.CI
+					? process.env.TRAVIS_BRANCH
+					: grunt.config.get( "currentBranch" )
+				).trim();
 
 				commands.push( "cd premium-configuration" );
 				commands.push( "git checkout develop" );
@@ -68,6 +72,16 @@ module.exports = function( grunt ) {
 			},
 			options: {
 				failOnError: false,
+			},
+		},
+		"pull-premium-configuration": {
+			command: function() {
+				const commands = [];
+
+				commands.push( "cd premium-configuration" );
+				commands.push( "git pull" );
+
+				return commands.join( "&&" );
 			},
 		},
 	};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Added the Grunt task `shell:pull-premium-configuration`.
* This is in a separate task because the `shell:checkout-premium-configuration` did not continue after a checkout error. Despite the `failOnError: false` option being set. And that task is supposed to be able to fail.

## Test instructions

This PR can be tested by following these steps:

* Before switching to this branch.
* Run the Grunt task: `grunt get-premium-configuration`.
* Maybe you already have it. Did you get output similar to this:
```
Your branch is behind 'origin/develop' by 3 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
```
* If not: Go to the `premium-configuration` folder and make it not be up-to-date by going back a commit: `cd premium-configuration&&git reset --hard HEAD~1&cd ..`.
* Switch to this branch: `git checkout 1977-add-pull-to-get-premium-configuration`.
* Run the Grunt task: `grunt get-premium-configuration`.
* Ensure you get output similar to this:
```
Running "shell:pull-premium-configuration" (shell) task
Updating c297d4e..ac02d89
Fast-forward
 .travis.yml       | 11 +++++++++++
 scripts/deploy.sh | 10 ++++++++++
 2 files changed, 21 insertions(+)
 create mode 100644 .travis.yml
 create mode 100644 scripts/deploy.sh
```

Fixes #1977 
