### PR TITLE
Improve German transition word list

### DIFF
--- a/src/researches/german/transitionWords.js
+++ b/src/researches/german/transitionWords.js
@@ -18,11 +18,11 @@ const singleWords = [ "aber", "abschließend", "abschliessend", "alldieweil", "a
 const multipleWords = [ "abgesehen von", "abgesehen davon", "als dass", "als wenn", "anders ausgedrückt", "anders ausgedrueckt",
 	"anders formuliert", "anders gefasst", "anders gefragt", "anders gesagt", "anders gesprochen", "anstatt dass", "auch wenn",
 	"auf grund", "auf jeden fall", "aus diesem grund", "ausser dass", "außer dass", "ausser wenn", "außer wenn", "besser ausgedrückt",
-	"besser ausgedrueckt", "besser formuliert", "besser gesagt", "besser gesprochen", "bloss dass", "bloß dass", "das heisst", "das heißt",
-	"des weiteren", "dessen ungeachtet", "ebenso wie", "genauso wie", "geschweige denn", "im fall", "im falle", "im folgenden",
-	"im gegensatz dazu", "im grunde genommen", "in diesem sinne", "je nachdem", "kurz gesagt", "mit anderen worten", "ohne dass",
-	"so dass", "umso mehr als", "umso weniger als", "umso mehr, als", "umso weniger, als", "unbeschadet dessen", "und zwar",
-	"ungeachtet dessen", "unter dem strich", "zum beispiel" ];
+	"besser ausgedrueckt", "besser formuliert", "besser gesagt", "besser gesprochen", "bloss dass", "bloß dass", "darüber hinaus",
+	"das heisst", "das heißt", "des weiteren", "dessen ungeachtet", "ebenso wie", "genauso wie", "geschweige denn", "im fall",
+	"im falle", "im folgenden", "im gegensatz dazu", "im grunde genommen", "in diesem sinne", "je nachdem", "kurz gesagt",
+	"mit anderen worten", "ohne dass", "so dass", "umso mehr als", "umso weniger als", "umso mehr, als", "umso weniger, als",
+	"unbeschadet dessen", "und zwar", "ungeachtet dessen", "unter dem strich", "zum beispiel" ];
 
 /**
  * Returns lists with transition words to be used by the assessments.

--- a/src/researches/german/twoPartTransitionWords.js
+++ b/src/researches/german/twoPartTransitionWords.js
@@ -6,8 +6,8 @@
  */
 export default function() {
 	return [ [ "anstatt", "dass" ], [ "bald", "bald" ], [ "dadurch", "dass" ], [ "dessen ungeachtet", "dass" ],
-		[ "entweder", "oder" ], [ "einerseits", "andererseits" ], [ "erst", "wenn" ], [ "je", "desto" ], [ "je", "umsto" ],
-		[ "nicht nur", "sondern auch" ], [ "ob", "oder" ], [ "ohne", "dass" ], [ "so", "dass" ], [ "sowohl", "als auch" ],
-		[ "sowohl", "wie auch" ], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ], [ "wenn", "auch" ],
-		[ "wenn", "schon" ], [ "nicht weil", "sondern" ]  ];
+		[ "entweder", "oder" ], [ "einerseits", "andererseits" ], [ "erst", "wenn" ], [ "je", "desto" ], [ "je", "umso" ],
+		[ "umso", "umso" ], [ "nicht nur", "sondern auch" ], [ "ob", "oder" ], [ "ohne", "dass" ], [ "so", "dass" ],
+		[ "sowohl", "als auch" ], [ "sowohl", "wie auch" ], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ],
+		[ "wenn", "auch" ], [ "wenn", "schon" ], [ "nicht weil", "sondern" ]  ];
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds transition words to the list and fixes typo

## Test instructions

This PR can be tested by following these steps:

* Switch locale to de_DE
* Make sure the following transition words are recognised:
`je...umso` (two-part transition word)
`umso...umso` (two-part transition word)
`darüber hinaus`

Fixes #2004 and #2036
