### PR TITLE
Fix url-permalink and add another full-text spec

### DIFF
--- a/spec/fullTextTests/testTexts/englishPaper1.js
+++ b/spec/fullTextTests/testTexts/englishPaper1.js
@@ -48,7 +48,8 @@ const paper = new Paper( "<p>My husband &#8211; <a href='https://yoast.com/about
 	title: "Voice search: what will the future bring?",
 	titleWidth: 450,
 	locale: "en_EN",
-	url: "https://yoast.com/future-of-voice-search/",
+	permalink: "https://yoast.com/future-of-voice-search/",
+	url: "future-of-voice-search",
 } );
 
 const expectedResults = {
@@ -89,12 +90,12 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 716 words. Good job!",
 	},
 	externalLinks: {
-		score: 9,
-		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!",
 	},
 	internalLinks: {
-		score: 3,
-		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: You have enough internal links. Good job!",
 	},
 	titleKeyword: {
 		score: 9,
@@ -109,8 +110,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: Great work!",
 	},
 	urlLength: {
-		score: 6,
-		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
+		score: 0,
+		resultText: "",
 	},
 	urlStopWords: {
 		score: 5,

--- a/spec/fullTextTests/testTexts/englishPaper2.js
+++ b/spec/fullTextTests/testTexts/englishPaper2.js
@@ -37,7 +37,8 @@ const paper = new Paper( "<div class=\"content\"><p></p>\n" +
 	title: "Annelieke's Analytics: 16 months of Google Search Console data",
 	titleWidth: 450,
 	locale: "en_EN",
-	url: "https://yoast.com/16-months-of-google-search-console-data/",
+	permalink: "https://yoast.com/16-months-of-google-search-console-data/",
+	url: "16-months-of-google-search-console-data",
 } );
 
 const expectedResults = {
@@ -78,12 +79,12 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 908 words. Good job!",
 	},
 	externalLinks: {
-		score: 9,
-		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!",
 	},
 	internalLinks: {
-		score: 3,
-		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: You have enough internal links. Good job!",
 	},
 	titleKeyword: {
 		score: 6,
@@ -98,8 +99,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: More than half of your keyphrase appears in the slug. That's great!",
 	},
 	urlLength: {
-		score: 6,
-		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
+		score: 0,
+		resultText: "",
 	},
 	urlStopWords: {
 		score: 5,

--- a/spec/fullTextTests/testTexts/englishPaper3.js
+++ b/spec/fullTextTests/testTexts/englishPaper3.js
@@ -31,7 +31,8 @@ const paper = new Paper( "<div class=\"content content__first\">\n" +
 	title: "Social Media Strategy: Where to begin?",
 	titleWidth: 450,
 	locale: "en_EN",
-	url: "https://yoast.com/social-media-strategy-where-to-begin/",
+	permalink: "https://yoast.com/social-media-strategy-where-to-begin/",
+	url: "social-media-strategy-where-to-begin",
 } );
 
 const expectedResults = {
@@ -72,12 +73,12 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 529 words. Good job!",
 	},
 	externalLinks: {
-		score: 9,
-		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!",
 	},
 	internalLinks: {
-		score: 3,
-		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: You have enough internal links. Good job!",
 	},
 	titleKeyword: {
 		score: 9,
@@ -92,8 +93,8 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: More than half of your keyphrase appears in the slug. That's great!",
 	},
 	urlLength: {
-		score: 6,
-		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
+		score: 0,
+		resultText: "",
 	},
 	urlStopWords: {
 		score: 5,

--- a/spec/fullTextTests/testTexts/englishPaper4.js
+++ b/spec/fullTextTests/testTexts/englishPaper4.js
@@ -1,0 +1,153 @@
+import Paper from "../../../src/values/Paper";
+
+const name = "englishPaper4";
+
+const paper = new Paper(
+	"<p>I love that WordPress allows you to raise your voice, no matter who you are, and where you are located. That's just one of the many inspiring quotes of Carole Olinger, our third interviewee in this series on open source. Carole is Community Manager at Plesk, and a true WordPress Community junkie. Learn why she feels every single contribution matters!</p>\n" +
+	"<p><strong>Q. Why is open source so important to you?</strong></p>\n" +
+	"<p>So far, I’ve only been in touch with the WordPress project and its inspiring community. The contribution of all the fellow open source contributors allows to grow and to maintain projects like WordPress which today covers one third of the internet.</p>\n" +
+	"<p>I love that WordPress allows you to raise your voice, no matter who you are, and where you are located. This is true when it comes to spread a message that is important to you, but also, it gives everybody incredible opportunities to run their own businesses, get hired remotely by companies all around the globe and make a living. Open source projects help to reduce boundaries like the local economy, limited travel opportunities and disabilities, to name only a few.</p>\n" +
+	"<p>I'm convinced that open source communities, in general, share values that I would consider important to myself, as the WordPress community does.</p>\n" +
+	"<p><img class=\"aligncenter size-full wp-image-1621003\" src=\"https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683.jpg\" alt=\"Carole Olinger at WordCamp Utrecht\" width=\"1024\" height=\"683\" srcset=\"https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683.jpg 1024w, https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683-250x167.jpg 250w, https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683-768x512.jpg 768w, https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683-600x400.jpg 600w, https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683-75x50.jpg 75w, https://yoast.com/app/uploads/2018/11/DSC_0446-1024x683-225x150.jpg 225w\" sizes=\"(max-width: 1024px) 100vw, 1024px\" /></p>\n" +
+	"<p><strong>Q. In what way do you contribute to open source projects?</strong></p>\n" +
+	"<p>Since I joined my very first WordCamp two years ago, I consider myself a WordPress community junkie. I wanted to get more involved with the inspiring people that make WordPress so I started to volunteer at WordCamps very soon. In the meantime, I'm a triple WordCamp organizer myself, I continue to volunteer and I speak at multiple conferences. Since August 2017, I am the WordPress Community Manager for (WebOps and hosting platform) <a href=\"https://www.plesk.com/\">Plesk</a>, which allows me to contribute a considerable amount of my work time to the open source project. Also, I arrange sponsorships for WordCamps, which allows me to act as an enabler, always on the lookout for win-win situations.</p>\n" +
+	"<p>WordCamps would not be as affordable as they are right now (average is 20€ per conference day), without the help of all the sponsors. On the other hand, getting involved with the community in person during an event allows sponsors to find out about the needs of actual and potential customers and to collect valuable feedback about their own product.</p>\n" +
+	"<p><strong>Q. Who is your open source hero?</strong></p>\n" +
+	"<p>There are for sure some people that come to my mind, but I think it would be unfair to name only a few, just because it happens that I know more about them and their individual contributions.</p>\n" +
+	"<p>I’m deeply convinced that every single contribution matters, independent of the amount of time (or money) they spend or the impact they might have. I'm aware that I'm in a very privileged situation as I can partly contribute to open source projects during paid work time. Other people have to make choices, because contributing time equals unpaid hours and/or less time with their families. I see people getting into trouble, because they are so passionate about open source, that they don’t put themselves first anymore. And I think, it's also our duty as a community to have an eye on these people.</p>\n" +
+	"<p>Therefore, everybody who manages to contribute to an open source project in a healthy way is my open source super hero.</p>\n" +
+	"<p><strong>Q. Does your company encourage people to be involved with open source?</strong></p>\n" +
+	"<p>The company I work with allows me to contribute a considerable amount of my work time to the organization of WordCamps. Also, some of my colleagues are regularly contributing to WordPress and other open source projects inside and outside their work time. In my opinion, it's important to understand that it is necessary to give something back to open source projects, if your business is mainly or partly running on these. I'm happy to be able to work with a company who shares these values.</p>\n" +
+	"<p><img class=\"aligncenter size-full wp-image-1621007\" src=\"https://yoast.com/app/uploads/2018/11/carole.jpg\" alt=\"Carole Olinger presenting\" width=\"1200\" height=\"800\" srcset=\"https://yoast.com/app/uploads/2018/11/carole.jpg 1200w, https://yoast.com/app/uploads/2018/11/carole-250x167.jpg 250w, https://yoast.com/app/uploads/2018/11/carole-768x512.jpg 768w, https://yoast.com/app/uploads/2018/11/carole-600x400.jpg 600w, https://yoast.com/app/uploads/2018/11/carole-75x50.jpg 75w, https://yoast.com/app/uploads/2018/11/carole-225x150.jpg 225w\" sizes=\"(max-width: 1200px) 100vw, 1200px\" /></p>\n" +
+	"<p><strong>Q. When and what was your first open source contribution?</strong></p>\n" +
+	"<p>I remember that pretty well. I volunteered in autumn 2016 at 2 German WordCamps. During the second one, WordCamp Cologne, people convinced me to attend the Contributor Day. I was totally scared, that it wouldn't be the right place for me, as a non-technical person. I joined the Polyglots team. At the end of the day, I had localized a theme into German, which got committed the same day. This made me very proud and empowered me to get more involved into the community. Only a few days later, I got involved into the organization of a WordCamp.</p>\n" +
+	"<p><strong>Q. Do you have to be a developer to be involved with open source? How about diversity within the open source community?</strong></p>\n" +
+	"<p>That’s what probably most people think and that’s what I thought as well. But from my own experience in the WordPress project, I can tell that it’s not true. You can get involved in many ways. You can translate plugins or themes, write documentation, help to organize events or the community itself, to name only a few possibilities.</p>\n" +
+	"<p>The community I belong to has strong values, also when it comes to strive for more diversity. As a non-technical woman, I totally appreciate the efforts and the Code of Conduct, which in my eyes is the reason why WordCamps are mostly welcoming, inclusive and safe events.</p>\n" +
+	"<p>But there are still things that can be improved. Representation matters and I personally don’t see enough women and other underrepresented minorities as team leads, part of event organizer teams or speakers. I'm convinced that this has an impact on the repartition of people. Whether they're willing to contribute to the different teams of open source projects, to speak up in general and to attend events. And diversity does not just increase because we call for it. Proactive initiatives are the way to go!</p>\n" +
+	"<p><strong>Q. I want to contribute to open source! Where do I start?</strong></p>\n" +
+	"<p>Get involved with the community, online and in person. Attend meetups, conferences, online meetings. Talk about what you like about your open source project but also about what you want to see improved. Find out, how you can help with your own skills. In the end, you could be the one to initiate the change that you need to move forward.</p>", {
+		keyword: "open source opportunities",
+		synonyms: "open source contribution, wordpress contribute, contribute to open source",
+		description: "You don't need to be a developer to contribute to WordPress! Carole Olinger explains why she believes all contributors are heros.",
+		title: "Open source: reducing boundaries and creating opportunities",
+		titleWidth: 450,
+		locale: "en_EN",
+		permalink: "https://yoast.com/open-source-reducing-boundaries-and-creating-opportunities/",
+		url: "open-source-reducing-boundaries-and-creating-opportunities",
+	} );
+
+const expectedResults = {
+	introductionKeyword: {
+		score: 6,
+		resultText: "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. <a href='https://yoa.st/33f' target='_blank'>Fix that</a>!",
+	},
+	keyphraseLength: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!",
+	},
+	keywordDensity: {
+		score: 4,
+		resultText: "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: 0.1%. This is too low; the keyphrase was found 1 time. <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!",
+	},
+	metaDescriptionKeyword: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: Keyphrase or synonym appear in the meta description. Well done!",
+	},
+	metaDescriptionLength: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!",
+	},
+	subheadingsKeyword: {
+		score: 6,
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your subheadings</a>!",
+	},
+	textCompetingLinks: {
+		score: 0,
+		resultText: "",
+	},
+	textImages: {
+		score: 6,
+		resultText: "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Images on this page do not have alt attributes with words from your keyphrase. <a href='https://yoa.st/33d' target='_blank'>Fix that</a>!",
+	},
+	textLength: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 1051 words. Good job!",
+	},
+	externalLinks: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!",
+	},
+	internalLinks: {
+		score: 3,
+		resultText: "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: No internal links appear in this page, <a href='https://yoa.st/34a' target='_blank'>make sure to add some</a>!",
+	},
+	titleKeyword: {
+		score: 6,
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Does not contain the exact match. <a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title</a>.",
+	},
+	titleWidth: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!",
+	},
+	urlKeyword: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: More than half of your keyphrase appears in the slug. That's great!",
+	},
+	urlLength: {
+		score: 6,
+		resultText: "<a href='https://yoa.st/35b' target='_blank'>Slug too long</a>: the slug for this page is a bit long. <a href='https://yoa.st/35c' target='_blank'>Shorten it</a>!",
+	},
+	urlStopWords: {
+		score: 5,
+		resultText: "<a href='https://yoa.st/34p' target='_blank'>Slug stopwords</a>: The slug for this page contains a stop word. <a href='https://yoa.st/34q' target='_blank'>Remove it</a>!",
+	},
+	keyphraseDistribution: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Good job!",
+	},
+	fleschReadingEase: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 60.8 in the test, which is considered ok to read. Good job!",
+	},
+	subheadingsTooLong: {
+		score: 2,
+		resultText: "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: You are not using any subheadings, although your text is rather long. <a href='https://yoa.st/34y' target='_blank'>Try and add some subheadings</a>.",
+	},
+	textParagraphTooLong: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs are too long. Great job!",
+	},
+	textSentenceLength: {
+		score: 6,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 28.6% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+	},
+	textTransitionWords: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
+	},
+	passiveVoice: {
+		score: 3,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 19.4% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+	},
+	textPresence: {
+		score: 0,
+		resultText: "",
+	},
+	sentenceBeginnings: {
+		score: 9,
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+	},
+};
+
+export {
+	name,
+	paper,
+	expectedResults,
+};
+
+export default {
+	name: name,
+	paper: paper,
+	expectedResults: expectedResults,
+};

--- a/spec/fullTextTests/testTexts/index.js
+++ b/spec/fullTextTests/testTexts/index.js
@@ -1,9 +1,11 @@
 import englishPaper1 from "./englishPaper1";
 import englishPaper2 from "./englishPaper2";
 import englishPaper3 from "./englishPaper3";
+import englishPaper4 from "./englishPaper4";
 
 export default [
 	englishPaper1,
 	englishPaper2,
 	englishPaper3,
+	englishPaper4,
 ];


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Fixes the confused arguments `url` and `permalink` in the full-text specs.
* Fixes specs for internal and external link counts (because of the confusion those were not counted correctly).
* Adds another English text to the full-text specs.

## Test instructions

This PR can be tested by following these steps:

* Check if all tests pass

Fixes #1957 
