### PR TITLE
2020 build structured heading object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwards.
 
+## 1.45.0
+### Fixed
+* Fixes a bug where special characters from certain word lists weren't correctly escaped when matched with a regex. This resulted in `eggs` being incorrectly matched as the transition word `e.g.`, for example.
+
+### Added
+* The browser console now shows more descriptive error messages when something went wrong during analyses in the web worker.
+* Adds readability analysis for Swedish.
+* Adds prominent words for Swedish.
+
+### Changed
+* Improved README Usage to detail the Web Worker API.
+
 ## 1.44.0
 ### Fixed
 * Fixes a bug where keyphrases weren't recognized in the URL when the words in the URL were separated by underscore characters instead of hyphens.

--- a/spec/tree/values/nodes/HeadingSpec.js
+++ b/spec/tree/values/nodes/HeadingSpec.js
@@ -1,0 +1,52 @@
+import Heading from "../../../../src/tree/values/nodes/Heading";
+import TextContainer from "../../../../src/tree/values/nodes/TextContainer";
+
+describe( "Heading", () => {
+	describe( "constructor", () => {
+		it( "can make a heading", () => {
+			const text = new TextContainer( "This is the main title", [] );
+			const heading = new Heading( 0, 8, 1, text );
+
+			expect( heading.startIndex ).toEqual( 0 );
+			expect( heading.endIndex ).toEqual( 8 );
+			expect( heading.level ).toEqual( 1 );
+			expect( heading.textContainer ).toEqual( text );
+		} );
+	} );
+
+	describe( "map function", () => {
+		it( "returns a changed heading when map is called.", () => {
+			const text = new TextContainer( "This is the main title", [] );
+			const heading = new Heading( 0, 8, 1, text );
+
+			const headingAfterMapping = heading.map( node => {
+				if ( node instanceof Heading ) {
+					node.textContainer.text += "!!!";
+				}
+				return node;
+			} );
+
+			expect( headingAfterMapping.textContainer.text ).toEqual( "This is the main title!!!" );
+		} );
+	} );
+
+	describe( "filter function", () => {
+		it( "returns this heading in an array when the predicate returns true", () => {
+			const text = new TextContainer( "This is the main title", [] );
+			const heading = new Heading( 0, 8, 1, text );
+
+			const filtered = heading.filter( node => node instanceof Heading );
+
+			expect( filtered.length ).toEqual( 1 );
+		} );
+
+		it( "returns an empty array when the predicate returns false", () => {
+			const text = new TextContainer( "This is the main title", [] );
+			const heading = new Heading( 0, 8, 1, text );
+
+			const filtered = heading.filter( node => node.startIndex > 0 );
+
+			expect( filtered.length ).toEqual( 0 );
+		} );
+	} );
+} );

--- a/src/tree/values/nodes/Heading.js
+++ b/src/tree/values/nodes/Heading.js
@@ -1,3 +1,4 @@
+import Node from "./Node";
 /**
  * A header in a document.
  */

--- a/src/tree/values/nodes/Heading.js
+++ b/src/tree/values/nodes/Heading.js
@@ -1,0 +1,54 @@
+/**
+ * A header in a document.
+ */
+class Heading extends Node {
+	/**
+	 * Makes a new header object.
+	 *
+	 * @param {number} startIndex			The index in the original text-string where this Node begins.
+	 * @param {number} endIndex			The index in the original text-string where this Node ends.
+	 * @param {number} level				The header level (e.g. 1 for main heading, 2 for subheading lvl 2, etc.)
+	 * @param {TextContainer} textContainer	The text contained within this heading.
+	 */
+	constructor( startIndex, endIndex, level, textContainer ) {
+		super( "heading", startIndex, endIndex );
+		this.level = level;
+		this.textContainer = textContainer;
+	}
+
+	/**
+	 * Makes a clone of this Node.
+	 *
+	 * @returns {Node} The clone of this Node.
+	 */
+	clone() {
+		return new Heading(
+			this.startIndex,
+			this.endIndex,
+			this.level,
+			this.textContainer,
+		);
+	}
+
+	/**
+	 * Maps the given function to this Heading.
+	 *
+	 * @param {mapCallback} mappingFunction	The function that should be mapped to this Heading.
+	 * @returns {Node} A clone of this Heading after the given function has been applied to it.
+	 */
+	map( mappingFunction ) {
+		return mappingFunction( this.clone() );
+	}
+
+	/**
+	 * Filters all the elements out of the tree for which the given predicate function returns `false`
+	 * and returns them as an array of Nodes.
+	 *
+	 * @param {filterCallback} filterFunction		The predicate to check each Node against.
+	 * @returns {Node[]} An array with this Paragraph, if the predicate returns true for this Paragraph, an empty array if not.
+	 */
+	filter( filterFunction ) {
+		return filterFunction( this ) ? [ this.clone() ] : [];
+	}
+}
+export default Heading;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _[not-user-facing]_ Adds a `Heading` class for the Structured Tree.

## Relevant technical choices:

* N/a

## Test instructions

This PR can be tested by following these steps:

* run `yarn test`
* check if all the tests pass and the coverage of `Heading` is 100%.

Fixes #2020 
