### PR TITLE
2081 more readable tree unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "grunt-shell": "^2.0.0",
     "istanbul": "^0.4.0",
     "jest": "^23.5.0",
+    "js-yaml": "^3.12.1",
     "load-grunt-config": "^1.0.0",
     "lodash-cli": "^4.14.1",
     "node-sass": "^4.9.3"

--- a/spec/specHelpers/buildTreeFromYaml.js
+++ b/spec/specHelpers/buildTreeFromYaml.js
@@ -36,6 +36,7 @@ class TreeFromYaml {
 			container.formatting = formatting.map( parameters => {
 				const type = Object.keys( parameters )[ 0 ];
 				parameters = parameters[ type ];
+
 				const formattingElement = new FormattingElement( type, parameters.attributes );
 
 				this.setSourceLocation( formattingElement, parameters );
@@ -137,7 +138,8 @@ class TreeFromYaml {
 	parse( parameters ) { // eslint-disable-line complexity
 		/*
 		  Type of node to add.
-		  E.g. encoded as `{ Paragraph: { text: "Some text"... } }`
+		  The type should be the first (and only) key of the JSON object.
+		  E.g. `{ Paragraph: { text: "Some text"... } }` => 'Paragraph'.
 		 */
 		const type = Object.keys( parameters )[ 0 ];
 		let element = {};
@@ -164,7 +166,9 @@ class TreeFromYaml {
  * @returns {module:tree/structure.Node} The parsed tree.
  */
 const buildTreeFromYaml = function( input ) {
+	// Parse YAML to JSON with `js-yaml` library.
 	const parameters = load( input );
+	// Parse and return tree from JSON.
 	const treeBuilder = new TreeFromYaml();
 	return treeBuilder.parse( parameters );
 };

--- a/spec/specHelpers/buildTreeFromYaml.js
+++ b/spec/specHelpers/buildTreeFromYaml.js
@@ -1,0 +1,14 @@
+import { load } from "js-yaml";
+
+/**
+ * Parses the given input string to a tree representation.
+ *
+ * @param {string} input The YAML string to parse to a tree.
+ *
+ * @returns {module:tree/structure.Node} The parsed tree.
+ */
+const buildTreeFromYaml = function( input ) {
+	return load( input );
+};
+
+export default buildTreeFromYaml;

--- a/spec/specHelpers/buildTreeFromYaml.js
+++ b/spec/specHelpers/buildTreeFromYaml.js
@@ -1,4 +1,160 @@
 import { load } from "js-yaml";
+import { ignoredHtmlElements } from "../../src/tree/builder/htmlConstants";
+import { FormattingElement, Paragraph, TextContainer,
+	Heading, StructuredNode, List, ListItem, Ignored } from "../../src/tree/structure";
+
+/**
+ * Supports building a tree from a YAML-encoded string.
+ */
+class TreeFromYaml {
+	/**
+	 * Sets the source code location (start index and end index) of the given element,
+	 * based on the info in the given object.
+	 *
+	 * @param {Object} element    The element to set the source code location of.
+	 * @param {Object} parameters The parameters to get the source code location info from.
+	 *
+	 * @returns {void}
+	 */
+	setSourceLocation( element, parameters ) {
+		element.sourceStartIndex = parameters.sourceStartIndex;
+		element.sourceEndIndex = parameters.sourceEndIndex;
+	}
+
+	/**
+	 * Parses the given text and formatting to a TextContainer.
+	 *
+	 * @param {string} text         The text to put in the TextContainer.
+	 * @param {Object[]} formatting The formatting to parse.
+	 *
+	 * @returns {module:tree/structure.TextContainer} The parsed TextContainer.
+	 */
+	parseTextContainer( text, formatting ) {
+		const container = new TextContainer();
+
+		container.text = text;
+		if ( formatting ) {
+			container.formatting = formatting.map( parameters => {
+				const formattingElement = new FormattingElement( parameters.type, parameters.attributes );
+
+				this.setSourceLocation( container, parameters );
+				formattingElement.textStartIndex = parameters.textStartIndex;
+				formattingElement.textEndIndex = parameters.textEndIndex;
+
+				return formattingElement;
+			} );
+		}
+
+		return container;
+	}
+
+	/**
+	 * Parses the given parameters to a Heading node.
+	 *
+	 * @param {Object} parameters The parameters to parse.
+	 *
+	 * @returns {module:tree/structure.Heading} The parsed Heading node.
+	 */
+	parseHeading( parameters ) {
+		const heading = new Heading( parameters.level );
+		heading.textContainer = this.parseTextContainer( parameters.text, parameters.formatting );
+		return heading;
+	}
+
+	/**
+	 * Parses the given parameters to a Paragraph node.
+	 *
+	 * @param {Object} parameters The parameters to parse.
+	 *
+	 * @returns {module:tree/structure.Paragraph} The parsed Paragraph node.
+	 */
+	parseParagraph( parameters ) {
+		const paragraph = new Paragraph( parameters.implicit ? "" : "p" );
+		paragraph.textContainer = this.parseTextContainer( parameters.text, parameters.formatting );
+		return paragraph;
+	}
+
+	/**
+	 * Parses the given parameters to a ListItem node.
+	 *
+	 * @param {Object} parameters The parameters to parse.
+	 *
+	 * @returns {module:tree/structure.ListItem} The parsed ListItem node.
+	 */
+	parseListItem( parameters ) {
+		const listItem = new ListItem();
+		listItem.children = parameters.children.map( child => this.parse( child ) );
+		return listItem;
+	}
+
+	/**
+	 * Parses the given parameters to a List node.
+	 *
+	 * @param {Object} parameters The parameters to parse.
+	 *
+	 * @returns {module:tree/structure.List} The parsed List node.
+	 */
+	parseList( parameters ) {
+		const list = new List( parameters.ordered );
+		list.children = parameters.children.map( child => this.parse( child ) );
+		return list;
+	}
+
+	/**
+	 * Parses the given parameters to a Structured node.
+	 *
+	 * @param {Object} parameters The parameters to parse.
+	 * @param {string} type   The type of structured node.
+	 *
+	 * @returns {module:tree/structure.StructuredNode} The parsed Structured node.
+	 */
+	parseStructured( parameters, type ) {
+		const structured = new StructuredNode( type );
+		structured.children = parameters.children.map( child => this.parse( child ) );
+		return structured;
+	}
+
+	/**
+	 * Parses the given parameters to an Ignored node.
+	 *
+	 * @param {Object} parameters The parameters to parse.
+	 * @param {string} type   The type of ignored element.
+	 *
+	 * @returns {module:tree/structure.Ignored} The parsed Ignored node.
+	 */
+	parseIgnored( parameters, type ) {
+		const ignored = new Ignored( type );
+		ignored.content = parameters.content;
+		return ignored;
+	}
+
+	/**
+	 * Parses the given JSON parameters to a node in the tree.
+	 *
+	 * @param {Object} parameters The JSON parameters to parse to a node.
+	 *
+	 * @returns {module:tree/structure.Node} The parsed tree.
+	 */
+	parse( parameters ) {
+		const type = Object.keys( parameters )[ 0 ];
+		let element = {};
+		switch ( type ) {
+			case "Paragraph": element = this.parseParagraph( parameters[ type ] ); break;
+			case "Heading": element = this.parseHeading( parameters[ type ] ); break;
+			case "List": element = this.parseList( parameters[ type ] ); break;
+			case "ListItem": element = this.parseListItem( parameters[ type ] ); break;
+			default:
+				if ( ignoredHtmlElements.includes( element ) ) {
+					element = this.parseIgnored( parameters[ type ], type );
+				} else {
+					element = this.parseStructured( parameters[ type ], type );
+				}
+		}
+		this.setSourceLocation( element, parameters[ type ] );
+		return element;
+	}
+}
+
 
 /**
  * Parses the given input string to a tree representation.
@@ -8,7 +164,9 @@ import { load } from "js-yaml";
  * @returns {module:tree/structure.Node} The parsed tree.
  */
 const buildTreeFromYaml = function( input ) {
-	return load( input );
+	const parameters = load( input );
+	const treeBuilder = new TreeFromYaml();
+	return treeBuilder.parse( parameters );
 };
 
 export default buildTreeFromYaml;

--- a/spec/tree/buildTreeFromYamlSpec.js
+++ b/spec/tree/buildTreeFromYamlSpec.js
@@ -1,0 +1,27 @@
+import buildTreeFromYaml from "../specHelpers/buildTreeFromYaml";
+
+const treeString = `
+- Paragraph:
+    text: This sentence needs to be read to have value as a sentence.
+    formatting:
+      - strong:
+          id: some-id
+          start: 8
+          end: 46
+      - em:
+          start: 49
+          end: 102
+      - strong:
+          class: weak
+          start: 63
+          end: 97
+- Header:
+    text: This is a header.
+`;
+
+describe( "buildTreeFromYaml", () => {
+	it( "can build a tree from a YAML string", () => {
+		const tree = buildTreeFromYaml( treeString );
+		console.log( tree );
+	} );
+} );

--- a/spec/tree/buildTreeFromYamlSpec.js
+++ b/spec/tree/buildTreeFromYamlSpec.js
@@ -1,31 +1,147 @@
+import {
+	Ignored,
+	List,
+	Paragraph,
+	Heading,
+	StructuredNode,
+	ListItem,
+	FormattingElement,
+} from "../../src/tree/structure";
 import buildTreeFromYaml from "../specHelpers/buildTreeFromYaml";
 
-const treeString = `
-root:
+const treeString1 = `
+Structured:
   sourceStartIndex: 0
   sourceEndIndex: 20
+  tag: root
+  children:
+    - Heading:
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        level: 2
+        text: This is a header.
+    - List:
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        ordered: true
+        children:
+          - ListItem:
+              sourceStartIndex: 23
+              sourceEndIndex: 50
+              children:
+                - Paragraph:
+                    sourceStartIndex: 23
+                    sourceEndIndex: 50
+                    text: Hello World!
+    - Ignored:
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        content: console.log("This should be ignored.");
+        tag: script
+`;
+
+const treeString2 = `
+Structured:
+  sourceStartIndex: 0
+  sourceEndIndex: 20
+  tag: root
   children:
     - Paragraph:
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        tag: p
         text: This sentence needs to be read to have value as a sentence.
         formatting:
-          - strong:
-              id: some-id
+          - strong:              
               textStartIndex: 8
               textEndIndex: 46
+              sourceStartIndex: 23
+              sourceEndIndex: 50
+              attributes:
+                id: some-id
           - em:
               textStartIndex: 49
               textEndIndex: 102
+              sourceStartIndex: 23
+              sourceEndIndex: 50
           - strong:
               class: weak
               textStartIndex: 63
               textEndIndex: 97
-    - Heading:
-        level: 2
-        text: This is a header.
+              sourceStartIndex: 23
+              sourceEndIndex: 50
 `;
 
 describe( "buildTreeFromYaml", () => {
 	it( "can build a tree from a YAML string", () => {
-		buildTreeFromYaml( treeString );
+		const tree = buildTreeFromYaml( treeString1 );
+
+		const ignored = new Ignored( "script" );
+		ignored.sourceStartIndex = 23;
+		ignored.sourceEndIndex = 50;
+		ignored.tag = "script";
+		ignored.content = "console.log(\"This should be ignored.\");";
+
+		const helloWorld = new Paragraph();
+		helloWorld.sourceStartIndex = 23;
+		helloWorld.sourceEndIndex = 50;
+		helloWorld.text = "Hello World!";
+
+		const listItem = new ListItem();
+		listItem.sourceStartIndex = 23;
+		listItem.sourceEndIndex = 50;
+		listItem.children = [ helloWorld ];
+
+		const list = new List( true );
+		list.sourceStartIndex = 23;
+		list.sourceEndIndex = 50;
+		list.children = [ listItem ];
+
+		const heading = new Heading( 2 );
+		heading.sourceStartIndex = 23;
+		heading.sourceEndIndex = 50;
+		heading.text = "This is a header.";
+
+		const expected = new StructuredNode( "root" );
+		expected.sourceStartIndex = 0;
+		expected.sourceEndIndex = 20;
+		expected.children = [ heading, list, ignored ];
+
+		expect( tree.toString() ).toEqual( expected.toString() );
+	} );
+
+	it( "builds a tree with a paragraph with formatting", () => {
+		const tree = buildTreeFromYaml( treeString2 );
+
+		const strong1 = new FormattingElement( "strong", { id: "some-id" } );
+		strong1.textStartIndex = 8;
+		strong1.textEndIndex = 46;
+		strong1.sourceStartIndex = 23;
+		strong1.sourceEndIndex = 50;
+
+		const em = new FormattingElement( "em" );
+		em.textStartIndex = 49;
+		em.textEndIndex = 102;
+		em.sourceEndIndex = 50;
+		em.sourceStartIndex = 23;
+
+		const strong2 = new FormattingElement( "strong" );
+		strong2.textStartIndex = 63;
+		strong2.textEndIndex = 97;
+		strong2.sourceStartIndex = 23;
+		strong2.sourceEndIndex = 50;
+
+		const paragraph = new Paragraph( "p" );
+		paragraph.sourceStartIndex = 23;
+		paragraph.sourceEndIndex = 50;
+		paragraph.text = "This sentence needs to be read to have value as a sentence.";
+		paragraph.textContainer.formatting = [ strong1, em, strong2 ];
+
+		const expected = new StructuredNode( "root" );
+		expected.sourceStartIndex = 0;
+		expected.sourceEndIndex = 20;
+		expected.children = [ paragraph ];
+
+		expect( tree.toString() ).toEqual( expected.toString() );
 	} );
 } );

--- a/spec/tree/buildTreeFromYamlSpec.js
+++ b/spec/tree/buildTreeFromYamlSpec.js
@@ -1,27 +1,31 @@
 import buildTreeFromYaml from "../specHelpers/buildTreeFromYaml";
 
 const treeString = `
-- Paragraph:
-    text: This sentence needs to be read to have value as a sentence.
-    formatting:
-      - strong:
-          id: some-id
-          start: 8
-          end: 46
-      - em:
-          start: 49
-          end: 102
-      - strong:
-          class: weak
-          start: 63
-          end: 97
-- Header:
-    text: This is a header.
+root:
+  sourceStartIndex: 0
+  sourceEndIndex: 20
+  children:
+    - Paragraph:
+        text: This sentence needs to be read to have value as a sentence.
+        formatting:
+          - strong:
+              id: some-id
+              textStartIndex: 8
+              textEndIndex: 46
+          - em:
+              textStartIndex: 49
+              textEndIndex: 102
+          - strong:
+              class: weak
+              textStartIndex: 63
+              textEndIndex: 97
+    - Heading:
+        level: 2
+        text: This is a header.
 `;
 
 describe( "buildTreeFromYaml", () => {
 	it( "can build a tree from a YAML string", () => {
-		const tree = buildTreeFromYaml( treeString );
-		console.log( tree );
+		buildTreeFromYaml( treeString );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4187,6 +4187,14 @@ js-yaml@^3.11.0, js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.5.2:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.5.5.tgz#0377c38017cabc7322b0d1fbcd25a491641f2fbe"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _[not-user-facing]_ Adds a function to parse YAML-strings to a structured tree.

## Relevant technical choices:

* Adds the `js-yaml` library as development dependency. This library is used to parse the YAML string to a JavaScript object to make parsing it to a tree a lot easier.

## Test instructions

This PR can be tested by following these steps:

* Not really applicable. You can review the code and added tests a second time. 

Fixes #2081.
