### PR TITLE
Add SingleH1Assessment as seo assessment export

### DIFF
--- a/src/assessments/index.js
+++ b/src/assessments/index.js
@@ -19,6 +19,7 @@ import MetaDescriptionKeywordAssessment from "./seo/MetaDescriptionKeywordAssess
 import MetaDescriptionLengthAssessment from "./seo/MetaDescriptionLengthAssessment";
 import OutboundLinksAssessment from "./seo/OutboundLinksAssessment";
 import PageTitleWidthAssessment from "./seo/PageTitleWidthAssessment";
+import SingleH1Assessment from './seo/SingleH1Assessment';
 import SubheadingsKeywordAssessment from "./seo/SubHeadingsKeywordAssessment";
 import TaxonomyTextLengthAssessment from "./seo/taxonomyTextLengthAssessment";
 import TextCompetingLinksAssessment from "./seo/TextCompetingLinksAssessment";
@@ -53,6 +54,7 @@ const seo = {
 	MetaDescriptionLengthAssessment,
 	OutboundLinksAssessment,
 	PageTitleWidthAssessment,
+	SingleH1Assessment,
 	SubheadingsKeywordAssessment,
 	TaxonomyTextLengthAssessment,
 	TextCompetingLinksAssessment,


### PR DESCRIPTION
The `SingleH1Assessment` class was not available as an seo assessment export. This changes makes it available with the others :)

## Summary

This PR can be summarized in the following changelog entry:

* `SingleH1Assessment` is now available as an assessment in the seo group. It was previously forgotten.

## Relevant technical choices:

* It appears to be the one of the few SeoAssessor assessments that were not exported.

## Test instructions

This PR can be tested by following these steps:

The following should work:
```js
import { assessments } from 'yoastseo';

const SingleH1Assessment = new assessments.seo.SingleH1Assessment();

console.log(SingleH1Assessment);
```

Fixes #
