### PR TITLE
Fix locale-specific config import in SentenceLengthAssessment

### DIFF
--- a/spec/fullTextTests/runFullTextTests.js
+++ b/spec/fullTextTests/runFullTextTests.js
@@ -94,7 +94,7 @@ testPapers.forEach( function( testPaper ) {
 		const keyphraseDistributionAssessment = new KeyphraseDistributionAssessment();
 		const fleschReadingAssessment = new FleschReadingAssessment( contentConfiguration( locale ).fleschReading );
 		const subheadingDistributionTooLongAssessment = new SubheadingDistributionTooLongAssessment();
-		const sentenceLengthInTextAssessment = new SentenceLengthInTextAssessment();
+		const sentenceLengthInTextAssessment = new SentenceLengthInTextAssessment( contentConfiguration( locale ).sentenceLength );
 
 		// SEO assessments.
 		it( "returns a score and the associated feedback text for the introductionKeyword assessment", function() {

--- a/spec/fullTextTests/testTexts/it/italianPaper3.js
+++ b/spec/fullTextTests/testTexts/it/italianPaper3.js
@@ -113,8 +113,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 46.2% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 28.2% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Fixes the bug when the locale-specific configuration was not exported in SentenceLengthAssessment in full-text tests.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test` and see that no tests fail.

Fixes #2063 
