### PR TITLE
1763 add worker transporter tests

### DIFF
--- a/spec/worker/transporter/parseSpec.js
+++ b/spec/worker/transporter/parseSpec.js
@@ -1,0 +1,102 @@
+import englishFunctionWordsFactory from "../../../src/researches/english/functionWords";
+import AssessmentResult from "../../../src/values/AssessmentResult";
+import Mark from "../../../src/values/Mark";
+import Paper from "../../../src/values/Paper";
+import WordCombination from "../../../src/values/WordCombination";
+import parse from "../../../src/worker/transporter/parse";
+
+const functionWords = englishFunctionWordsFactory().all;
+
+describe( "parse", () => {
+	it( "parses strings", () => {
+		expect( parse( "a string" ) ).toEqual( "a string" );
+	} );
+
+	it( "parses numbers", () => {
+		expect( parse( 42 ) ).toEqual( 42 );
+	} );
+
+	it( "parses objects", () => {
+		const thing = {
+			number: 123,
+			"some key": "some value",
+			x: null,
+		};
+		expect( parse( thing ) ).toEqual( thing );
+	} );
+
+	it( "parses serialized WordCombinations", () => {
+		const serialized = {
+			_parseClass: "WordCombination",
+			functionWords: functionWords,
+			occurrences: 2,
+			words: [ "syllable", "combinations" ],
+			relevantWords: {
+				syllable: 4,
+				combinations: 4,
+			},
+		};
+
+		const expected = new WordCombination( [ "syllable", "combinations" ], 2, functionWords );
+		const words = {	syllable: 4, combinations: 4 };
+		expected.setRelevantWords( words );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+
+	it( "parses serialized Marks", () => {
+		const serialized = {
+			_parseClass: "Mark",
+			original: "<h1>A heading</h1>",
+			marked: "<yoastmark class='yoast-text-mark'><h1>A heading</h1></yoastmark>",
+		};
+
+		const expected = new Mark( {
+			original: "<h1>A heading</h1>",
+			marked: "<yoastmark class='yoast-text-mark'><h1>A heading</h1></yoastmark>",
+		} );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+
+	it( "parses Papers", () => {
+		const serialized = {
+			_parseClass: "Paper",
+			text: "This is a sample text.",
+			description: "This a meta description.",
+			keyword: "some keywords",
+			locale: "en_US",
+			permalink: "https://example.com/page-0",
+			title: "A text about a keyword.",
+			synonyms: "",
+			titleWidth: 0,
+			url: "",
+		};
+
+		const expected = new Paper( "This is a sample text.", {
+			description: "This a meta description.",
+			keyword: "some keywords",
+			locale: "en_US",
+			permalink: "https://example.com/page-0",
+			title: "A text about a keyword.",
+		} );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+
+	it( "parses AssessmentResults", () => {
+		const serialized = {
+			_parseClass: "AssessmentResult",
+			identifier: "",
+			marks: [],
+			score: 666,
+			text: "Good job!",
+		};
+
+		const expected = new AssessmentResult();
+		expected.setScore( 666 );
+		expected.setText( "Good job!" );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+} );

--- a/spec/worker/transporter/parseSpec.js
+++ b/spec/worker/transporter/parseSpec.js
@@ -2,6 +2,9 @@ import englishFunctionWordsFactory from "../../../src/researches/english/functio
 import AssessmentResult from "../../../src/values/AssessmentResult";
 import Mark from "../../../src/values/Mark";
 import Paper from "../../../src/values/Paper";
+import Participle from "../../../src/values/Participle";
+import Sentence from "../../../src/values/Sentence";
+import SentencePart from "../../../src/values/SentencePart";
 import WordCombination from "../../../src/values/WordCombination";
 import parse from "../../../src/worker/transporter/parse";
 
@@ -23,6 +26,11 @@ describe( "parse", () => {
 			x: null,
 		};
 		expect( parse( thing ) ).toEqual( thing );
+	} );
+
+	it( "parses arrays", () => {
+		const serialized = [ "a", 1, "bcdefg", null ];
+		expect( parse( serialized ) ).toEqual( serialized );
 	} );
 
 	it( "parses serialized WordCombinations", () => {
@@ -59,7 +67,7 @@ describe( "parse", () => {
 		expect( parse( serialized ) ).toEqual( expected );
 	} );
 
-	it( "parses Papers", () => {
+	it( "parses serialized Papers", () => {
 		const serialized = {
 			_parseClass: "Paper",
 			text: "This is a sample text.",
@@ -84,7 +92,7 @@ describe( "parse", () => {
 		expect( parse( serialized ) ).toEqual( expected );
 	} );
 
-	it( "parses AssessmentResults", () => {
+	it( "parses serialized AssessmentResults", () => {
 		const serialized = {
 			_parseClass: "AssessmentResult",
 			identifier: "",
@@ -96,6 +104,53 @@ describe( "parse", () => {
 		const expected = new AssessmentResult();
 		expected.setScore( 666 );
 		expected.setText( "Good job!" );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+
+	it( "parses serialized Participles", () => {
+		const serialized = {
+			_parseClass: "Participle",
+			attributes: {
+				auxiliaries: [ "wird", "worden" ],
+				language: "de",
+				type: "irregular",
+			},
+			determinesSentencePartIsPassive: false,
+			participle: "geschlossen",
+			sentencePart: "Es wird geschlossen worden sein.",
+		};
+
+		const expected = new Participle( "geschlossen", "Es wird geschlossen worden sein.",
+			{ auxiliaries: [ "wird", "worden" ], type: "irregular", language: "de" } );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+
+	it( "parses serialized Sentences", () => {
+		const serialized = {
+			_parseClass: "Sentence",
+			isPassive: false,
+			locale: "en_US",
+			sentenceText: "This is a sample text.",
+		};
+
+		const expected = new Sentence( "This is a sample text.", "en_US" );
+
+		expect( parse( serialized ) ).toEqual( expected );
+	} );
+
+	it( "parses serialized SentenceParts", () => {
+		const serialized = {
+			_parseClass: "SentencePart",
+			auxiliaries: [ "wird" ],
+			isPassive: true,
+			locale: "de",
+			sentencePartText: "wird geschlossen",
+		};
+
+		const expected = new SentencePart( "wird geschlossen", [ "wird" ], "de" );
+		expected.setPassive( true );
 
 		expect( parse( serialized ) ).toEqual( expected );
 	} );

--- a/spec/worker/transporter/serializeSpec.js
+++ b/spec/worker/transporter/serializeSpec.js
@@ -169,5 +169,4 @@ describe( "serialize", () => {
 
 		expect( serialize( thing ) ).toEqual( expected );
 	} );
-
 } );

--- a/spec/worker/transporter/serializeSpec.js
+++ b/spec/worker/transporter/serializeSpec.js
@@ -1,6 +1,9 @@
 import AssessmentResult from "../../../src/values/AssessmentResult";
 import Mark from "../../../src/values/Mark";
 import Paper from "../../../src/values/Paper";
+import Participle from "../../../src/values/Participle";
+import Sentence from "../../../src/values/Sentence";
+import SentencePart from "../../../src/values/SentencePart";
 import WordCombination from "../../../src/values/WordCombination";
 import serialize from "../../../src/worker/transporter/serialize";
 import englishFunctionWordsFactory from "../../../src/researches/english/functionWords.js";
@@ -120,4 +123,51 @@ describe( "serialize", () => {
 			relevantWords: words,
 		} );
 	} );
+
+	it( "serializes Participles", () => {
+		const thing = new Participle( "geschlossen", "Es wird geschlossen worden sein.",
+			{ auxiliaries: [ "wird", "worden" ], type: "irregular", language: "de" } );
+
+		const expected = {
+			_parseClass: "Participle",
+			attributes: {
+				auxiliaries: [ "wird", "worden" ],
+				language: "de",
+				type: "irregular",
+			},
+			determinesSentencePartIsPassive: false,
+			participle: "geschlossen",
+			sentencePart: "Es wird geschlossen worden sein.",
+		};
+
+		expect( serialize( thing ) ).toEqual( expected );
+	} );
+
+	it( "serializes Sentences", () => {
+		const thing = new Sentence( "This is a sample text.", "en_US" );
+		const expected = {
+			_parseClass: "Sentence",
+			isPassive: false,
+			locale: "en_US",
+			sentenceText: "This is a sample text.",
+		};
+
+		expect( serialize( thing ) ).toEqual( expected );
+	} );
+
+	it( "serializes SentenceParts", () => {
+		const thing = new SentencePart( "wird geschlossen", [ "wird" ], "de" );
+		thing.setPassive( true );
+
+		const expected = {
+			_parseClass: "SentencePart",
+			auxiliaries: [ "wird" ],
+			isPassive: true,
+			locale: "de",
+			sentencePartText: "wird geschlossen",
+		};
+
+		expect( serialize( thing ) ).toEqual( expected );
+	} );
+
 } );

--- a/spec/worker/transporter/serializeSpec.js
+++ b/spec/worker/transporter/serializeSpec.js
@@ -1,5 +1,11 @@
 import AssessmentResult from "../../../src/values/AssessmentResult";
+import Mark from "../../../src/values/Mark";
+import Paper from "../../../src/values/Paper";
+import WordCombination from "../../../src/values/WordCombination";
 import serialize from "../../../src/worker/transporter/serialize";
+import englishFunctionWordsFactory from "../../../src/researches/english/functionWords.js";
+
+const functionWords = englishFunctionWordsFactory().all;
 
 describe( "serialize", () => {
 	it( "serializes strings", () => {
@@ -66,14 +72,52 @@ describe( "serialize", () => {
 	} );
 
 	it( "serializes Papers", () => {
-		const thing = new Paper( "" )
+		const thing = new Paper( "This is a sample text.", {
+			description: "This a meta description.",
+			keyword: "some keywords",
+			locale: "en_US",
+			permalink: "https://example.com/page-0",
+			title: "A text about a keyword.",
+		} );
 
 		expect( serialize( thing ) ).toEqual( {
-			_parseClass: "AssessmentResult",
-			identifier: "",
-			marks: [],
-			score: 666,
-			text: "Good job!",
+			_parseClass: "Paper",
+			text: "This is a sample text.",
+			description: "This a meta description.",
+			keyword: "some keywords",
+			locale: "en_US",
+			permalink: "https://example.com/page-0",
+			title: "A text about a keyword.",
+			synonyms: "",
+			titleWidth: 0,
+			url: "",
+		} );
+	} );
+
+	it( "serializes Marks", () => {
+		const thing = new Mark( {
+			original: "<h1>A heading</h1>",
+			marked: "<yoastmark class='yoast-text-mark'><h1>A heading</h1></yoastmark>",
+		} );
+
+		expect( serialize( thing ) ).toEqual( {
+			_parseClass: "Mark",
+			original: "<h1>A heading</h1>",
+			marked: "<yoastmark class='yoast-text-mark'><h1>A heading</h1></yoastmark>",
+		} );
+	} );
+
+	it( "serializes WordCombinations", () => {
+		const thing = new WordCombination( [ "syllable", "combinations" ], 2, functionWords );
+		const words = {	syllable: 4, combinations: 4 };
+		thing.setRelevantWords( words );
+
+		expect( serialize( thing ) ).toEqual( {
+			_parseClass: "WordCombination",
+			functionWords: functionWords,
+			occurrences: 2,
+			words: [ "syllable", "combinations" ],
+			relevantWords: words,
 		} );
 	} );
 } );

--- a/spec/worker/transporter/serializeSpec.js
+++ b/spec/worker/transporter/serializeSpec.js
@@ -1,0 +1,79 @@
+import AssessmentResult from "../../../src/values/AssessmentResult";
+import serialize from "../../../src/worker/transporter/serialize";
+
+describe( "serialize", () => {
+	it( "serializes strings", () => {
+		expect( serialize( "A sample text." ) ).toBe( "A sample text." );
+	} );
+
+	it( "serializes numbers", () => {
+		expect( serialize( 5 ) ).toBe( 5 );
+	} );
+
+	it( "serializes arrays of strings and numbers", () => {
+		expect( serialize( [ 5, "hello", 9 ] ) ).toEqual( [ 5, "hello", 9 ] );
+	} );
+
+	it( "serializes objects", () => {
+		const thing = {
+			hello: "world",
+			5: "six",
+			"some stuff": "",
+		};
+		expect( serialize( thing ) ).toEqual( thing );
+	} );
+
+	it( "serializes nested objects", () => {
+		const thing = {
+			hello: "world",
+			5: "six",
+			"some stuff": {
+				"blah blah": {
+					answer: 42,
+				},
+			},
+		};
+		expect( serialize( thing ) ).toEqual( thing );
+	} );
+
+	it( "replaces functions with empty objects", () => {
+		const thing = {
+			hello: "world",
+			5: "six",
+			"some stuff": () => "nope",
+		};
+		const expected = {
+			hello: "world",
+			5: "six",
+			"some stuff": {},
+		};
+		expect( serialize( thing ) ).toEqual( expected );
+		expect( serialize( () => "no way" ) ).toEqual( {} );
+	} );
+
+	it( "serializes AssessmentResults", () => {
+		const thing = new AssessmentResult();
+		thing.setScore( 666 );
+		thing.setText( "Good job!" );
+
+		expect( serialize( thing ) ).toEqual( {
+			_parseClass: "AssessmentResult",
+			identifier: "",
+			marks: [],
+			score: 666,
+			text: "Good job!",
+		} );
+	} );
+
+	it( "serializes Papers", () => {
+		const thing = new Paper( "" )
+
+		expect( serialize( thing ) ).toEqual( {
+			_parseClass: "AssessmentResult",
+			identifier: "",
+			marks: [],
+			score: 666,
+			text: "Good job!",
+		} );
+	} );
+} );

--- a/src/values/Mark.js
+++ b/src/values/Mark.js
@@ -10,7 +10,6 @@ import { defaults } from "lodash-es";
  */
 function Mark( properties ) {
 	defaults( properties, { original: "", marked: "" } );
-
 	this._properties = properties;
 }
 
@@ -64,6 +63,7 @@ Mark.prototype.serialize = function() {
  * @returns {Mark} The parsed Mark.
  */
 Mark.parse = function( serialized ) {
+	delete serialized._parseClass;
 	return new Mark( serialized );
 };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds missing tests for the `parse` and `serialize` functions of the transporter layer between the analysis web worker and the plugin.

## Relevant technical choices:

* I noticed that the test for parsing serialized `Mark`s I added was failing. Since it was an easy fix, I decided to solve the problem in this PR, instead of making another issue. 

## Test instructions

This PR can be tested by following these steps:

* Review the added test files, check if everything that you expect to be tested is tested.
* Run `yarn test`.
   * Check if every test passes.
   * Check if the coverage of `serialize` and `parse` (at the bottom of the coverage report) are 100%).

Fixes #1763 
