### PR TITLE
Remove slightly from the feedback string for cornerstone content

### DIFF
--- a/spec/assessments/textLengthSpec.js
+++ b/spec/assessments/textLengthSpec.js
@@ -54,4 +54,67 @@ describe( "A word count assessment", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 325 words. Good job!" );
 	} );
+
+	const cornerstoneConfig = {
+		recommendedMinimum: 900,
+		slightlyBelowMinimum: 400,
+		belowMinimum: 300,
+
+		scores: {
+			belowMinimum: -20,
+			farBelowMinimum: -20,
+		},
+
+		cornerstoneContent: true,
+	};
+
+	it( "different boundaries are applied if the content is cornerstone: very far below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
+		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
+
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
+
+		expect( results.getScore() ).toEqual( -20 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 25 words. This is far below the recommended minimum of 900 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: far below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 125 ) );
+		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
+
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 125 ), i18n );
+
+		expect( results.getScore() ).toEqual( -20 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 125 words. This is far below the recommended minimum of 900 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 325 ) );
+		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
+
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 325 ), i18n );
+
+		expect( results.getScore() ).toEqual( -20 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 325 words. This is below the recommended minimum of 900 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: slightly below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 425 ) );
+		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
+
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 425 ), i18n );
+
+		expect( results.getScore() ).toEqual( 6 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 425 words. This is below the recommended minimum of 900 words. <a href='https://yoa.st/34o' target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: above minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 925 ) );
+		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
+
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 925 ), i18n );
+
+		expect( results.getScore() ).toEqual( 9 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 925 words. Good job!" );
+	} );
 } );

--- a/src/assessments/seo/TextLengthAssessment.js
+++ b/src/assessments/seo/TextLengthAssessment.js
@@ -33,6 +33,8 @@ export default class TextLengthAssessment extends Assessment {
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/34n" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34o" ),
+
+			cornerstoneContent: false,
 		};
 
 		this.identifier = "textLength";
@@ -91,6 +93,20 @@ export default class TextLengthAssessment extends Assessment {
 	}
 
 	/**
+	 * Checks if the feedback should include "slightly".
+	 *
+	 * @param {number} score The amount of words to be checked against.
+	 *
+	 * @returns {boolean} Whether the feedback should include "slightly".
+	 */
+	useSlightly( score ) {
+		if ( score === this._config.scores.slightlyBelowMinimum ) {
+			return ! this._config.cornerstoneContent;
+		}
+	}
+
+
+	/**
 	 * Translates the score to a message the user can understand.
 	 *
 	 * @param {number} score The amount of words to be checked against.
@@ -112,60 +128,6 @@ export default class TextLengthAssessment extends Assessment {
 				wordCount,
 				this._config.urlTitle,
 				"</a>",
-			);
-		}
-
-		if ( score === this._config.scores.slightlyBelowMinimum ) {
-			return  i18n.sprintf(
-				i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text,
-					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
-					"%2$sText length%4$s: The text contains %1$d word.",
-					"%2$sText length%4$s: The text contains %1$d words.",
-					wordCount
-				) + " " + i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: The preceding sentence is "Text length: The text contains x words.",
-					%3$s expands to a link on yoast.com,
-					%4$s expands to the anchor end tag,
-					%5$d expands to the recommended minimum of words. */
-					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
-					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
-					this._config.recommendedMinimum
-				),
-				wordCount,
-				this._config.urlTitle,
-				this._config.urlCallToAction,
-				"</a>",
-				this._config.recommendedMinimum
-			);
-		}
-
-		if ( score === this._config.scores.belowMinimum ) {
-			return i18n.sprintf(
-				i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text,
-					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
-					"%2$sText length%4$s: The text contains %1$d word.",
-					"%2$sText length%4$s: The text contains %1$d words.",
-					wordCount
-				) + " " + i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: The preceding sentence is "Text length: The text contains x words.",
-					%3$s expands to a link on yoast.com,
-					%4$s expands to the anchor end tag,
-					%5$d expands to the recommended minimum of words. */
-					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
-					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
-					this._config.recommendedMinimum
-				),
-				wordCount,
-				this._config.urlTitle,
-				this._config.urlCallToAction,
-				"</a>",
-				this._config.recommendedMinimum
 			);
 		}
 
@@ -196,6 +158,56 @@ export default class TextLengthAssessment extends Assessment {
 			);
 		}
 
