### PR TITLE
Deprecate App

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -250,6 +250,9 @@ function verifyArguments( args ) {
  * @constructor
  */
 var App = function( args ) {
+	// Deprecate the app.
+	console.warn( "App in YoastSEO.js is no longer supported, please use the analysis web worker instead." );
+
 	if ( ! isObject( args ) ) {
 		args = {};
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Deprecated the App in favor of the Analysis Web Worker.

## Relevant technical choices:

* Added a `console.warn` in the App.

## Test instructions

This PR can be tested by following these steps:

* Link to `wordpress-seo` `trunk`.
* Verify that the warning is output in the console.

Related #2045
