### PR TITLE
Add StructuredText element

### DIFF
--- a/spec/tree/values/nodes/StructuredTextSpec.js
+++ b/spec/tree/values/nodes/StructuredTextSpec.js
@@ -1,0 +1,14 @@
+import StructuredText from "../../../../src/tree/values/nodes/StructuredText";
+
+describe( "StructuredText", () => {
+	it( "can make a StructuredText node", () => {
+		const children = [ "a", 1, true ];
+		const startHtml = "<div>";
+		const endHtml = "</div>";
+
+		const structuredTextNode = new StructuredText( children, startHtml, endHtml );
+		expect( structuredTextNode.children ).toEqual( children );
+		expect( structuredTextNode.startHtml ).toEqual( startHtml );
+		expect( structuredTextNode.endHtml ).toEqual( endHtml );
+	} );
+} );

--- a/src/tree/values/nodes/StructuredText.js
+++ b/src/tree/values/nodes/StructuredText.js
@@ -11,7 +11,7 @@ class StructuredText {
 	 *
 	 * Talking about HTML, this would encompass thing like <div>, <section>, <aside>, <fieldset> and other HTML block elements.
 	 *
-	 * @param {Array<Paragraph|List|Heading|>} children	The sub-elements of the structured text.
+	 * @param {Array<Paragraph|List|Heading>} children	The sub-elements of the structured text.
 	 * @param {string}                   startHtml  The opening tag of the structured text.
 	 * @param {string}                   endHtml    The closing tag of the structured text.
 	 *

--- a/src/tree/values/nodes/StructuredText.js
+++ b/src/tree/values/nodes/StructuredText.js
@@ -6,7 +6,7 @@
  */
 class StructuredText {
 	/**
-	 * Represents represents a piece of structure that is present in the original text, but is not relevant for the further
+	 * Represents a piece of structure that is present in the original text, but is not relevant for the further
 	 * analysis of the text.
 	 *
 	 * Talking about HTML, this would encompass thing like <div>, <section>, <aside>, <fieldset> and other HTML block elements.

--- a/src/tree/values/nodes/StructuredText.js
+++ b/src/tree/values/nodes/StructuredText.js
@@ -1,0 +1,26 @@
+/**
+ * Represents a piece of structure that is present in the original text, but is not relevant for the further analysis
+ * of the text.
+ *
+ * Talking about HTML, this would encompass thing like <div>, <section>, <aside>, <fieldset> and other HTML block elements.
+ */
+class StructuredText {
+	/**
+	 * Represents represents a piece of structure that is present in the original text, but is not relevant for the further
+	 * analysis of the text.
+	 *
+	 * Talking about HTML, this would encompass thing like <div>, <section>, <aside>, <fieldset> and other HTML block elements.
+	 *
+	 * @param {Paragraph|List|Heading[]} children	The sub-elements of the structured text.
+	 * @param {string}                   startHtml  The opening tag of the structured text.
+	 * @param {string}                   endHtml    The closing tag of the structured text.
+	 *
+	 * @returns {void}
+	 */
+	constructor( children, startHtml, endHtml ) {
+		this.children = children;
+		this.startHtml = startHtml;
+		this.endHtml = endHtml;
+	}
+}
+export default StructuredText;

--- a/src/tree/values/nodes/StructuredText.js
+++ b/src/tree/values/nodes/StructuredText.js
@@ -11,7 +11,7 @@ class StructuredText {
 	 *
 	 * Talking about HTML, this would encompass thing like <div>, <section>, <aside>, <fieldset> and other HTML block elements.
 	 *
-	 * @param {Paragraph|List|Heading[]} children	The sub-elements of the structured text.
+	 * @param {Array<Paragraph|List|Heading|>} children	The sub-elements of the structured text.
 	 * @param {string}                   startHtml  The opening tag of the structured text.
 	 * @param {string}                   endHtml    The closing tag of the structured text.
 	 *


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Adds a `StructuredText` class for use within the structured tree.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test` to see if all tests pass and that the coverage is 100%.

Fixes #2024