-		return "";
+		if ( this.useSlightly( score ) ) {
+			return i18n.sprintf(
+				i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					"%2$sText length%4$s: The text contains %1$d word.",
+					"%2$sText length%4$s: The text contains %1$d words.",
+					wordCount
+				) + " " + i18n.dngettext(
+					"js-text-analysis",
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$d expands to the recommended minimum of words. */
+					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
+					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
+					this._config.recommendedMinimum
+				),
+				wordCount,
+				this._config.urlTitle,
+				this._config.urlCallToAction,
+				"</a>",
+				this._config.recommendedMinimum
+			);
+		}
+
+		return i18n.sprintf(
+			i18n.dngettext(
+				"js-text-analysis",
+				/* Translators: %1$d expands to the number of words in the text,
+				%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+				"%2$sText length%4$s: The text contains %1$d word.",
+				"%2$sText length%4$s: The text contains %1$d words.",
+				wordCount
+			) + " " + i18n.dngettext(
+				"js-text-analysis",
+				/* Translators: The preceding sentence is "Text length: The text contains x words.",
+				%3$s expands to a link on yoast.com,
+				%4$s expands to the anchor end tag,
+				%5$d expands to the recommended minimum of words. */
+				"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+				"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
+				this._config.recommendedMinimum
+			),
+			wordCount,
+			this._config.urlTitle,
+			this._config.urlCallToAction,
+			"</a>",
+			this._config.recommendedMinimum
+		);
 	}
 }

