### PR TITLE
Fix checking for window when loading module

### DIFF
--- a/src/worker/createWorker.js
+++ b/src/worker/createWorker.js
@@ -1,4 +1,25 @@
 /**
+ * Creates an URL to a blob. This blob imports a script for use in a web worker (using `importScripts`).
+ *
+ * @param {string} url The URL to the script that has to be loaded.
+ * @returns {string} the URL to the blob.
+ */
+function createBlobURL( url ) {
+	const URL = window.URL || window.webkitURL;
+	const BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
+
+	let blob;
+	try {
+		blob = new Blob( [ "importScripts('" + url + "');" ], { type: "application/javascript" } );
+	} catch ( e1 ) {
+		const blobBuilder = new BlobBuilder();
+		blobBuilder.append( "importScripts('" + url + "');" );
+		blob = blobBuilder.getBlob( "application/javascript" );
+	}
+	return URL.createObjectURL( blob );
+}
+
+/**
  * Creates a WebWorker using the given url.
  *
  * @param {string} url The url of the worker.
@@ -6,23 +27,12 @@
  * @returns {Worker} The worker.
  */
 function createWorker( url ) {
-	const URL = window.URL || window.webkitURL;
-	const BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
-
 	let worker = null;
 	try {
 		worker = new Worker( url );
 	} catch ( e ) {
 		try {
-			let blob;
-			try {
-				blob = new Blob( [ "importScripts('" + url + "');" ], { type: "application/javascript" } );
-			} catch ( e1 ) {
-				const blobBuilder = new BlobBuilder();
-				blobBuilder.append( "importScripts('" + url + "');" );
-				blob = blobBuilder.getBlob( "application/javascript" );
-			}
-			const blobUrl = URL.createObjectURL( blob );
+			const blobUrl = createBlobURL( url );
 			worker = new Worker( blobUrl );
 		} catch ( e2 ) {
 			throw e2;

--- a/src/worker/createWorker.js
+++ b/src/worker/createWorker.js
@@ -1,6 +1,3 @@
-const URL = window.URL || window.webkitURL;
-const BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
-
 /**
  * Creates a WebWorker using the given url.
  *
@@ -9,6 +6,9 @@ const BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.Moz
  * @returns {Worker} The worker.
  */
 function createWorker( url ) {
+	const URL = window.URL || window.webkitURL;
+	const BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
+
 	let worker = null;
 	try {
 		worker = new Worker( url );


### PR DESCRIPTION
This would crash, because the window was accessed inside the web worker. I don't know why it works in Yoast SEO, but alas.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a crash when loading the `createWorker` module because the `window` was accessed in the global scope immediately.

## Relevant technical choices:

* We only need the window inside the function, so I moved the code there.

## Test instructions

This PR can be tested by following these steps:

* N/A