### PR TITLE
Handle worker error

### DIFF
--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -110,10 +110,12 @@ class AnalysisWorkerWrapper {
 		 * Try to get the last request. This might not perfectly match the request error.
 		 * However, that is not as bad as not being able to reject it like this.
 		 *
-		 * This is the current length - 1 and not _autoIncrementedRequestId
-		 * because that might be a request that is handled already.
+		 * This is not the _autoIncrementedRequestId because that might be a
+		 * request that is handled already. Instead the last object key is used.
 		 */
-		const lastRequest = this._requests[ this._requests.length - 1 ];
+		const requestKeys = Object.keys( this._requests );
+		const lastRequestId = requestKeys[ requestKeys.length - 1 ];
+		const lastRequest = this._requests[ lastRequestId ];
 		if ( ! lastRequest ) {
 			console.error( "AnalysisWebWorker error:", event );
 			return;

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -76,6 +76,9 @@ class AnalysisWorkerWrapper {
 			default:
 				console.warn( "AnalysisWebWorker unrecognized action:", type );
 		}
+
+		// Remove the handled request from our queue.
+		delete this._requests[ id ];
 	}
 
 	/**
@@ -103,7 +106,12 @@ class AnalysisWorkerWrapper {
 	 * @returns {void}
 	 */
 	handleError( event ) {
-		console.error( "AnalysisWebWorker error:", event );
+		const lastRequest = this._requests[ this._autoIncrementedRequestId ];
+		if ( ! lastRequest ) {
+			console.error( "AnalysisWebWorker error:", event );
+			return;
+		}
+		lastRequest.reject( event );
 	}
 
 	/**

--- a/src/worker/AnalysisWorkerWrapper.js
+++ b/src/worker/AnalysisWorkerWrapper.js
@@ -106,7 +106,14 @@ class AnalysisWorkerWrapper {
 	 * @returns {void}
 	 */
 	handleError( event ) {
-		const lastRequest = this._requests[ this._autoIncrementedRequestId ];
+		/*
+		 * Try to get the last request. This might not perfectly match the request error.
+		 * However, that is not as bad as not being able to reject it like this.
+		 *
+		 * This is the current length - 1 and not _autoIncrementedRequestId
+		 * because that might be a request that is handled already.
+		 */
+		const lastRequest = this._requests[ this._requests.length - 1 ];
 		if ( ! lastRequest ) {
 			console.error( "AnalysisWebWorker error:", event );
 			return;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves error handling in the analysis worker by rejecting the last request instead of just throwing the error.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Works in cooperation with https://github.com/Yoast/wordpress-seo/pull/11707, please follow those test instructions.

Fixes https://github.com/Yoast/wordpress-seo/issues/11700
