### PR TITLE
Added Text node class for Structured Tree.

### DIFF
--- a/spec/tree/values/PhrasingContentSpec.js
+++ b/spec/tree/values/PhrasingContentSpec.js
@@ -1,0 +1,32 @@
+import PhrasingContent from "../../../src/tree/values/PhrasingContent";
+
+describe( "PhrasingContent", () => {
+	it( "can make a new PhrasingContent object", () => {
+		const phrasingElement = new PhrasingContent( "strong", 5, 30, { id: "some-id" } );
+
+		expect( phrasingElement.tag ).toEqual( "strong" );
+		expect( phrasingElement.start ).toEqual( 5 );
+		expect( phrasingElement.end ).toEqual( 30 );
+		expect( phrasingElement.attributes ).toEqual( { id: "some-id" } );
+	} );
+
+	describe( "to HTML-string", () => {
+		it( "can generate an HTML-string", () => {
+			const phrasingElement = new PhrasingContent( "a", 25, 29, {
+				href: "https://example.com",
+			} );
+
+			expect( phrasingElement.toHtml( "some link" ) ).toEqual(
+				"<a href='https://example.com'>some link</a>"
+			);
+		} );
+
+		it( "can generate an HTML-string with no attributes", () => {
+			const phrasingElement = new PhrasingContent( "strong", 25, 29 );
+
+			expect( phrasingElement.toHtml( "some link" ) ).toEqual(
+				"<strong>some link</strong>"
+			);
+		} );
+	} );
+} );

--- a/spec/tree/values/nodes/TextSpec.js
+++ b/spec/tree/values/nodes/TextSpec.js
@@ -1,0 +1,30 @@
+import Text from "../../../../src/tree/values/nodes/Text";
+import PhrasingContent from "../../../../src/tree/values/PhrasingContent";
+
+describe( "Text tree node", () => {
+	it( "can make a new Text tree node", () => {
+		const phrasingElements = [
+			new PhrasingContent( "a", 25, 29 ),
+		];
+		const text = "This is some text with a link.";
+		const textElement = new Text( text, phrasingElements );
+
+		expect( textElement.phrasingElements ).toEqual( textElement.phrasingElements );
+		expect( textElement.text ).toEqual( text );
+	} );
+
+	it( "can generate an HTML-string from the text and accompanying phrasing content.", () => {
+		const phrasingElements = [
+			new PhrasingContent( "a", 25, 29, {
+				href: "https://example.com",
+			} ),
+			new PhrasingContent( "strong", 0, 4 ),
+		];
+		const text = "This is some text with a link.";
+		const textElement = new Text( text, phrasingElements );
+
+		expect( textElement.toHtml() ).toEqual(
+			"<strong>This</strong> is some text with a <a href='https://example.com'>link</a>."
+		);
+	} );
+} );

--- a/spec/tree/values/nodes/TextSpec.js
+++ b/spec/tree/values/nodes/TextSpec.js
@@ -24,7 +24,7 @@ describe( "Text tree node", () => {
 		const textElement = new Text( text, phrasingElements );
 
 		expect( textElement.toHtml() ).toEqual(
-			"<strong>This</strong> is some text with a <a href='https://example.com'>link</a>."
+			"<strong>This</strong> is some text with a <a href=\"https://example.com\">link</a>."
 		);
 	} );
 } );

--- a/src/tree/values/PhrasingContent.js
+++ b/src/tree/values/PhrasingContent.js
@@ -1,0 +1,46 @@
+/**
+ * Represents phrasing content (e.g. <strong>, <a>, <em>) within an HTML-text.
+ */
+class PhrasingContent {
+	/**
+	 * Represents phrasing content (e.g. <strong>, <a>, <em>) within an HTML-text.
+	 *
+	 * @param {string} tag the HTML-tag of this element (e.g. "strong", "a", etc.)
+	 * @param {number} start the start position of the tag within the text.
+	 * @param {number} end the end position of the tag within the text.
+	 * @param {Object} [attributes] the attributes (as key-value pairs, e.g. "href='...'" => { href: '...' } ).
+	 */
+	constructor( tag, start, end, attributes ) {
+		this.tag = tag;
+		this.attributes = attributes;
+		this.start = start;
+		this.end = end;
+	}
+
+	/**
+	 * Stringifies the given HTML-attributes to a string of " key=value" pairs.
+	 *
+	 * @param {Object} attributes the attributes to serialize.
+	 * @returns {string} the stringified attributes.
+	 */
+	getAttributeString( attributes ) {
+		if ( attributes ) {
+			return Object.keys( attributes ).reduce( ( string, key ) => {
+				return string + ` ${key}='${attributes[ key ]}'`;
+			}, "" );
+		}
+		return "";
+	}
+
+	/**
+	 * Stringifies this phrasing content to an HTML-string.
+	 *
+	 * @param {string} content the content to insert between the content tags.
+	 * @returns {string} the HTML-string.
+	 */
+	toHtml( content ) {
+		return `<${this.tag}${this.getAttributeString( this.attributes )}>${content}</${this.tag}>`;
+	}
+}
+
+export default PhrasingContent;

--- a/src/tree/values/PhrasingContent.js
+++ b/src/tree/values/PhrasingContent.js
@@ -26,7 +26,7 @@ class PhrasingContent {
 	getAttributeString( attributes ) {
 		if ( attributes ) {
 			return Object.keys( attributes ).reduce( ( string, key ) => {
-				return string + ` ${key}='${attributes[ key ]}'`;
+				return string + ` ${key}="${attributes[ key ]}"`;
 			}, "" );
 		}
 		return "";

--- a/src/tree/values/nodes/Text.js
+++ b/src/tree/values/nodes/Text.js
@@ -1,0 +1,32 @@
+/**
+ * Represents a text within an HTML-document that can be read by a reader.
+ */
+class Text {
+	/**
+	 * A piece of text within an HTML-document that can be read by a reader.
+	 *
+	 * @param {string} text the text, without any formatting.
+	 * @param {PhrasingContent[]} phrasingElements the inline HTML-elements (e.g. <strong>, <a>) within the text.
+	 */
+	constructor( text, phrasingElements ) {
+		this.text = text;
+		this.phrasingElements = phrasingElements;
+	}
+
+	/**
+	 * Returns the stringified HTML-content of this text, including formatting and other phrasing content.
+	 *
+	 * @returns {string} the stringified HTML-content of this text.
+	 */
+	toHtml() {
+		return this.phrasingElements.reduce( ( text, element ) => {
+			const end = text.slice( element.end );
+			const start = text.slice( 0, element.start );
+			const content = text.slice( element.start, element.end );
+
+			return start + element.toHtml( content ) + end;
+		}, this.text );
+	}
+}
+
+export default Text;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Adds a text node class for the new Text Parser.
* I decided to add a `PhrasingContent` class for holding phrasing content / formatting data. IMO this is better for self-documentation of the code. It had the added advantage of making the `toHtml` method easier to be implemented.
* Added a `toHtml` method to serialize the `Text`-node back to HTML.

## Test instructions

This PR can be tested by following these steps:

* run `yarn test`, check if all the tests pass and all the added classes (`Text`, `PhrasingContent`) have a coverage of 100%.

Fixes #2018 .
