### PR TITLE
Remove empty HTML blocks before research

### DIFF
--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -21,7 +21,7 @@ describe( "Gets all H1s in the text", function() {
 		] );
 	} );
 
-	it( "should return two h1s next to eachother", function() {
+	it( "should return two h1s next to each other", function() {
 		const mockPaper = new Paper( "<h1>first h1</h1><h1>second h1</h1><h2>not an h1</h2>" );
 
 		expect( h1s( mockPaper ) ).toEqual( [

--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -21,11 +21,90 @@ describe( "Gets all H1s in the text", function() {
 		] );
 	} );
 
+	it( "should return two h1s next to eachother", function() {
+		const mockPaper = new Paper( "<h1>first h1</h1><h1>second h1</h1><h2>not an h1</h2>" );
+
+		expect( h1s( mockPaper ) ).toEqual( [
+			{ tag: "h1", content: "first h1", position: 0 },
+			{ tag: "h1", content: "second h1", position: 1 },
+		] );
+	} );
+
 	it( "should find H1 within division tags", function() {
 		const mockPaper = new Paper( "<div><h1>first h1</h1></div><div><p>blah blah</p></div><div><h1>second h1</h1></div>" );
 		expect( h1s( mockPaper ) ).toEqual( [
 			{ tag: "h1", content: "first h1", position: 0 },
 			{ tag: "h1", content: "second h1", position: 2 },
+		] );
+	} );
+
+	it( "should perform well, even on longer texts.", function() {
+		const mockPaper = new Paper( "<h1>Voice Search</h1>" +
+			"<p>My husband &#8211; <a href='https://yoast.com/about-us/team/joost-de-valk/'>Joost de Valk</a> &#8211;" +
+			"and I often have discussions on how technology will change our day-to-day life. Joost is an early adopter, " +
+			"while I am much slower" +
+			"and more reluctant to technological change. Our discussions are pretty heated. So, what&#8217;s " +
+			"Joost&#8217;s opinion on the future" +
+			"of voice search? How dominant will voice search be? And how will search be affected by it?" +
+			"I interviewed my early-adopting-voice-addict-husband  to shed some light and perspective on " +
+			"the matter of voice search. " +
+			"I did some thinking myself as well. Here, I share our views on what the future of voice search could " +
+			"look like. " +
+			"<h2>Voice queries make a lot of sense</h2> " +
+			"<p>Joost just likes voice. He likes talking to machines. Joost asks Siri to set the timer " +
+			"while he&#8217;s cooking dinner " +
+			"and gives orders to Google Home when he wants to listen to some music. " +
+			"So what is it what attracts him in voice search? " +
+			"&#8216;I like voice whenever I cannot type,&#8217; Joost answers,  &#8216;So, " +
+			"I use it while I am cooking, or when we are " +
+			"in a car together and we have a discussion. Using a voice query is just as easy as typing in a keyword. " +
+			"And if you do not have access to a keyboard, voice search is especially useful.&#8217;</p>" +
+			"<p>I think Joost is right about that: voice queries just make sense. " +
+			"Voice search is easy to use (as long as your voice is recognized properly). " +
+			"For most people, speaking to a machine is quicker than typing. " +
+			"And, you can use voice search everywhere, even when you&#8217;re doing other things.</p> " +
+			"<h2>Voice results do not (always) make sense</h2> " +
+			"<p>The results that voice gives us are always singular. Siri will set a timer, " +
+			"Google Home will play the song. " +
+			"Joost:  &#8216;Voice results only make sense if you&#8217;re looking for a singular result. " +
+			"If you want to know something specific. " +
+			"If you want to end the discussion you&#8217;re having in the car and need to know exactly " +
+			"how many people live in France. " +
+			"And also, if you search for a specific restaurant. But if you want to have dinner in a nice " +
+			"restaurant and you&#8217;re not sure which " +
+			"one it &#8216;ll be,  you&#8217;ll probably prefer to see some options. And right then and there, " +
+			"is where I think voice results as they work now stop making sense.&#8217;</p> " +
+			"<p>I started thinking about that. Most search queries people use are not aimed at a singular result. " +
+			"People like to browse. People want to choose. That&#8217;s why physical stores have a lot of options. " +
+			"People like to browse through different pairs of jeans before they choose which one they&#8217;ll buy. " +
+			"Online, we&#8217;ll probably check out different sites or at least different models before we add a " +
+			"pair of jeans to our shopping cart.</p> " +
+			"<p>If you&#8217;re searching for information that is longer than a few sentences, voice result is " +
+			"not very useful either. " +
+			"That&#8217;s because it is hard to digest information solely by listening. As a listener, " +
+			"you&#8217;re a very passive receiver of information. " +
+			"As a reader,  you can scan a text, you can skip pieces of information or read an important paragraph twice. " +
+			"You cannot do that as a listener. As a reader, you&#8217;re much more in control. " +
+			"So, if you&#8217;re searching for information about what to do in Barcelona, " +
+			"it makes much more sense to get that information from a book or a screen.</p> " +
+			"<h2>Search engines are growing towards singular results</h2> " +
+			"<p>Joost thinks that search engines are working towards singular results. " +
+			"They are developing that type of functionality." +
+			" &#8216;The answer boxes you see in the search results are an example of that,&#8217; Joost explains. &#8216;" +
+			"Search engines are trying to give one single answer to a search query. But, in a lot of the cases, " +
+			"people aren&#8217;t searching for one answer. " +
+			"In many cases people want to make a choice, they want to browse.&#8217;</p> " +
+			"<h1>So what will the future bring?</h1> " +
+			"<p>&#8216;I think you&#8217;ll see different applications being connected to each other,&#8217; " +
+			"Joost answers when I ask him what the future of voice search will look like. " +
+			"&#8216;Siri, for example, would then be connected to your Apple TV. " +
+			"Search results and information would appear on the screen closest to you that Apple controls. " +
+			"I think voice will become the dominant search query, but I think screens will continue to be " +
+			"important in presenting search results.&#8217;</p>" );
+
+		expect( h1s( mockPaper ) ).toEqual( [
+			{ tag: "h1", content: "Voice Search", position: 0 },
+			{ tag: "h1", content: "So what will the future bring?", position: 11 },
 		] );
 	} );
 } );

--- a/spec/researches/h1sSpec.js
+++ b/spec/researches/h1sSpec.js
@@ -30,6 +30,15 @@ describe( "Gets all H1s in the text", function() {
 		] );
 	} );
 
