### PR TITLE
2051 base node class structured tree

### DIFF
--- a/spec/tree/values/nodes/NodeSpec.js
+++ b/spec/tree/values/nodes/NodeSpec.js
@@ -1,0 +1,29 @@
+import Node from "../../../../src/tree/values/nodes/Node";
+
+describe( "Node", () => {
+	beforeEach( () => {
+		console.warn = jest.fn();
+	} );
+
+	it( "can make a new Node", () => {
+		const node = new Node( 0, 5, "node" );
+
+		expect( node.startIndex ).toEqual( 0 );
+		expect( node.endIndex ).toEqual( 5 );
+		expect( node.type ).toEqual( "node" );
+	} );
+
+	it( "throws a warning when calling the abstract map function", () => {
+		const node = new Node( 0, 5, "node" );
+		node.map( () => {} );
+		expect( console.warn ).toBeCalled();
+	} );
+
+	it( "throws a warning when calling the abstract filter function", () => {
+		const node = new Node( 0, 5, "node" );
+		node.filter( () => {} );
+
+		expect( console.warn ).toBeCalled();
+	} );
+} );
+

--- a/src/tree/values/nodes/Node.js
+++ b/src/tree/values/nodes/Node.js
@@ -9,6 +9,8 @@ class Node { // eslint-disable-line no-unused-vars
 	 * @param {number} startIndex	The index in the original text-string where this Node begins.
 	 * @param {number} endIndex	The index in the original text-string where this Node ends.
 	 * @param {string} type		The type of Node (should be unique for each child class of Node).
+	 *
+	 * @abstract
 	 */
 	constructor( startIndex, endIndex, type ) {
 		this.type = type;
@@ -19,13 +21,13 @@ class Node { // eslint-disable-line no-unused-vars
 	/**
 	 * Maps the given function to each Node in this tree.
 	 *
-	 * @param {Node~mapCallback} callback 	The function that should be mapped to each Node in the tree.
+	 * @param {mapCallback} callback 	The function that should be mapped to each Node in the tree.
 	 *
 	 * @returns {Node} A new tree, after the given function has been mapped on each Node.
 	 *
 	 * @abstract
 	 */
-	static map( callback ) { // eslint-disable-line no-unused-vars
+	map( callback ) { // eslint-disable-line no-unused-vars
 		console.warn( "Developer warning: " +
 			"Map is an abstract method that should be implemented by a child class." );
 	}
@@ -33,24 +35,26 @@ class Node { // eslint-disable-line no-unused-vars
 	/**
 	 * Callback function for the Node's map-function.
 	 *
-	 * @callback Node~mapCallback
+	 * @callback mapCallback
 	 *
 	 * @param {Node} currentValue 	The current Node being processed.
-	 * @param {Node} tree			The tree `map` was called upon.
 	 *
 	 * @returns {Node} The current Node after being processed by this function.
+	 *
+	 * @private
 	 */
 
 	/**
-	 * Maps the given function to each Node in this tree.
+	 * Filters all the elements out of the tree for which the given predicate function returns `false`
+	 * and returns them as an array of Nodes.
 	 *
-	 * @param {Node~filterCallback} callback 	The predicate to check each Node against.
+	 * @param {filterCallback} callback 	The predicate to check each Node against.
 	 *
-	 * @returns {Node[]} An array of all the Nodes in the tree for which the given predicate function returns true.
+	 * @returns {Node[]} An array of all the Nodes in the tree for which the given predicate function returns `true`.
 	 *
 	 * @abstract
 	 */
-	static filter( callback ) { // eslint-disable-line no-unused-vars
+	filter( callback ) { // eslint-disable-line no-unused-vars
 		console.warn( "Developer warning: " +
 			"Filter is an abstract method that should be implemented by a child class." );
 	}
@@ -58,11 +62,14 @@ class Node { // eslint-disable-line no-unused-vars
 	/**
 	 * Callback function for the Node's filter-function.
 	 *
-	 * @callback Node~filterCallback
+	 * @callback filterCallback
 	 *
 	 * @param {Node} currentValue 	The current Node being processed.
-	 * @param {Node} tree			The tree `map` was called upon.
 	 *
 	 * @returns {boolean} If the current Node should be contained in the array after filtering.
+	 *
+	 * @private
 	 */
 }
+
+export default Node;

--- a/src/tree/values/nodes/Node.js
+++ b/src/tree/values/nodes/Node.js
@@ -1,0 +1,68 @@
+/**
+ * Abstract class representing a node in the structured tree.
+ * @abstract
+ */
+class Node { // eslint-disable-line no-unused-vars
+	/**
+	 * Makes a new Node.
+	 *
+	 * @param {number} startIndex	The index in the original text-string where this Node begins.
+	 * @param {number} endIndex	The index in the original text-string where this Node ends.
+	 * @param {string} type		The type of Node (should be unique for each child class of Node).
+	 */
+	constructor( startIndex, endIndex, type ) {
+		this.type = type;
+		this.startIndex = startIndex;
+		this.endIndex = endIndex;
+	}
+
+	/**
+	 * Maps the given function to each Node in this tree.
+	 *
+	 * @param {Node~mapCallback} callback 	The function that should be mapped to each Node in the tree.
+	 *
+	 * @returns {Node} A new tree, after the given function has been mapped on each Node.
+	 *
+	 * @abstract
+	 */
+	static map( callback ) { // eslint-disable-line no-unused-vars
+		console.warn( "Developer warning: " +
+			"Map is an abstract method that should be implemented by a child class." );
+	}
+
+	/**
+	 * Callback function for the Node's map-function.
+	 *
+	 * @callback Node~mapCallback
+	 *
+	 * @param {Node} currentValue 	The current Node being processed.
+	 * @param {Node} tree			The tree `map` was called upon.
+	 *
+	 * @returns {Node} The current Node after being processed by this function.
+	 */
+
+	/**
+	 * Maps the given function to each Node in this tree.
+	 *
+	 * @param {Node~filterCallback} callback 	The predicate to check each Node against.
+	 *
+	 * @returns {Node[]} An array of all the Nodes in the tree for which the given predicate function returns true.
+	 *
+	 * @abstract
+	 */
+	static filter( callback ) { // eslint-disable-line no-unused-vars
+		console.warn( "Developer warning: " +
+			"Filter is an abstract method that should be implemented by a child class." );
+	}
+
+	/**
+	 * Callback function for the Node's filter-function.
+	 *
+	 * @callback Node~filterCallback
+	 *
+	 * @param {Node} currentValue 	The current Node being processed.
+	 * @param {Node} tree			The tree `map` was called upon.
+	 *
+	 * @returns {boolean} If the current Node should be contained in the array after filtering.
+	 */
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _[not-user-facing]_ Adds a `Node` base (abstract) class for the Structured Tree.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`.
* Check if all tests pass and the coverage of `Node` is 100%.

Fixes #2051 
