### PR TITLE
Export SeoAssessor from project index

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import * as config from "./src/config";
 import App from "./src/app";
 import Assessor from "./src/assessor";
 import ContentAssessor from "./src/contentAssessor";
+import SeoAssessor from './src/seoAssessor';
 import TaxonomyAssessor from "./src/taxonomyAssessor";
 import Pluggable from "./src/pluggable";
 import Researcher from "./src/researcher";
@@ -21,6 +22,7 @@ export {
 	App,
 	Assessor,
 	ContentAssessor,
+	SeoAssessor,
 	TaxonomyAssessor,
 	Pluggable,
 	Researcher,


### PR DESCRIPTION
Fixes #1878

## Summary

This PR can be summarized in the following changelog entry:

* _[not user facing]_ The `SEOAssessor` is exported from the analysis index again.

## Relevant technical choices:

* This was exported previously I believe but removed in the refactoring to import/export.

## Test instructions

This PR can be tested by following these steps:

* Install yoastseo through NPM
* Try to `import { SeoAssessor } from 'yoastseo';`
* See that webpack happily compiles

Fixes #1878