+	it( "should rightly ignore empty paragraphs or empty blocks", function() {
+		const mockPaper = new Paper( "<p></p>\n<h1>first h1</h1><h1>second h1</h1><h2>not an h1</h2>" );
+
+		expect( h1s( mockPaper ) ).toEqual( [
+			{ tag: "h1", content: "first h1", position: 0 },
+			{ tag: "h1", content: "second h1", position: 1 },
+		] );
+	} );
+
 	it( "should find H1 within division tags", function() {
 		const mockPaper = new Paper( "<div><h1>first h1</h1></div><div><p>blah blah</p></div><div><h1>second h1</h1></div>" );
 		expect( h1s( mockPaper ) ).toEqual( [

--- a/src/researches/h1s.js
+++ b/src/researches/h1s.js
@@ -1,6 +1,7 @@
 // We use an external library, which can be found here: https://github.com/fb55/htmlparser2.
-import htmlparser from "htmlparser2";
-import isEmpty from "lodash/isEmpty";
+import { getBlocks } from "../helpers/html";
+
+const h1Regex = /<h1.*?>(.*?)<\/h1>/;
 
 /**
  * Gets all H1s in a text, including their content and their position with regards to other HTML blocks.
@@ -11,70 +12,20 @@ import isEmpty from "lodash/isEmpty";
  */
 export default function( paper ) {
 	const text = paper.getText();
-	const allHTMLBlocks = [];
-	let isH1 = false;
-	let htmlBlock = {};
+
+	const blocks = getBlocks( text );
+
 	const h1s = [];
-
-	/*
-	 * Gets the tag names for all HTML blocks. In case an HTML block is an H1, also the content is included.
-	 * The content is required for marking.
-	 */
-	const parser = new htmlparser.Parser( {
-		/**
-		 * Processes the opening h1 tags.
-		 *
-		 * @param {string} tagName The name of the tag.
-		 *
-		 * @returns {void}
-		 */
-		onopentag: function( tagName ) {
-			htmlBlock.tag = tagName;
-			if ( tagName === "h1" ) {
-				isH1 = true;
-			}
-		},
-		/**
-		 * Saves content of the H1 tags.
-		 *
-		 * @param {string} text The input text.
-		 *
-		 * @returns {void}
-		 */
-		ontext: function( text ) {
-			if ( isH1 === true ) {
-				htmlBlock.content = text;
-			}
-			if ( ! isEmpty( htmlBlock ) ) {
-				allHTMLBlocks.push( htmlBlock );
-			}
-			htmlBlock = {};
-		},
-		/**
-		 * Processes the closing h1 tags.
-		 *
-		 * @param {string} tagName The name of the tag.
-		 *
-		 * @returns {void}
-		 */
-		onclosetag: function( tagName ) {
-			if ( tagName === "h1" ) {
-				isH1 = false;
-			}
-		},
-	}, { decodeEntities: true } );
-
-	parser.write( text );
-
-	// Pushes all H1s into an array and adds their position with regards to the other HTML blocks in the body.
-	for ( let i = 0; i < allHTMLBlocks.length; i++ ) {
-		if ( allHTMLBlocks[ i ].tag !== "h1" ) {
-			continue;
+	blocks.forEach( ( block, index ) => {
+		const match = h1Regex.exec( block );
+		if ( match ) {
+			h1s.push( {
+				tag: "h1",
+				content: match[ 1 ],
+				position: index,
+			} );
 		}
-
-		allHTMLBlocks[ i ].position = i;
-		h1s.push( allHTMLBlocks[ i ] );
-	}
+	} );
 
 	return h1s;
 }

--- a/src/researches/h1s.js
+++ b/src/researches/h1s.js
@@ -1,4 +1,3 @@
-// We use an external library, which can be found here: https://github.com/fb55/htmlparser2.
 import { getBlocks } from "../helpers/html";
 
 const h1Regex = /<h1.*?>(.*?)<\/h1>/;

--- a/src/researches/h1s.js
+++ b/src/researches/h1s.js
@@ -1,6 +1,20 @@
 import { getBlocks } from "../helpers/html";
+import { reject } from "lodash-es";
 
 const h1Regex = /<h1.*?>(.*?)<\/h1>/;
+
+/**
+ * Gets a block from a text and checks if it is totally empty or if it is an empty paragraph.
+ *
+ * @param {string} block A HTML block extracted from the paper.
+ *
+ * @returns {boolean} Whether the block is empty or not.
+ */
+const emptyBlock = function( block ) {
+	block = block.trim();
+	return block === "<p></p>" || block === "";
+};
+
 
 /**
  * Gets all H1s in a text, including their content and their position with regards to other HTML blocks.
@@ -12,7 +26,8 @@ const h1Regex = /<h1.*?>(.*?)<\/h1>/;
 export default function( paper ) {
 	const text = paper.getText();
 
-	const blocks = getBlocks( text );
+	let blocks = getBlocks( text );
+	blocks = reject( blocks, emptyBlock );
 
 	const h1s = [];
 	blocks.forEach( ( block, index ) => {


### PR DESCRIPTION
Note: this PR is a copy of https://github.com/Yoast/YoastSEO.js/pull/2008, based off the release branch. It also incorporates https://github.com/Yoast/YoastSEO.js/pull/1997, which had been previously merged on `develop`. This way, all the new recalibration-specific H1 functionality will be merged into the 9.3 release branch, from which we can deploy a new recalibration version.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug where the first H1 of the text would be highlighted as spurious H1 in Gutenberg

## Relevant technical choices:

* Alternatively, the issue could be solved with the following steps:
In YoastSEO.js: remove autop application to the post text (in [AnalysisWebWorker](https://github.com/Yoast/YoastSEO.js/blob/develop/src/worker/AnalysisWebWorker.js#L660)) and add trimming of the spaces at the very beginning and at the very end of the text.
In wordpress-seo: add autop dependancy, add autop application to the post text (in [collectAnalysisData](https://github.com/Yoast/wordpress-seo/blob/trunk/js/src/analysis/collectAnalysisData.js#L31)), but only to posts in classic editor (using [isGutenbergDataAvailable](https://github.com/Yoast/wordpress-seo/blob/trunk/js/src/helpers/isGutenbergDataAvailable.js)). 
Unfortunately, this (elegant) approach does not work for posts created in classic and reopened in Gutenberg.


## Test instructions

This PR can be tested by following these steps:

* See here for how to test locally: https://github.com/Yoast/YoastSEO.js/wiki/How-to-test-Recalibration-locally%3F
* Create a new post in Gutenberg that has two or more headings of H1 level.
- [ ] Make sure the `Single H1` assessment is triggered and that the eye marker highlights the all H1 headers except for the first one.
* Add a paragraph before the first H1.
- [ ] Make sure the first H1 is now also highlighted.
- [ ] Check the same functionality in Classic editor (Visual)
- [ ] Check the same functionality in Classic editor (Text)
- [ ] Try switching between Visual and Text and check if the result is stable
* Open a post created in Classic with Gutenberg that contains two H1s and
- [ ] make sure that the assessment gets triggered.
- [ ] Delete the second H1, so that the first H1 is at the top of the text.
- [ ] Make sure that the assessment doens't get triggered.
- [ ] Add a paragraph block with some text before the H1, and make sure that the assessment gets triggered again.


Fixes #https://github.com/Yoast/wordpress-seo/issues/11661