### PR TITLE
1998 h1s with attribute markings

### DIFF
--- a/spec/assessments/SingleH1AssessmentSpec.js
+++ b/spec/assessments/SingleH1AssessmentSpec.js
@@ -72,6 +72,21 @@ describe( "A test for marking incorrect H1s in the body", function() {
 
 		expect( results._hasMarks ).toEqual( false );
 	} );
+
+	it( "returns markers for incorrect H1s in the body, including attributes", function() {
+		const mockPaper = new Paper( "<p>a paragraph</p><h1 id='heading_id'>heading</h1>" );
+		const assessment = h1Assessment;
+		assessment.getResult( mockPaper, Factory.buildMockResearcher( [ {
+			content: "heading", position: 2, attributes: " id='heading_id'",
+		} ] ), i18n );
+
+		const expected = [
+			new Mark( { original: "<h1 id='heading_id'>heading</h1>",
+				marked: "<h1 id='heading_id'><yoastmark class='yoast-text-mark'>heading</yoastmark></h1>" } ),
+		];
+
+		expect( assessment.getMarks() ).toEqual( expected );
+	} );
 } );
 
 describe( "Checks if the assessment is applicable", function() {

--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -9,32 +9,37 @@ describe( "Gets all H1s in the text", function() {
 
 	it( "should return one object when there is one H1", function() {
 		const mockPaper = new Paper( "<h1>first h1</h1>some content<h2>content h2</h2>" );
-		expect( h1s( mockPaper ) ).toEqual( [ { tag: "h1", content: "first h1", position: 0 } ] );
+		expect( h1s( mockPaper ) ).toEqual( [ { content: "first h1", attributes: "", position: 0 } ] );
+	} );
+
+	it( "should return captured attributes in a H1.", function() {
+		const mockPaper = new Paper( "<h1 id='header_id' class='xyz'>first h1</h1>some content<h2>content h2</h2>" );
+		expect( h1s( mockPaper ) ).toEqual( [ { content: "first h1", attributes: " id='header_id' class='xyz'", position: 0 } ] );
 	} );
 
 	it( "should return all H1s in the text", function() {
 		const mockPaper = new Paper( "<h1>first h1</h1><p>not an h1</p><h1>second h1</h1><h2>not an h1</h2>" );
 
 		expect( h1s( mockPaper ) ).toEqual( [
-			{ tag: "h1", content: "first h1", position: 0 },
-			{ tag: "h1", content: "second h1", position: 2 },
+			{ content: "first h1", attributes: "", position: 0 },
+			{ content: "second h1", attributes: "", position: 2 },
 		] );
 	} );
 
-	it( "should return two h1s next to eachother", function() {
+	it( "should return two h1s next to each other", function() {
 		const mockPaper = new Paper( "<h1>first h1</h1><h1>second h1</h1><h2>not an h1</h2>" );
 
 		expect( h1s( mockPaper ) ).toEqual( [
-			{ tag: "h1", content: "first h1", position: 0 },
-			{ tag: "h1", content: "second h1", position: 1 },
+			{  content: "first h1", attributes: "", position: 0 },
+			{  content: "second h1", attributes: "", position: 1 },
 		] );
 	} );
 
 	it( "should find H1 within division tags", function() {
 		const mockPaper = new Paper( "<div><h1>first h1</h1></div><div><p>blah blah</p></div><div><h1>second h1</h1></div>" );
 		expect( h1s( mockPaper ) ).toEqual( [
-			{ tag: "h1", content: "first h1", position: 0 },
-			{ tag: "h1", content: "second h1", position: 2 },
+			{  content: "first h1", attributes: "", position: 0 },
+			{  content: "second h1", attributes: "", position: 2 },
 		] );
 	} );
 
@@ -103,8 +108,8 @@ describe( "Gets all H1s in the text", function() {
 			"important in presenting search results.&#8217;</p>" );
 
 		expect( h1s( mockPaper ) ).toEqual( [
-			{ tag: "h1", content: "Voice Search", position: 0 },
-			{ tag: "h1", content: "So what will the future bring?", position: 11 },
+			{  attributes: "", content: "Voice Search", position: 0 },
+			{  attributes: "", content: "So what will the future bring?", position: 11 },
 		] );
 	} );
 } );

--- a/src/assessments/seo/SingleH1Assessment.js
+++ b/src/assessments/seo/SingleH1Assessment.js
@@ -121,9 +121,10 @@ class singleH1Assessment extends Assessment {
 		}
 
 		return map( h1s, function( h1 ) {
+			const attributes = h1.attributes ? h1.attributes : "";
 			return new Mark( {
-				original: "<h1>" + h1.content + "</h1>",
-				marked: "<h1>" + marker( h1.content ) + "</h1>",
+				original: `<h1${attributes}>${h1.content}</h1>`,
+				marked: `<h1${attributes}>${marker( h1.content )}</h1>`,
 			} );
 		} );
 	}

--- a/src/researches/h1s.js
+++ b/src/researches/h1s.js
@@ -1,7 +1,7 @@
 // We use an external library, which can be found here: https://github.com/fb55/htmlparser2.
 import { getBlocks } from "../helpers/html";
 
-const h1Regex = /<h1.*?>(.*?)<\/h1>/;
+const h1Regex = /<h1(.*?)>(.*?)<\/h1>/;
 
 /**
  * Gets all H1s in a text, including their content and their position with regards to other HTML blocks.
@@ -20,8 +20,8 @@ export default function( paper ) {
 		const match = h1Regex.exec( block );
 		if ( match ) {
 			h1s.push( {
-				tag: "h1",
-				content: match[ 1 ],
+				attributes: match[ 1 ],
+				content: match[ 2 ],
 				position: index,
 			} );
 		}


### PR DESCRIPTION
## Summary

**Note**: Please review and test #1997 before this one, since this PR is based on changes made in that PR.

This PR can be summarized in the following changelog entry:

* Improves the markings of the single title assessment. It now marks H1-headers with attributes in the opening tag as well.

## Relevant technical choices:

* Removed the `tag: "h1"` from the H1's found by the `h1s` researcher since the function will only return H1's.

## Test instructions

This PR can be tested by following these steps:

* Start up the devtool in recalibration mode.
* Enter a random (html) text.
* Add two or more H1's, one at the start and the other ones in the middle of the text.
* Press the eye mark button next to the single title assessment in the assessment results.
* Scroll down to the markings paper.
* [ ] The H1's in the middle should be marked, the one at the start should not be. NB: Use different title text!
* Add some attributes to one or more H1's in the middle, like `id='some_header' class='some classes'`.
* [ ] The H1's with attributes should still be marked.

Fixes #1998 
Requires #1964 