### PR TITLE
Add FunctionWordsInKeyphraseAssessment as seo assessment export

### DIFF
--- a/src/assessments/index.js
+++ b/src/assessments/index.js
@@ -9,6 +9,7 @@ import TextPresenceAssessment from "./readability/textPresenceAssessment";
 import TransitionWordsAssessment from "./readability/transitionWordsAssessment";
 import WordComplexityAssessment from "./readability/wordComplexityAssessment";
 
+import FunctionWordsInKeyphraseAssessment from './FunctionWordsInKeyphraseAssessment';
 import InternalLinksAssessment from "./seo/InternalLinksAssessment";
 import IntroductionKeywordAssessment from "./seo/IntroductionKeywordAssessment";
 import KeyphraseLengthAssessment from "./seo/KeyphraseLengthAssessment";
@@ -43,6 +44,7 @@ const readability = {
 };
 
 const seo = {
+	FunctionWordsInKeyphraseAssessment,
 	InternalLinksAssessment,
 	IntroductionKeywordAssessment,
 	KeyphraseLengthAssessment,


### PR DESCRIPTION
The `FunctionWordsInKeyphraseAssessment` class was not available as an seo assessment export. This changes makes it available with the others :)

## Summary

This PR can be summarized in the following changelog entry:

* `FunctionWordsInKeyphraseAssessment` is now available as an assessment in the `seo` group. It was previously forgotten.

## Relevant technical choices:

* It appears to be the only SeoAssessor assessment that was not exported.

## Test instructions

This PR can be tested by following these steps:

The following should work:
```js
import { assessments } from 'yoastseo';

const FunctionWordsInKeyphraseAssessment = new assessments.seo.FunctionWordsInKeyphraseAssessment();

console.log(FunctionWordsInKeyphraseAssessment);
```

Fixes #
