### PR TITLE
Add List and ListItem

### DIFF
--- a/spec/tree/values/nodes/ListItemSpec.js
+++ b/spec/tree/values/nodes/ListItemSpec.js
@@ -1,0 +1,15 @@
+import ListItem from "../../../../src/tree/values/nodes/ListItem";
+
+describe( "ListItem", () => {
+	it( "can make a ListItem node", () => {
+		const startIndex = 0;
+		const endIndex = 5;
+		const children = [ "a", 1, true ];
+
+		const listItemNode = new ListItem( startIndex, endIndex, children );
+		expect( listItemNode.type ).toEqual( "listItem" );
+		expect( listItemNode.startIndex ).toEqual( startIndex );
+		expect( listItemNode.endIndex ).toEqual( endIndex );
+		expect( listItemNode.children ).toEqual( children );
+	} );
+} );

--- a/spec/tree/values/nodes/ListSpec.js
+++ b/spec/tree/values/nodes/ListSpec.js
@@ -2,6 +2,10 @@ import List from "../../../../src/tree/values/nodes/List";
 import ListItem from "../../../../src/tree/values/nodes/ListItem";
 
 describe( "List", () => {
+	beforeEach( () => {
+		console.warn = jest.fn();
+	} );
+
 	it( "can make a List node", () => {
 		const startIndex = 0;
 		const endIndex = 30;
@@ -10,11 +14,29 @@ describe( "List", () => {
 		const listItem2 = new ListItem( 11, 17, childrenForListItems );
 		const children = [ listItem1, listItem2 ];
 
-		const listNode = new List( startIndex, endIndex, [ listItem1, listItem2 ] );
+		const listNode = new List( startIndex, endIndex, children );
 
 		expect( listNode.type ).toEqual( "list" );
 		expect( listNode.startIndex ).toEqual( startIndex );
 		expect( listNode.endIndex ).toEqual( endIndex );
 		expect( listNode.children ).toEqual( children );
+		expect( console.warn ).not.toBeCalled();
+	} );
+
+	it( "warns about creating a List from elements which are not ListItems", () => {
+		const startIndex = 0;
+		const endIndex = 30;
+		const childrenForListItems = [ "a", 1, true ];
+		const listItem1 = new ListItem( 4, 10, childrenForListItems );
+		const listItem2 = new ListItem( 11, 17, childrenForListItems );
+		const children = [ listItem1, listItem2, childrenForListItems ];
+
+		const listNode = new List( startIndex, endIndex, children );
+
+		expect( listNode.type ).toEqual( "list" );
+		expect( listNode.startIndex ).toEqual( startIndex );
+		expect( listNode.endIndex ).toEqual( endIndex );
+		expect( listNode.children ).toEqual( children );
+		expect( console.warn ).toBeCalled();
 	} );
 } );

--- a/spec/tree/values/nodes/ListSpec.js
+++ b/spec/tree/values/nodes/ListSpec.js
@@ -10,15 +10,17 @@ describe( "List", () => {
 		const startIndex = 0;
 		const endIndex = 30;
 		const childrenForListItems = [ "a", 1, true ];
+		const ordered = true;
 		const listItem1 = new ListItem( 4, 10, childrenForListItems );
 		const listItem2 = new ListItem( 11, 17, childrenForListItems );
 		const children = [ listItem1, listItem2 ];
 
-		const listNode = new List( startIndex, endIndex, children );
+		const listNode = new List( startIndex, endIndex, ordered, children );
 
 		expect( listNode.type ).toEqual( "list" );
 		expect( listNode.startIndex ).toEqual( startIndex );
 		expect( listNode.endIndex ).toEqual( endIndex );
+		expect( listNode.ordered ).toEqual( ordered );
 		expect( listNode.children ).toEqual( children );
 		expect( console.warn ).not.toBeCalled();
 	} );
@@ -26,16 +28,18 @@ describe( "List", () => {
 	it( "warns about creating a List from elements which are not ListItems", () => {
 		const startIndex = 0;
 		const endIndex = 30;
+		const ordered = false;
 		const childrenForListItems = [ "a", 1, true ];
 		const listItem1 = new ListItem( 4, 10, childrenForListItems );
 		const listItem2 = new ListItem( 11, 17, childrenForListItems );
 		const children = [ listItem1, listItem2, childrenForListItems ];
 
-		const listNode = new List( startIndex, endIndex, children );
+		const listNode = new List( startIndex, endIndex, ordered, children );
 
 		expect( listNode.type ).toEqual( "list" );
 		expect( listNode.startIndex ).toEqual( startIndex );
 		expect( listNode.endIndex ).toEqual( endIndex );
+		expect( listNode.ordered ).toEqual( ordered );
 		expect( listNode.children ).toEqual( children );
 		expect( console.warn ).toBeCalled();
 	} );

--- a/spec/tree/values/nodes/ListSpec.js
+++ b/spec/tree/values/nodes/ListSpec.js
@@ -1,0 +1,20 @@
+import List from "../../../../src/tree/values/nodes/List";
+import ListItem from "../../../../src/tree/values/nodes/ListItem";
+
+describe( "List", () => {
+	it( "can make a List node", () => {
+		const startIndex = 0;
+		const endIndex = 30;
+		const childrenForListItems = [ "a", 1, true ];
+		const listItem1 = new ListItem( 4, 10, childrenForListItems );
+		const listItem2 = new ListItem( 11, 17, childrenForListItems );
+		const children = [ listItem1, listItem2 ];
+
+		const listNode = new List( startIndex, endIndex, [ listItem1, listItem2 ] );
+
+		expect( listNode.type ).toEqual( "list" );
+		expect( listNode.startIndex ).toEqual( startIndex );
+		expect( listNode.endIndex ).toEqual( endIndex );
+		expect( listNode.children ).toEqual( children );
+	} );
+} );

--- a/src/tree/values/nodes/List.js
+++ b/src/tree/values/nodes/List.js
@@ -1,4 +1,3 @@
-import { filter } from "lodash-es";
 import ListItem from "./ListItem";
 import Node from "./Node";
 /**

--- a/src/tree/values/nodes/List.js
+++ b/src/tree/values/nodes/List.js
@@ -10,12 +10,14 @@ class List extends Node {
 	 *
 	 * @param {number}            startIndex  The index of the beginning of the list item.
 	 * @param {number}            endIndex    The index of the end of the list item.
+	 * @param {boolean}           ordered     Whether the list is ordered or not.
 	 * @param {Array<ListItem>}   children    The sub-elements of the list item.
 	 *
 	 * @returns {void}
 	 */
-	constructor( startIndex, endIndex, children ) {
+	constructor( startIndex, endIndex, ordered, children ) {
 		super( "list", startIndex, endIndex );
+		this.ordered = ordered;
 		this.children = children;
 
 		this._checkChildren();

--- a/src/tree/values/nodes/List.js
+++ b/src/tree/values/nodes/List.js
@@ -1,0 +1,20 @@
+import Node from "./Node";
+/**
+ * Represents an item within a list.
+ */
+class List extends Node {
+	/**
+	 * Represents an item within a list.
+	 *
+	 * @param {number}            startIndex  The index of the beginning of the list item.
+	 * @param {number}            endIndex    The index of the end of the list item.
+	 * @param {Array<ListItem>}   children    The sub-elements of the list item.
+	 *
+	 * @returns {void}
+	 */
+	constructor( startIndex, endIndex, children ) {
+		super( "list", startIndex, endIndex );
+		this.children = children;
+	}
+}
+export default List;

--- a/src/tree/values/nodes/List.js
+++ b/src/tree/values/nodes/List.js
@@ -31,7 +31,7 @@ class List extends Node {
 	 */
 	_checkChildren() {
 		// Check if any child is not an instance of ListItem.
-		const naughtyChildren = filter( this.children, function( child ) {
+		const naughtyChildren = this.children.filter( function( child ) {
 			return ! ( child instanceof ListItem );
 		} );
 

--- a/src/tree/values/nodes/List.js
+++ b/src/tree/values/nodes/List.js
@@ -23,7 +23,7 @@ class List extends Node {
 	}
 
 	/**
-	 * Constrains the children of the List to ListItems. Throws a warning if any child of the List is not a ListItem.
+	 * Throws a warning if any child of the List is not a ListItem.
 	 *
 	 * @returns {void}
 	 * @private

--- a/src/tree/values/nodes/List.js
+++ b/src/tree/values/nodes/List.js
@@ -1,3 +1,5 @@
+import { filter } from "lodash-es";
+import ListItem from "./ListItem";
 import Node from "./Node";
 /**
  * Represents an item within a list.
@@ -15,6 +17,25 @@ class List extends Node {
 	constructor( startIndex, endIndex, children ) {
 		super( "list", startIndex, endIndex );
 		this.children = children;
+
+		this._checkChildren();
+	}
+
+	/**
+	 * Constrains the children of the List to ListItems. Throws a warning if any child of the List is not a ListItem.
+	 *
+	 * @returns {void}
+	 * @private
+	 */
+	_checkChildren() {
+		// Check if any child is not an instance of ListItem.
+		const naughtyChildren = filter( this.children, function( child ) {
+			return ! ( child instanceof ListItem );
+		} );
+
+		if ( naughtyChildren.length > 0 ) {
+			console.warn( "Not all items of the List are of type ListItem!" );
+		}
 	}
 }
 export default List;

--- a/src/tree/values/nodes/ListItem.js
+++ b/src/tree/values/nodes/ListItem.js
@@ -1,0 +1,20 @@
+import Node from "./Node";
+/**
+ * Represents an item within a list.
+ */
+class ListItem extends Node {
+	/**
+	 * Represents an item within a list.
+	 *
+	 * @param {number}       startIndex  The index of the beginning of the list item.
+	 * @param {number}       endIndex    The index of the end of the list item.
+	 * @param {Array<Node>}  children    The sub-elements of the list item.
+	 *
+	 * @returns {void}
+	 */
+	constructor( startIndex, endIndex, children ) {
+		super( "listItem", startIndex, endIndex );
+		this.children = children;
+	}
+}
+export default ListItem;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Adds nodes List and ListItem to the Structured Tree

## Relevant technical choices:

* Adds a function that checks if all children of the List being constructed are indeed ListItems.

## Test instructions

This PR can be tested by following these steps:

* Run a `yarn test` and see that all tests pass and that the coverage is 100%.

Fixes #2021 Fixes #2022 