--- a/src/assessments/seo/TextLengthAssessment.js
+++ b/src/assessments/seo/TextLengthAssessment.js
@@ -95,7 +95,7 @@ export default class TextLengthAssessment extends Assessment {
 	/**
 	 * Checks if the feedback should include "slightly".
 	 *
-	 * @param {number} score The amount of words to be checked against.
+	 * @param {number} score The score the text received for the assessment.
 	 *
 	 * @returns {boolean} Whether the feedback should include "slightly".
 	 */

--- a/src/assessments/seo/TextLengthAssessment.js
+++ b/src/assessments/seo/TextLengthAssessment.js
@@ -53,86 +53,140 @@ export default class TextLengthAssessment extends Assessment {
 	getResult( paper, researcher, i18n ) {
 		const wordCount = researcher.getResearch( "wordCountInText" );
 		const assessmentResult = new AssessmentResult();
+		const calculatedResult = this.calculateResult( wordCount, i18n );
 
-		assessmentResult.setScore( this.calculateScore( wordCount ) );
-		assessmentResult.setText(
-			i18n.sprintf( this.translateScore( assessmentResult.getScore(), wordCount, i18n ), wordCount, this._config.recommendedMinimum ) );
+		assessmentResult.setScore( calculatedResult.score );
+		assessmentResult.setText( calculatedResult.resultText );
 
 		return assessmentResult;
 	}
 
 	/**
-	 * Calculates the score based on the current word count.
+	 * Calculates the score based on the current word count and the appropriate feedback string.
 	 *
 	 * @param {number} wordCount The amount of words to be checked against.
+	 * @param {Jed} i18n The locale object.
 
-	 * @returns {number|null} The score.
+	 * @returns {Object} The score and the feedback string.
 	 */
-	calculateScore( wordCount ) {
+	calculateResult( wordCount, i18n ) {
 		if ( wordCount >= this._config.recommendedMinimum ) {
-			return this._config.scores.recommendedMinimum;
+			return {
+				score: this._config.scores.recommendedMinimum,
+				resultText: i18n.sprintf(
+					i18n.dngettext(
+						"js-text-analysis",
+						/* Translators: %1$d expands to the number of words in the text,
+						%2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+						"%2$sText length%3$s: The text contains %1$d word. Good job!",
+						"%2$sText length%3$s: The text contains %1$d words. Good job!",
+						wordCount ),
+					wordCount,
+					this._config.urlTitle,
+					"</a>",
+				),
+			};
+		}
+
+		if ( inRange( wordCount, 0, this._config.belowMinimum ) ) {
+			let badScore = this._config.scores.farBelowMinimum;
+
+			if ( inRange( wordCount, 0, this._config.veryFarBelowMinimum ) ) {
+				badScore = this._config.scores.veryFarBelowMinimum;
+			}
+
+			return {
+				score: badScore,
+				resultText: i18n.sprintf(
+					i18n.dngettext(
+						"js-text-analysis",
+						/* Translators: %1$d expands to the number of words in the text,
+						%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+						"%2$sText length%4$s: The text contains %1$d word.",
+						"%2$sText length%4$s: The text contains %1$d words.",
+						wordCount
+					) + " " + i18n.dngettext(
+						"js-text-analysis",
+						/* Translators: The preceding sentence is "Text length: The text contains x words.",
+						%3$s expands to a link on yoast.com,
+						%4$s expands to the anchor end tag,
+						%5$d expands to the recommended minimum of words. */
+						"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+						"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
+						this._config.recommendedMinimum
+					),
+					wordCount,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>",
+					this._config.recommendedMinimum
+				),
+			};
 		}
 
 		if ( inRange( wordCount, this._config.slightlyBelowMinimum, this._config.recommendedMinimum ) ) {
-			return this._config.scores.slightlyBelowMinimum;
+			if ( this._config.cornerstoneContent === false ) {
+				return {
+					score: this._config.scores.slightlyBelowMinimum,
+					resultText: i18n.sprintf(
+						i18n.dngettext(
+							"js-text-analysis",
+							/* Translators: %1$d expands to the number of words in the text,
+							%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+							"%2$sText length%4$s: The text contains %1$d word.",
+							"%2$sText length%4$s: The text contains %1$d words.",
+							wordCount
+						) + " " + i18n.dngettext(
+							"js-text-analysis",
+							/* Translators: The preceding sentence is "Text length: The text contains x words.",
+							%3$s expands to a link on yoast.com,
+							%4$s expands to the anchor end tag,
+							%5$d expands to the recommended minimum of words. */
+							"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
+							"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
+							this._config.recommendedMinimum
+						),
+						wordCount,
+						this._config.urlTitle,
+						this._config.urlCallToAction,
+						"</a>",
+						this._config.recommendedMinimum
+					),
+				};
+			}
+
+			return {
+				score: this._config.scores.slightlyBelowMinimum,
+				resultText: i18n.sprintf(
+					i18n.dngettext(
+						"js-text-analysis",
+						/* Translators: %1$d expands to the number of words in the text,
+						%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+						"%2$sText length%4$s: The text contains %1$d word.",
+						"%2$sText length%4$s: The text contains %1$d words.",
+						wordCount
+					) + " " + i18n.dngettext(
+						"js-text-analysis",
+						/* Translators: The preceding sentence is "Text length: The text contains x words.",
+						%3$s expands to a link on yoast.com,
+						%4$s expands to the anchor end tag,
+						%5$d expands to the recommended minimum of words. */
+						"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+						"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
+						this._config.recommendedMinimum
+					),
+					wordCount,
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>",
+					this._config.recommendedMinimum
+				),
+			};
 		}
 
-		if ( inRange( wordCount, this._config.belowMinimum, this._config.slightlyBelowMinimum ) ) {
-			return this._config.scores.belowMinimum;
-		}
-
-		if ( inRange( wordCount, this._config.veryFarBelowMinimum, this._config.belowMinimum ) ) {
-			return this._config.scores.farBelowMinimum;
-		}
-
-		if ( inRange( wordCount, 0, this._config.veryFarBelowMinimum ) ) {
-			return this._config.scores.veryFarBelowMinimum;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Checks if the feedback should include "slightly".
-	 *
-	 * @param {number} score The score the text received for the assessment.
-	 *
-	 * @returns {boolean} Whether the feedback should include "slightly".
-	 */
-	useSlightly( score ) {
-		if ( score === this._config.scores.slightlyBelowMinimum ) {
-			return ! this._config.cornerstoneContent;
-		}
-	}
-
-
-	/**
-	 * Translates the score to a message the user can understand.
-	 *
-	 * @param {number} score The amount of words to be checked against.
-	 * @param {number} wordCount The amount of words.
-	 * @param {Jed} i18n The object used for translations.
-	 *
-	 * @returns {string} The translated string.
-	 */
-	translateScore( score, wordCount, i18n ) {
-		if ( score === this._config.scores.recommendedMinimum ) {
-			return i18n.sprintf(
-				i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text,
-					%2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
-					"%2$sText length%3$s: The text contains %1$d word. Good job!",
-					"%2$sText length%3$s: The text contains %1$d words. Good job!",
-					wordCount ),
-				wordCount,
-				this._config.urlTitle,
-				"</a>",
-			);
-		}
-
-		if ( score === this._config.scores.farBelowMinimum || score === this._config.scores.veryFarBelowMinimum ) {
-			return i18n.sprintf(
+		return {
+			score: this._config.scores.belowMinimum,
+			resultText: i18n.sprintf(
 				i18n.dngettext(
 					"js-text-analysis",
 					/* Translators: %1$d expands to the number of words in the text,
@@ -146,68 +200,16 @@ export default class TextLengthAssessment extends Assessment {
 					%3$s expands to a link on yoast.com,
 					%4$s expands to the anchor end tag,
 					%5$d expands to the recommended minimum of words. */
-					"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
-					"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
+					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
+					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 					this._config.recommendedMinimum
 				),
 				wordCount,
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>",
-				this._config.recommendedMinimum
-			);
-		}
-
-		if ( this.useSlightly( score ) ) {
-			return i18n.sprintf(
-				i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: %1$d expands to the number of words in the text,
-					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
-					"%2$sText length%4$s: The text contains %1$d word.",
-					"%2$sText length%4$s: The text contains %1$d words.",
-					wordCount
-				) + " " + i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: The preceding sentence is "Text length: The text contains x words.",
-					%3$s expands to a link on yoast.com,
-					%4$s expands to the anchor end tag,
-					%5$d expands to the recommended minimum of words. */
-					"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
-					"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
-					this._config.recommendedMinimum
-				),
-				wordCount,
-				this._config.urlTitle,
-				this._config.urlCallToAction,
-				"</a>",
-				this._config.recommendedMinimum
-			);
-		}
-
-		return i18n.sprintf(
-			i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: %1$d expands to the number of words in the text,
-				%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
-				"%2$sText length%4$s: The text contains %1$d word.",
-				"%2$sText length%4$s: The text contains %1$d words.",
-				wordCount
-			) + " " + i18n.dngettext(
-				"js-text-analysis",
-				/* Translators: The preceding sentence is "Text length: The text contains x words.",
-				%3$s expands to a link on yoast.com,
-				%4$s expands to the anchor end tag,
-				%5$d expands to the recommended minimum of words. */
-				"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
-				"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
 				this._config.recommendedMinimum
 			),
-			wordCount,
-			this._config.urlTitle,
-			this._config.urlCallToAction,
-			"</a>",
-			this._config.recommendedMinimum
-		);
+		};
 	}
 }

--- a/src/assessments/seo/TextLengthAssessment.js
+++ b/src/assessments/seo/TextLengthAssessment.js
@@ -62,11 +62,11 @@ export default class TextLengthAssessment extends Assessment {
 	}
 
 	/**
-	 * Calculates the score based on the current word count and the appropriate feedback string.
+	 * Returns the score and the appropriate feedback string based on the current word count.
 	 *
 	 * @param {number} wordCount The amount of words to be checked against.
 	 * @param {Jed} i18n The locale object.
-
+	 *
 	 * @returns {Object} The score and the feedback string.
 	 */
 	calculateResult( wordCount, i18n ) {

--- a/src/cornerstone/seoAssessor.js
+++ b/src/cornerstone/seoAssessor.js
@@ -65,6 +65,8 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 					belowMinimum: -20,
 					farBelowMinimum: -20,
 				},
+
+				cornerstoneContent: true,
 			} ),
 			new OutboundLinks( {
 				scores: {
@@ -130,6 +132,8 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 					belowMinimum: -20,
 					farBelowMinimum: -20,
 				},
+
+				cornerstoneContent: true,
 			} ),
 			new OutboundLinks( {
 				scores: {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes feedback for the assessment that checks the length of the text in cornerstone articles. 

## Relevant technical choices:

* Changes one feedback string for the assessment that checks the length of the text for cornerstone content. If a cornerstone text has a length between 400 and 900 words, the assessment now returns an orange bullet and a feedback string _"Text length: The text contains __ words. This is below the recommended minimum of __ words. Add more content."_, instead of an orange bullet and a feedback string _"Text length: The text contains __ words. This is slightly below the recommended minimum of __ words. Add a bit more copy."_

## Test instructions

This PR can be tested by following these steps:

* Run a developer environment or link the branch to the trunk of wordpress-seo
* Check if the assessment works as described [here](https://github.com/Yoast/YoastSEO.js/wiki/Scoring-SEO-analysis#11-text-length) for both regular / cornerstone content and under current analysis and recalibrated analysis.

Fixes #2032 
