### PR TITLE
2104 audit presenter strings

### DIFF
--- a/spec/renderers/AssessorPresenterSpec.js
+++ b/spec/renderers/AssessorPresenterSpec.js
@@ -3,8 +3,8 @@ import AssessmentResult from "../../src/values/AssessmentResult";
 import Factory from "../specHelpers/factory.js";
 
 describe( "an AssessorPresenter", function() {
-	var i18n;
-	var assessorPresenter;
+	let i18n;
+	let assessorPresenter;
 
 	beforeEach( function() {
 		i18n = Factory.buildJed();
@@ -36,11 +36,11 @@ describe( "an AssessorPresenter", function() {
 	} );
 
 	describe( "A function to transform a numeric overall score into a textual score", function() {
-		var expectations = [
+		let expectations = [
 			[ 0, "feedback", "Feedback" ],
-			[ 1, "bad", "Bad SEO score" ],
-			[ 23, "bad", "Bad SEO score" ],
-			[ 40, "bad", "Bad SEO score" ],
+			[ 1, "bad", "Needs improvement" ],
+			[ 23, "bad", "Needs improvement" ],
+			[ 40, "bad", "Needs improvement" ],
 			[ 41, "ok", "OK SEO score" ],
 			[ 55, "ok", "OK SEO score" ],
 			[ 70, "ok", "OK SEO score" ],
@@ -77,7 +77,7 @@ describe( "an AssessorPresenter", function() {
 	} );
 
 	describe( "assessment result sorting", function() {
-		var result1, result2;
+		let result1, result2;
 
 		beforeEach( function() {
 			result1 = new AssessmentResult();
@@ -87,16 +87,16 @@ describe( "an AssessorPresenter", function() {
 		} );
 
 		it( "should be able to sort assessment results", function() {
-			var assessments = [ result1, result2 ];
-			var expectation = [ result2, result1 ];
+			const assessments = [ result1, result2 ];
+			const expectation = [ result2, result1 ];
 
 			expect( assessorPresenter.sort( assessments ) ).toEqual( expectation );
 		} );
 
 		it( "should order undefined results lower than defined results", function() {
-			var result3 = new AssessmentResult();
-			var assessments = [ result1, result2, result3 ];
-			var expectation = [ result3, result2, result1 ];
+			const result3 = new AssessmentResult();
+			const assessments = [ result1, result2, result3 ];
+			const expectation = [ result3, result2, result1 ];
 
 			expect( assessorPresenter.sort( assessments ) ).toEqual( expectation );
 		} );

--- a/spec/renderers/AssessorPresenterSpec.js
+++ b/spec/renderers/AssessorPresenterSpec.js
@@ -36,7 +36,7 @@ describe( "an AssessorPresenter", function() {
 	} );
 
 	describe( "A function to transform a numeric overall score into a textual score", function() {
-		let expectations = [
+		const expectations = [
 			[ 0, "feedback", "Feedback" ],
 			[ 1, "bad", "Needs improvement" ],
 			[ 23, "bad", "Needs improvement" ],

--- a/src/config/presenter.js
+++ b/src/config/presenter.js
@@ -13,8 +13,8 @@ export default function( i18n ) {
 		},
 		bad: {
 			className: "bad",
-			screenReaderText: i18n.dgettext( "js-text-analysis", "Bad SEO score" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Bad SEO score" ),
+			screenReaderText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Needs improvement" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
 		},
 		ok: {

--- a/src/config/presenter.js
+++ b/src/config/presenter.js
@@ -3,31 +3,31 @@
  * @param {Jed} i18n The translator object.
  * @returns {Object} The config object.
  */
-export default function ( i18n ) {
+export default function( i18n ) {
 	return {
 		feedback: {
 			className: "na",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Feedback" ),
 			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Has feedback" ),
-			screenReaderReadabilityText: ''
+			screenReaderReadabilityText: "",
 		},
 		bad: {
 			className: "bad",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Bad SEO score" ),
 			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Bad SEO score" ),
-			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Needs improvement" )
+			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
 		},
 		ok: {
 			className: "ok",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "OK SEO score" ),
 			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: OK SEO score" ),
-			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "OK" )
+			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "OK" ),
 		},
 		good: {
 			className: "good",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Good SEO score" ),
 			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Good SEO score" ),
-			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Good" )
-		}
+			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Good" ),
+		},
 	};
-};
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the text read out by a screen reader when your text needs SEO improvement to "Needs improvement.", instead of "Bad SEO score.", when focussed on certain elements in your post.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Go to a post in WordPress.
* Make sure that your SEO score needs improvement (you get a red bullet for the SEO analysis).
* Turn on the screen reader on your computer.
   * If you got a Mac you can turn on "voice over" by pressing `Cmd+F5`.
* Use the `tab` key to navigate to these elements in turn:
   <img width="477" alt="screenshot 2019-01-24 at 17 28 30" src="https://user-images.githubusercontent.com/1682452/51695886-6b14e400-2004-11e9-8cc5-0c8ad229af05.png">
* Both elements should contain the text "Needs improvement", instead of "Bad SEO score".

Fixes #2104 
