### PR TITLE
Restore Swedish readability analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 | Russian    	| ✅                	| ✅                   	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
 | Catalan    	| ✅                	|                     	|               	|                     	|                             	|                            	|
 | Polish     	| ✅                	| ❌<sup>4</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Swedish    	| ✅                	| ❌<sup>4</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
 

--- a/spec/assessments/sentenceBeginningsSpec.js
+++ b/spec/assessments/sentenceBeginningsSpec.js
@@ -127,12 +127,12 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		expect( assessment ).toBe( true );
 	} );
 
-	it.skip( "is not applicable for a Swedish paper without text.", function() {
+	it( "is not applicable for a Swedish paper without text.", function() {
 		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "sv_SE" } ) );
 		expect( assessment ).toBe( false );
 	} );
 
-	it.skip( "is applicable for a Swedish paper with text.", function() {
+	it( "is applicable for a Swedish paper with text.", function() {
 		var assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hej", { locale: "sv_SE" } ) );
 		expect( assessment ).toBe( true );
 	} );

--- a/spec/fullTextTests/testTexts/index.js
+++ b/spec/fullTextTests/testTexts/index.js
@@ -4,6 +4,10 @@ import englishPaper2 from "./en/englishPaper2";
 import englishPaper3 from "./en/englishPaper3";
 import englishPaper4 from "./en/englishPaper4";
 
+// Swedish papers
+import swedishPaper1 from "./sv/swedishPaper1";
+import swedishPaper2 from "./sv/swedishPaper2";
+
 // German papers
 import germanPaper1 from "./de/germanPaper1";
 import germanPaper2 from "./de/germanPaper2";
@@ -19,6 +23,8 @@ export default [
 	englishPaper2,
 	englishPaper3,
 	englishPaper4,
+	swedishPaper1,
+	swedishPaper2,
 	germanPaper1,
 	germanPaper2,
 	germanPaper3,

--- a/spec/helpers/getFunctionWordsLanguagesSpec.js
+++ b/spec/helpers/getFunctionWordsLanguagesSpec.js
@@ -2,6 +2,6 @@ import getFunctionWordsLanguages from "../../src/helpers/getFunctionWordsLanguag
 
 describe( "Checks which languages have function word support in YoastSEO.js", function() {
 	it( "returns an array of languages that have function word support", function() {
-		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl" ] );
+		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl", "sv" ] );
 	} );
 } );

--- a/spec/stringProcessing/relevantWordsSwedishSpec.js
+++ b/spec/stringProcessing/relevantWordsSwedishSpec.js
@@ -5,7 +5,7 @@ import swedishFunctionWordsFactory from "../../src/researches/swedish/functionWo
 const getRelevantWords = relevantWords.getRelevantWords;
 const swedishFunctionWords = swedishFunctionWordsFactory().all;
 
-describe.skip( "gets Swedish word combinations", function() {
+describe( "gets Swedish word combinations", function() {
 	it( "returns word combinations", function() {
 		const input = "Det vanligaste sättet för katten att kommunicera med människor är att jama. Det vanligaste sättet" +
 			" för katten att kommunicera med människor är att jama. Det vanligaste sättet för katten att kommunicera med " +

--- a/src/assessments/readability/passiveVoiceAssessment.js
+++ b/src/assessments/readability/passiveVoiceAssessment.js
@@ -9,7 +9,7 @@ import { stripIncompleteTags as stripTags } from "../../stringProcessing/stripHT
 import AssessmentResult from "../../values/AssessmentResult";
 import Mark from "../../values/Mark";
 
-const availableLanguages = [ "en", "de", "fr", "es", "ru", "it", "nl", "pl" ];
+const availableLanguages = [ "en", "de", "fr", "es", "ru", "it", "nl", "pl", "sv" ];
 
 /**
  * Calculates the result based on the number of sentences and passives.

--- a/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -9,7 +9,7 @@ import Mark from "../../values/Mark";
 const maximumConsecutiveDuplicates = 2;
 
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/src/assessments/readability/transitionWordsAssessment.js
+++ b/src/assessments/readability/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ import AssessmentResult from "../../values/AssessmentResult";
 import Mark from "../../values/Mark.js";
 import marker from "../../markers/addMark.js";
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl", "sv" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/src/helpers/getFunctionWords.js
+++ b/src/helpers/getFunctionWords.js
@@ -22,6 +22,8 @@ import russianFunctionWordsFactory from "../researches/russian/functionWords.js"
 const russianFunctionWords = russianFunctionWordsFactory();
 import polishFunctionWordsFactory from "../researches/polish/functionWords.js";
 const polishFunctionWords = polishFunctionWordsFactory();
+import swedishFunctionWordsFactory from "../researches/swedish/functionWords.js";
+const swedishFunctionWords = swedishFunctionWordsFactory();
 
 /**
  * Returns the function words for all languages.
@@ -39,5 +41,6 @@ export default function() {
 		pt: portugueseFunctionWords,
 		ru: russianFunctionWords,
 		pl: polishFunctionWords,
+		sv: swedishFunctionWords,
 	};
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Restores the Swedish readability analysis. This was disabled for the 9.4 release [here](https://github.com/Yoast/YoastSEO.js/pull/2074) and should be restored for the 9.5 release.

## Test instructions

This PR can be tested by following these steps:

* Link this branch to the plugin.
* Switch your site language to Swedish.
* Add a text.
* Make sure you see negative feedback for the transition word assessment. Add a transition word, e.g. `alltså`. Make sure the transition word ratio is now higher than 0%.
* Make sure you initially see positive feedback for the sentence beginnings assessments. Add 3 consecutive sentences that each start with the same word, e.g. "Lorem". The sentence beginnings assessment should return negative feedback now.
* Make sure the passive voice assessment gives you a green bullet. Add a Swedish participle in a sentence, e.g. `åberopades`. Copy the sentence with the passive a few times and make sure the passive voice assessment gives you a red bullet at some point.
* Add a keyphrase with a function word, e.g. `en katt`. Only add the content word `katt` in the text. Make sure your keyphrase density is higher than 0%.

