### PR TITLE
Disable Swedish readability analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 | Russian    	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
 | Catalan    	| ✅                	|                     	|               	|                     	|                             	|                            	|
 | Polish     	| ✅                	| ❌<sup>4</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
-| Swedish    	| ✅                	| ❌<sup>4</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
 

--- a/spec/assessments/sentenceBeginningsSpec.js
+++ b/spec/assessments/sentenceBeginningsSpec.js
@@ -127,12 +127,12 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		expect( assessment ).toBe( true );
 	} );
 
-	it( "is not applicable for a Swedish paper without text.", function() {
+	it.skip( "is not applicable for a Swedish paper without text.", function() {
 		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "sv_SE" } ) );
 		expect( assessment ).toBe( false );
 	} );
 
-	it( "is applicable for a Swedish paper with text.", function() {
+	it.skip( "is applicable for a Swedish paper with text.", function() {
 		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hej", { locale: "sv_SE" } ) );
 		expect( assessment ).toBe( true );
 	} );

--- a/spec/fullTextTests/testTexts/index.js
+++ b/spec/fullTextTests/testTexts/index.js
@@ -4,10 +4,6 @@ import englishPaper2 from "./en/englishPaper2";
 import englishPaper3 from "./en/englishPaper3";
 import englishPaper4 from "./en/englishPaper4";
 
-// Swedish papers
-import swedishPaper1 from "./sv/swedishPaper1";
-import swedishPaper2 from "./sv/swedishPaper2";
-
 // German papers
 import germanPaper1 from "./de/germanPaper1";
 import germanPaper2 from "./de/germanPaper2";
@@ -23,8 +19,6 @@ export default [
 	englishPaper2,
 	englishPaper3,
 	englishPaper4,
-	swedishPaper1,
-	swedishPaper2,
 	germanPaper1,
 	germanPaper2,
 	germanPaper3,

--- a/spec/helpers/getFunctionWordsLanguagesSpec.js
+++ b/spec/helpers/getFunctionWordsLanguagesSpec.js
@@ -2,6 +2,6 @@ import getFunctionWordsLanguages from "../../src/helpers/getFunctionWordsLanguag
 
 describe( "Checks which languages have function word support in YoastSEO.js", function() {
 	it( "returns an array of languages that have function word support", function() {
-		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl", "sv" ] );
+		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl" ] );
 	} );
 } );

--- a/spec/stringProcessing/relevantWordsSwedishSpec.js
+++ b/spec/stringProcessing/relevantWordsSwedishSpec.js
@@ -5,7 +5,7 @@ import swedishFunctionWordsFactory from "../../src/researches/swedish/functionWo
 const getRelevantWords = relevantWords.getRelevantWords;
 const swedishFunctionWords = swedishFunctionWordsFactory().all;
 
-describe( "gets Swedish word combinations", function() {
+describe.skip( "gets Swedish word combinations", function() {
 	it( "returns word combinations", function() {
 		const input = "Det vanligaste sättet för katten att kommunicera med människor är att jama. Det vanligaste sättet" +
 			" för katten att kommunicera med människor är att jama. Det vanligaste sättet för katten att kommunicera med " +

--- a/src/assessments/readability/passiveVoiceAssessment.js
+++ b/src/assessments/readability/passiveVoiceAssessment.js
@@ -9,7 +9,7 @@ import { stripIncompleteTags as stripTags } from "../../stringProcessing/stripHT
 import AssessmentResult from "../../values/AssessmentResult";
 import Mark from "../../values/Mark";
 
-const availableLanguages = [ "en", "de", "fr", "es", "ru", "it", "nl", "pl", "sv" ];
+const availableLanguages = [ "en", "de", "fr", "es", "ru", "it", "nl", "pl" ];
 
 /**
  * Calculates the result based on the number of sentences and passives.

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -9,7 +9,7 @@ import Mark from "../../values/Mark";
 const maximumConsecutiveDuplicates = 2;
 
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ import AssessmentResult from "../../values/AssessmentResult";
 import Mark from "../../values/Mark.js";
 import marker from "../../markers/addMark.js";
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl", "sv" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/src/helpers/getFunctionWords.js
+++ b/src/helpers/getFunctionWords.js
@@ -22,8 +22,6 @@ import russianFunctionWordsFactory from "../researches/russian/functionWords.js"
 const russianFunctionWords = russianFunctionWordsFactory();
 import polishFunctionWordsFactory from "../researches/polish/functionWords.js";
 const polishFunctionWords = polishFunctionWordsFactory();
-import swedishFunctionWordsFactory from "../researches/swedish/functionWords.js";
-const swedishFunctionWords = swedishFunctionWordsFactory();
 
 /**
  * Returns the function words for all languages.
@@ -41,6 +39,5 @@ export default function() {
 		pt: portugueseFunctionWords,
 		ru: russianFunctionWords,
 		pl: polishFunctionWords,
-		sv: swedishFunctionWords,
 	};
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Disables the Swedish readability analysis

## Test instructions

This PR can be tested by following these steps:

* Link this branch to WordPress SEO premium.
* Switch your site language to Swedish.
* Add a text.
* Make sure you don't see feedback about the transition word assessment. Add a transition word, e.g. `alltså`. Make sure you still don't get any feedback.
* Add 3 consecutive sentences that each start with the same word, e.g. "Lorem". The sentence beginnings assessment shouldn't be triggered.
* Add a Swedish participle in a sentence, e.g. `åberopades`. Make sure the passive voice assessment doesn't get triggered.
* Add a keyphrase with a function word, e.g. `en katt`. Only add the content word `katt` in the text. Make sure your keyphrase density is 0%. Add `en katt` in the text. Now your keyphrase should be recognized.
* Make sure you don't get any internal linking suggestions and insights.

Fixes #2072 
