### PR TITLE
1775 worker analyzerelatedkeywords failsafe

### DIFF
--- a/.eslintrc-tests
+++ b/.eslintrc-tests
@@ -13,5 +13,5 @@ rules:
   no-redeclare: 0
   # Longer grace period for Yoast config.
   no-shadow: [ 1, { "builtinGlobals": false, "hoist": "all", "allow": [] } ]
-  require-jsdoc: [ 1, {"require": {"MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true}} ]
+  require-jsdoc: [ 1, {"require": {"MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": false, "FunctionExpression": true}} ]
   no-useless-escape: 1

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -6,7 +6,7 @@ module.exports = function( grunt ) {
 		target: {
 			src: [ "<%= files.js %>", "<%= files.jsDontLint %>" ],
 			options: {
-				maxWarnings: 88,
+				maxWarnings: 87,
 				fix: fix,
 			},
 		},
@@ -14,7 +14,7 @@ module.exports = function( grunt ) {
 			src: [ "<%= files.jsTests %>" ],
 			options: {
 				configFile: ".eslintrc-tests",
-				maxWarnings: 105,
+				maxWarnings: 103,
 				fix: fix,
 			},
 		},

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -703,7 +703,7 @@ describe( "AnalysisWebWorker", () => {
 					expect( id ).toBe( 0 );
 					expect( isObject( payload ) ).toBe( true );
 					expect( payload.error ).toBeDefined();
-					expect( payload.error ).toBe( "An error occurred while running the analysis.\n\tError: Simulated error!" );
+					expect( payload.error ).toBe( "An error occurred while running the related keywords analysis.\n\tError: Simulated error!" );
 					done();
 				};
 

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -546,7 +546,9 @@ describe( "AnalysisWebWorker", () => {
 				const paper = new Paper( "This is the content." );
 
 				// Mock the console to see if it is used and to not output anything for real.
+				// eslint-disable-next-line no-console
 				console.log = jest.fn();
+				// eslint-disable-next-line no-console
 				console.error = jest.fn();
 
 				// Mock the first function call in analyze to throw an error.
@@ -559,7 +561,9 @@ describe( "AnalysisWebWorker", () => {
 					expect( isObject( result ) ).toBe( true );
 					expect( result.error ).toBeDefined();
 					expect( result.error ).toBe( "An error occurred while running the analysis.\n\tError: Simulated error!" );
+					// eslint-disable-next-line no-console
 					expect( console.log ).toHaveBeenCalled();
+					// eslint-disable-next-line no-console
 					expect( console.error ).toHaveBeenCalled();
 					done();
 				};

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -600,7 +600,7 @@ describe( "AnalysisWebWorker", () => {
 				expect( worker._scheduler.schedule ).toHaveBeenCalledTimes( 1 );
 				expect( worker._scheduler.schedule ).toHaveBeenCalledWith( {
 					id: 0,
-					execute: worker.analyze,
+					execute: worker.analyzeRelatedKeywords,
 					done: worker.analyzeRelatedKeywordsDone,
 					data: { paper, relatedKeywords },
 					type: "analyzeRelatedKeywords",
@@ -610,7 +610,7 @@ describe( "AnalysisWebWorker", () => {
 			test( "calls analyzeRelatedKeywords", done => {
 				const paper = new Paper( "This is the content." );
 				const relatedKeywords = { a: { keyword: "content", synonyms: "" } };
-				const spy = spyOn( worker, "analyze" );
+				const spy = spyOn( worker, "analyzeRelatedKeywords" );
 
 				worker.analyzeRelatedKeywordsDone = () => {
 					expect( spy ).toHaveBeenCalledTimes( 1 );
@@ -681,6 +681,33 @@ describe( "AnalysisWebWorker", () => {
 				worker.analyzeRelatedKeywordsDone( 0, { result: true } );
 				expect( worker.send ).toHaveBeenCalledTimes( 1 );
 				expect( worker.send ).toHaveBeenCalledWith( "analyzeRelatedKeywords:done", 0, { result: true } );
+			} );
+
+			test( "analyzeRelatedKeywords:failed is called if analyzeRelatedKeywords:done received a result with an error", done => {
+				const paper = new Paper( "This is the content.", {} );
+				const relatedKeywords = { a: { keyword: "content", synonyms: "" } };
+
+				scope.onmessage( createMessage( "initialize", { logLevel: "trace" } ) );
+
+				// Mock the first function call in analyze to throw an error.
+				worker.shouldReadabilityUpdate = () => {
+					throw new Error( "Simulated error!" );
+				};
+
+				/*
+				 * Check whether send - which is called from analyzeRelatedKeywords - gets passed the right
+				 * arguments that we expect if analyzeRelatedKeywords failed.
+				 */
+				worker.send = ( type, id, payload ) => {
+					expect( type ).toBe( "analyzeRelatedKeywords:failed" );
+					expect( id ).toBe( 0 );
+					expect( isObject( payload ) ).toBe( true );
+					expect( payload.error ).toBeDefined();
+					expect( payload.error ).toBe( "An error occurred while running the analysis.\n\tError: Simulated error!" );
+					done();
+				};
+
+				scope.onmessage( createMessage( "analyzeRelatedKeywords", { paper: paper.serialize(), relatedKeywords } ) );
 			} );
 		} );
 

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -520,6 +520,60 @@ describe( "AnalysisWebWorker", () => {
 				expect( worker.send ).toHaveBeenCalledTimes( 1 );
 				expect( worker.send ).toHaveBeenCalledWith( "analyze:done", 0, { result: true } );
 			} );
+
+			test( "handles analyze error", done => {
+				const paper = new Paper( "This is the content." );
+
+				// Mock the first function call in analyze to throw an error.
+				worker.shouldReadabilityUpdate = () => {
+					throw new Error( "Simulated error!" );
+				};
+
+				worker.analyzeDone = ( id, result ) => {
+					expect( id ).toBe( 0 );
+					expect( isObject( result ) ).toBe( true );
+					expect( result.error ).toBeDefined();
+					expect( result.error ).toBe( "An error occurred while running the analysis.\n\tError: Simulated error!" );
+					done();
+				};
+
+				// Silent to prevent console logging in the tests.
+				scope.onmessage( createMessage( "initialize", { logLevel: "silent" } ) );
+				scope.onmessage( createMessage( "analyze", { paper: paper.serialize() } ) );
+			} );
+
+			test( "handles analyze error, with stack trace", done => {
+				const paper = new Paper( "This is the content." );
+
+				// Mock the console to see if it is used and to not output anything for real.
+				console.log = jest.fn();
+				console.error = jest.fn();
+
+				// Mock the first function call in analyze to throw an error.
+				worker.shouldReadabilityUpdate = () => {
+					throw new Error( "Simulated error!" );
+				};
+
+				worker.analyzeDone = ( id, result ) => {
+					expect( id ).toBe( 0 );
+					expect( isObject( result ) ).toBe( true );
+					expect( result.error ).toBeDefined();
+					expect( result.error ).toBe( "An error occurred while running the analysis.\n\tError: Simulated error!" );
+					expect( console.log ).toHaveBeenCalled();
+					expect( console.error ).toHaveBeenCalled();
+					done();
+				};
+
+				scope.onmessage( createMessage( "initialize", { logLevel: "trace" } ) );
+				scope.onmessage( createMessage( "analyze", { paper: paper.serialize() } ) );
+			} );
+
+			test( "analyze done calls send on failure", () => {
+				worker.send = jest.fn();
+				worker.analyzeDone( 0, { error: "failed" } );
+				expect( worker.send ).toHaveBeenCalledTimes( 1 );
+				expect( worker.send ).toHaveBeenCalledWith( "analyze:failed", 0, { error: "failed" } );
+			} );
 		} );
 
 		describe( "analyzeRelatedKeywords", () => {

--- a/spec/worker/wrapTryCatchAroundActionSpec.js
+++ b/spec/worker/wrapTryCatchAroundActionSpec.js
@@ -1,0 +1,108 @@
+import { isFunction, isObject } from "lodash-es";
+import { getLogger } from "loglevel";
+import wrapTryCatchAroundAction from "../../src/worker/wrapTryCatchAroundAction";
+
+let logger;
+
+describe( "wrapTryAroundAction", () => {
+	beforeEach( () => {
+		logger = getLogger( "yoast-test" );
+		// Mute the actual error logs.
+		logger.error = jest.fn();
+	} );
+
+	test( "returns a function that calls the action", () => {
+		const action = jest.fn();
+		const wrapper = wrapTryCatchAroundAction( logger, action );
+
+		expect( isFunction( wrapper ) ).toBe( true );
+
+		wrapper();
+		expect( action ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( "catches an error", () => {
+		const action = () => {
+			throw new Error( "Testing error!" );
+		};
+		const wrapper = wrapTryCatchAroundAction( logger, action );
+		const result = wrapper();
+
+		expect( isObject( result ) ).toBe( true );
+		expect( result.error ).toBe( "Error: Testing error!" );
+	} );
+
+	test( "catches an error, with a stack", () => {
+		const action = () => {
+			throw new Error( "Testing error!" );
+		};
+		const wrapper = wrapTryCatchAroundAction( logger, action );
+
+		logger.debug = jest.fn();
+
+		const result = wrapper();
+
+		expect( isObject( result ) ).toBe( true );
+		expect( logger.debug ).toHaveBeenCalledTimes( 1 );
+		expect( result.error ).toBe( "Error: Testing error!" );
+	} );
+
+	test( "catches an error, without a stack", () => {
+		const action = () => {
+			throw { name: "Error", message: "Testing error!" };
+		};
+		const wrapper = wrapTryCatchAroundAction( logger, action );
+
+		logger.debug = jest.fn();
+
+		const result = wrapper();
+
+		expect( isObject( result ) ).toBe( true );
+		expect( logger.debug ).toHaveBeenCalledTimes( 0 );
+		expect( result.error ).toBe( "Error: Testing error!" );
+	} );
+
+	test( "catches an error, without a name and message", () => {
+		const action = () => {
+			throw "Testing error!";
+		};
+		const wrapper = wrapTryCatchAroundAction( logger, action );
+		const result = wrapper();
+
+		expect( isObject( result ) ).toBe( true );
+		expect( result.error ).toBe( "" );
+	} );
+
+	test( "set a message prefix", () => {
+		const action = () => {
+			throw new Error( "Testing error!" );
+		};
+		const wrapper = wrapTryCatchAroundAction( logger, action, "PREFIX" );
+
+		// Mute the actual logs.
+		logger.error = jest.fn();
+
+		const result = wrapper();
+
+		expect( isObject( result ) ).toBe( true );
+		expect( result.error ).toBe( "PREFIX\n\tError: Testing error!" );
+	} );
+
+	test( "works with console as logger", () => {
+		const action = () => {
+			throw new Error( "Testing error!" );
+		};
+		const wrapper = wrapTryCatchAroundAction( console, action );
+
+		// Mute the actual logs.
+		console.debug = jest.fn();
+		console.error = jest.fn();
+
+		const result = wrapper();
+
+		expect( isObject( result ) ).toBe( true );
+		expect( result.error ).toBe( "Error: Testing error!" );
+		expect( console.debug ).toHaveBeenCalledTimes( 1 );
+		expect( console.error ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/spec/worker/wrapTryCatchAroundActionSpec.js
+++ b/spec/worker/wrapTryCatchAroundActionSpec.js
@@ -95,14 +95,18 @@ describe( "wrapTryAroundAction", () => {
 		const wrapper = wrapTryCatchAroundAction( console, action );
 
 		// Mute the actual logs.
+		// eslint-disable-next-line no-console
 		console.debug = jest.fn();
+		// eslint-disable-next-line no-console
 		console.error = jest.fn();
 
 		const result = wrapper();
 
 		expect( isObject( result ) ).toBe( true );
 		expect( result.error ).toBe( "Error: Testing error!" );
+		// eslint-disable-next-line no-console
 		expect( console.debug ).toHaveBeenCalledTimes( 1 );
+		// eslint-disable-next-line no-console
 		expect( console.error ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -153,9 +153,13 @@ export default class AnalysisWebWorker {
 		this.handleMessage = this.handleMessage.bind( this );
 
 		// Wrap try/catch around actions.
-		this.analyze = wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the analysis." );
 		this.analyzeRelatedKeywords =
 			wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the related keywords analysis." );
+		/*
+		 * Overwrite this.analyze after we use it in this.analyzeRelatedKeywords so that this.analyzeRelatedKeywords
+		 * doesn't use the overwritten version. Therefore, this order shouldn't be changed.
+		 */
+		this.analyze = wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the analysis." );
 	}
 
 	/**

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -154,6 +154,8 @@ export default class AnalysisWebWorker {
 
 		// Wrap try/catch around actions.
 		this.analyze = wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the analysis." );
+		this.analyzeRelatedKeywords =
+			wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the analysis related keywords." );
 	}
 
 	/**
@@ -207,7 +209,7 @@ export default class AnalysisWebWorker {
 			case "analyzeRelatedKeywords":
 				this._scheduler.schedule( {
 					id,
-					execute: this.analyze,
+					execute: this.analyzeRelatedKeywords,
 					done: this.analyzeRelatedKeywordsDone,
 					data: payload,
 					type: type,
@@ -785,6 +787,10 @@ export default class AnalysisWebWorker {
 	 * @returns {void}
 	 */
 	analyzeRelatedKeywordsDone( id, result ) {
+		if ( result.error ) {
+			this.send( "analyzeRelatedKeywords:failed", id, result );
+			return;
+		}
 		this.send( "analyzeRelatedKeywords:done", id, result );
 	}
 

--- a/src/worker/AnalysisWebWorker.js
+++ b/src/worker/AnalysisWebWorker.js
@@ -155,7 +155,7 @@ export default class AnalysisWebWorker {
 		// Wrap try/catch around actions.
 		this.analyze = wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the analysis." );
 		this.analyzeRelatedKeywords =
-			wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the analysis related keywords." );
+			wrapTryCatchAroundAction( logger, this.analyze, "An error occurred while running the related keywords analysis." );
 	}
 
 	/**

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -72,6 +72,7 @@ class AnalysisWorkerWrapper {
 			case "analyze:failed":
 			case "loadScript:failed":
 			case "customMessage:failed":
+			case "analyzeRelatedKeywords:failed":
 				request.reject( payload );
 				break;
 			default:

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -69,6 +69,7 @@ class AnalysisWorkerWrapper {
 			case "analyze:done":
 				request.resolve( payload );
 				break;
+			case "analyze:failed":
 			case "loadScript:failed":
 			case "customMessage:failed":
 				request.reject( payload );

--- a/src/worker/wrapTryCatchAroundAction.js
+++ b/src/worker/wrapTryCatchAroundAction.js
@@ -1,0 +1,32 @@
+import { compact } from "lodash-es";
+
+/**
+ * Wraps the given action in a try-catch that logs the error message.
+ *
+ * @param {Logger}   logger                  The logger instance to log with.
+ * @param {Function} action                  The action to safely run.
+ * @param {string}   [errorMessagePrefix=""] The prefix of the error message.
+ *
+ * @returns {Function} The wrapped action.
+ */
+export default function wrapTryCatchAroundAction( logger, action, errorMessagePrefix = "" ) {
+	return ( ...args ) => {
+		try {
+			return action( ...args );
+		} catch ( error ) {
+			let errorMessage = [ errorMessagePrefix ];
+
+			if ( error.name && error.message ) {
+				if ( error.stack ) {
+					logger.debug( error.stack );
+				}
+				// Standard JavaScript error (e.g. when calling `throw new Error( message )`).
+				errorMessage.push( `${error.name}: ${error.message}` );
+			}
+
+			errorMessage = compact( errorMessage ).join( "\n\t" );
+			logger.error( errorMessage );
+			return { error: errorMessage };
+		}
+	};
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The browser console now shows more descriptive error messages when something went wrong during related keyphrase analyses in the web worker.

## Relevant technical choices:

* Added an `analyzeRelatedKeywords:failed` action to the AnalysisWebWorker.
* The AnalysisWorkerWrapper rejects the promise when receiving an analyze:failed.
* Adds a `analyzeRelatedKeywords` action. This still calls the regular `analyze` internally, but will trigger a more specific error message if it fails.

## Test instructions

This PR can be tested by following these steps:


* Run the test suite.

Regression testing:
* Link the branch to premium.
* Add a related keyphrase and make sure that the related keyphrase analyses still work as expected.

Testing the error:
* Add `throw new Error( "test" );` in the anayze method.
* Link the branch to premium.
* Add a related keyphrase.
* Observe that you get an error message specifically for related keyphrases.

Requires #1995 to be merged
Fixes #1775 
