### PR TITLE
Don't strip numbers from text when marking keyphrases containing numbers

### DIFF
--- a/src/stringProcessing/markWordsInSentences.js
+++ b/src/stringProcessing/markWordsInSentences.js
@@ -23,24 +23,11 @@ const collectMarkingsInSentence = function( sentence, topicFoundInSentence ) {
 export function markWordsInSentences( wordsToMark, sentences, locale ) {
 	let topicFoundInSentence = [];
 	let markings = [];
-	const indexOfSentence = 0;
-	let indexRunningThroughSentence = 0;
-	const matchesIndices = [];
 
 	sentences.forEach( function( sentence ) {
 		topicFoundInSentence = matchWords( sentence, wordsToMark, locale ).matches;
 
 		if ( topicFoundInSentence.length > 0 ) {
-			topicFoundInSentence.forEach( function( occurrence ) {
-				const indexOfOccurrenceInSentence = sentence.indexOf( occurrence, indexRunningThroughSentence );
-				matchesIndices.push(
-					{
-						index: indexOfOccurrenceInSentence + indexOfSentence,
-						match: occurrence,
-					}
-				);
-				indexRunningThroughSentence += indexOfOccurrenceInSentence + occurrence.length;
-			} );
 			markings = markings.concat( new Mark( {
 				original: sentence,
 				marked: collectMarkingsInSentence( sentence, topicFoundInSentence ),

--- a/src/stringProcessing/stripWordBoundaries.js
+++ b/src/stringProcessing/stripWordBoundaries.js
@@ -1,4 +1,4 @@
-const wordBoundary = "[ \\u00a0 \\n\\r\\t.,'()\"+\-;!?:/»«‹›<>]";
+const wordBoundary = "[ \\u00a0 \\n\\r\\t.,'()\"+\\-;!?:/»«‹›<>]";
 const wordBoundaryStart = new RegExp( "^(" + wordBoundary + "+)", "ig" );
 const wordBoundaryEnd = new RegExp( "(" + wordBoundary + "+$)", "ig" );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug that caused numbers to be stripped when marking a keyphrase containing a number, e.g. `Yoast SEO 9.3`.

## Relevant technical choices:

* Adds an extra escape character to make sure `-` in the `stripWordBoundaries` regex gets properly escaped. Previously this wasn't the case, resulting in `+-;` to be interpreted as `all characters between index 43 (+) and 59 (;)`. These indexes happen to include the numerals `0-9` (and also `+,-./_;`.

## Test instructions

This PR can be tested by following these steps:

* In the plugin, add a text with >150 words.
* Set a keyphrase including a numeral, e.g. `Yoast SEO 9.3`. Include the keyphrase at least once in your text.
* Mark the keyphrase using the eye marker next to the keyphrase density assessment or, if you're using premium, the keyphrase distribution assessment.
* Confirm that the whole keyphrase gets marked and the text isn't changed.

Fixes #2007 
