### PR TITLE
Use pull request branch when checking out the premium config on Travis

### DIFF
--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -57,12 +57,18 @@ module.exports = function( grunt ) {
 		"checkout-premium-configuration": {
 			command: function() {
 				const commands = [];
+				let branch = grunt.config.get( "currentBranch" );
+
+				if ( process.env.CI ) {
+					if ( process.env.TRAVIS_PULL_REQUEST_BRANCH === "" ) {
+						branch = process.env.TRAVIS_BRANCH;
+					} else {
+						branch = process.env.TRAVIS_PULL_REQUEST_BRANCH;
+					}
+				}
 
 				// Whitespace within the commands results into unexpected tokens.
-				const branch = ( process.env.CI
-					? process.env.TRAVIS_BRANCH
-					: grunt.config.get( "currentBranch" )
-				).trim();
+				branch = branch.trim();
 
 				commands.push( "cd premium-configuration" );
 				commands.push( "git checkout develop" );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] When checking out the premium configuration on Travis, we now use the pull request branch if the current job is a pull request.

## Relevant technical choices:

* Previously, we'd use `TRAVIS_BRANCH` as the branch for the premium configuration on Travis. When the current job is a pull request, this would result in that branch being set to the branch  targeted by the pull request. (See the [Travis environment variable documentation](https://docs.travis-ci.com/user/environment-variables/) for more information.) However, we want the premium configuration branch to be set to the pull request branch in order to test compatibility between the pull request branch on YoastSEO.js and a corresponding pull request branch on the premium config repo.

## Test instructions

This PR can be tested by following these steps:

* Check out this branch.
* Put a `console.log` of the `branch` variable after it has been set (for example on line 72). 
* Run `grunt get-premium-configuration -vvv`. The console.log should be visible with the branch being set to your current branch. (This is the fallback option set by `grunt.config.get( "currentBranch" )`.)
* Set the environment variable for the travis branch to testing and the pull request branch to empty and run the `checkout-premium-configuration` command using the following: `CI=true TRAVIS_BRANCH=testing1 TRAVIS_PULL_REQUEST_BRANCH= grunt shell:checkout-premium-configuration -vvv`.
* Confirm that the console log outputs the value the travis branch has been set to `testing1`. (This is the fallback in case no pull request branch has been set).
* Now run the same command again, with the pull request branch also set to a non-empty value: `CI=true TRAVIS_BRANCH=testing1 TRAVIS_PULL_REQUEST_BRANCH=testing2 grunt shell:checkout-premium-configuration -vvv`.
* Confirm that now the console.log outputs the value of the pull request branch (i.e., `testing2`), since when this value is set it gets precedence over the travis branch.