### PR TITLE
Remove empty HTML blocks before research

### DIFF
--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -30,6 +30,15 @@ describe( "Gets all H1s in the text", function() {
 		] );
 	} );
 
+	it( "should rightly ignore empty paragraphs or empty blocks", function() {
+		const mockPaper = new Paper( "<p></p>\n<h1>first h1</h1><h1>second h1</h1><h2>not an h1</h2>" );
+
+		expect( h1s( mockPaper ) ).toEqual( [
+			{ tag: "h1", content: "first h1", position: 0 },
+			{ tag: "h1", content: "second h1", position: 1 },
+		] );
+	} );
+
 	it( "should find H1 within division tags", function() {
 		const mockPaper = new Paper( "<div><h1>first h1</h1></div><div><p>blah blah</p></div><div><h1>second h1</h1></div>" );
 		expect( h1s( mockPaper ) ).toEqual( [

--- a/src/researches/h1s.js
+++ b/src/researches/h1s.js
@@ -1,6 +1,20 @@
 import { getBlocks } from "../helpers/html";
+import { reject } from "lodash-es";
 
 const h1Regex = /<h1.*?>(.*?)<\/h1>/;
+
+/**
+ * Gets a block from a text and checks if it is totally empty or if it is an empty paragraph.
+ *
+ * @param {string} block A HTML block extracted from the paper.
+ *
+ * @returns {boolean} Whether the block is empty or not.
+ */
+const emptyBlock = function( block ) {
+	block = block.trim();
+	return block === "<p></p>" || block === "";
+};
+
 
 /**
  * Gets all H1s in a text, including their content and their position with regards to other HTML blocks.
@@ -12,7 +26,8 @@ const h1Regex = /<h1.*?>(.*?)<\/h1>/;
 export default function( paper ) {
 	const text = paper.getText();
 
-	const blocks = getBlocks( text );
+	let blocks = getBlocks( text );
+	blocks = reject( blocks, emptyBlock );
 
 	const h1s = [];
 	blocks.forEach( ( block, index ) => {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where the first H1 of the text would be highlighted as spurious H1 in Gutenberg

## Relevant technical choices:

* Alternatively, the issue could be solved with the following steps:
In YoastSEO.js: remove autop application to the post text (in [AnalysisWebWorker](https://github.com/Yoast/YoastSEO.js/blob/develop/src/worker/AnalysisWebWorker.js#L660)) and add trimming of the spaces at the very beginning and at the very end of the text.
In wordpress-seo: add autop dependancy, add autop application to the post text (in [collectAnalysisData](https://github.com/Yoast/wordpress-seo/blob/trunk/js/src/analysis/collectAnalysisData.js#L31)), but only to posts in classic editor (using [isGutenbergDataAvailable](https://github.com/Yoast/wordpress-seo/blob/trunk/js/src/helpers/isGutenbergDataAvailable.js)). 
Unfortunately, this (elegant) approach does not work for posts created in classic and reopened in Gutenberg.


## Test instructions

This PR can be tested by following these steps:

* See here for how to test locally: https://github.com/Yoast/YoastSEO.js/wiki/How-to-test-Recalibration-locally%3F
* Create a new post in Gutenberg that has two or more headings of H1 level.
- [ ] Make sure the `Single H1` assessment is triggered and that the eye marker highlights the all H1 headers except for the first one.
* Add a paragraph before the first H1.
- [ ] Make sure the first H1 is now also highlighted.
- [ ] Check the same functionality in Classic editor (Visual)
- [ ] Check the same functionality in Classic editor (Text)
- [ ] Try switching between Visual and Text and check if the result is stable
* Open a post created in Classic with Gutenberg and
- [ ] check the same functionality.

Fixes #https://github.com/Yoast/wordpress-seo/issues/11661
