### PR TITLE
Added StructuredIrrelevant node.

### DIFF
--- a/spec/tree/values/nodes/StructuredIrrelevantSpec.js
+++ b/spec/tree/values/nodes/StructuredIrrelevantSpec.js
@@ -2,7 +2,7 @@ import StructuredIrrelevant from "../../../../src/tree/values/nodes/StructuredIr
 
 describe( "StructuredIrrelevant", () => {
 	it( "can make a StructuredIrrelevant node", () => {
-		const nodeContents = "<script> console.log('hey!'); </script>";
+		const nodeContents = "<script> console.log(\"hey!\"); </script>";
 		const structuredIrrelevantNode = new StructuredIrrelevant( nodeContents );
 		expect( structuredIrrelevantNode.content ).toEqual( nodeContents );
 	} );

--- a/spec/tree/values/nodes/StructuredIrrelevantSpec.js
+++ b/spec/tree/values/nodes/StructuredIrrelevantSpec.js
@@ -1,0 +1,9 @@
+import StructuredIrrelevant from "../../../../src/tree/values/nodes/StructuredIrrelevant";
+
+describe( "StructuredIrrelevant", () => {
+	it( "can make an StructuredIrrelevant node", () => {
+		const nodeContents = "<script> console.log('hey!'); </script>";
+		const structuredIrrelevantNode = new StructuredIrrelevant( nodeContents );
+		expect( structuredIrrelevantNode.content ).toEqual( nodeContents );
+	} );
+} );

--- a/spec/tree/values/nodes/StructuredIrrelevantSpec.js
+++ b/spec/tree/values/nodes/StructuredIrrelevantSpec.js
@@ -1,7 +1,7 @@
 import StructuredIrrelevant from "../../../../src/tree/values/nodes/StructuredIrrelevant";
 
 describe( "StructuredIrrelevant", () => {
-	it( "can make an StructuredIrrelevant node", () => {
+	it( "can make a StructuredIrrelevant node", () => {
 		const nodeContents = "<script> console.log('hey!'); </script>";
 		const structuredIrrelevantNode = new StructuredIrrelevant( nodeContents );
 		expect( structuredIrrelevantNode.content ).toEqual( nodeContents );

--- a/src/tree/values/nodes/StructuredIrrelevant.js
+++ b/src/tree/values/nodes/StructuredIrrelevant.js
@@ -1,0 +1,19 @@
+/**
+ * Represents a piece of structured data that is not relevant for further analysis.
+ *
+ * Examples from HTML include content within `<script>` and `<style>` elements.
+ */
+class StructuredIrrelevant {
+	/**
+	 * Represents a piece of structured data that is not relevant for further analysis.
+	 *
+	 * Examples from HTML include content within `<script>` and `<style>` elements.
+	 *
+	 * @param {string} content 	The raw content of this node.
+	 */
+	constructor( content ) {
+		this.content = content;
+	}
+}
+
+export default StructuredIrrelevant;

--- a/src/tree/values/nodes/StructuredIrrelevant.js
+++ b/src/tree/values/nodes/StructuredIrrelevant.js
@@ -10,6 +10,8 @@ class StructuredIrrelevant {
 	 * Examples from HTML include content within `<script>` and `<style>` elements.
 	 *
 	 * @param {string} content 	The raw content of this node.
+	 *
+	 * @returns {void}
 	 */
 	constructor( content ) {
 		this.content = content;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* *[not-user-facing]* Adds a `StructuredIrrelevant` class for use within the structured tree.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Nothing to test, really.
  * You could run `yarn test`, check if all the tests run and the `StructuredIrrelevant` class' coverage is 100%.

Fixes #2025 
