### PR TITLE
Fix keyphrase in slug researcher for compound keyphrases with hyphens

### DIFF
--- a/spec/fullTextTests/testTexts/ru/russianPaper1.js
+++ b/spec/fullTextTests/testTexts/ru/russianPaper1.js
@@ -82,8 +82,8 @@ const expectedResults = {
 	},
 	urlKeyword: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: (Part of) your keyphrase does not appear in the slug. <a href='https://yoa.st/33p' target='_blank'>Change that</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: Great work!",
 	},
 	urlLength: {
 		isApplicable: true,

--- a/spec/researches/keywordCountInUrlSpec.js
+++ b/spec/researches/keywordCountInUrlSpec.js
@@ -18,11 +18,25 @@ describe( "test to check url for keyword", function() {
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
-	it( "returns no matches for dashed words", function() {
+	it( "returns no matches for differently dashed words", function() {
 		const paper = new Paper( "", { url: "url-with-key-word", keyword: "keyword" } );
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
+	} );
+
+	it( "returns matches for equally dashed words", function() {
+		const paper = new Paper( "", { url: "url-with-key-word", keyword: "key-word" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
+	} );
+
+	it( "returns matches for equally dashed words with more words around", function() {
+		const paper = new Paper( "", { url: "url-with-key-word", keyword: "exciting key-word exciting" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 4, percentWordMatches: 50 } );
 	} );
 
 	it( "returns matches with diacritics", function() {

--- a/src/researches/keywordCountInUrl.js
+++ b/src/researches/keywordCountInUrl.js
@@ -3,6 +3,51 @@
 import { findTopicFormsInString } from "./findKeywordFormsInString.js";
 
 /**
+ * Trims the modifier from compound words and makes it a separate keyphrase entry.
+ * E.g., for a keyphrase "modern pop-art" the current version of the morphological research generates forms
+ * [ [ modern, moderner, ...], [ pop-art, pop-arts, ...] ]. This is problematic for the research that searches for
+ * keyphrase in slug, because it treats compound words as 2 words. I.e., the research is looking for forms `pop` and `art`.
+ * This function takes the default-generated morphological forms and splits the compound words into two, such that
+ * the forms that serve input to the keyphraseCountInUrl researcher are
+ * [ [ modern, moderner, ...], [ pop ], [ art, arts, ...] ].
+ *
+ * @param {Array} topicForms The keyphraseForms and synonymsForms of the paper.
+ *
+ * @returns {Array} topicForms with split compounds.
+ */
+function dehyphenateKeyphraseForms( topicForms ) {
+	const dehyphenatedKeyphraseForms = [];
+
+	topicForms.keyphraseForms.forEach( function( lemma ) {
+		const firstWord = lemma[ 0 ];
+
+		if ( firstWord.indexOf( "-" ) === -1 ) {
+			dehyphenatedKeyphraseForms.push( lemma );
+			return;
+		}
+
+		const unchangedPart = firstWord.split( "-" )[ 0 ];
+
+		dehyphenatedKeyphraseForms.push( [ unchangedPart ] );
+
+		const dehyphenatedLemma = [];
+		lemma.forEach( function( wordInLemma ) {
+			if ( wordInLemma.indexOf( unchangedPart ) === 0 ) {
+				const trimmedWordInLemma = wordInLemma.slice( unchangedPart.length + 1, wordInLemma.length );
+				dehyphenatedLemma.push( trimmedWordInLemma );
+			}
+		} );
+
+		dehyphenatedKeyphraseForms.push( dehyphenatedLemma );
+	} );
+
+	topicForms.keyphraseForms = dehyphenatedKeyphraseForms;
+
+	return topicForms;
+}
+
+
+/**
  * Matches the keyword in the URL. Replaces dashes and underscores with whitespaces and uses whitespace as wordboundary.
  *
  * @param {Paper} paper the Paper object to use in this count.
@@ -11,7 +56,7 @@ import { findTopicFormsInString } from "./findKeywordFormsInString.js";
  * @returns {int} Number of times the keyword is found.
  */
 export default function( paper, researcher ) {
-	const topicForms = researcher.getResearch( "morphology" );
+	const topicForms = dehyphenateKeyphraseForms( researcher.getResearch( "morphology" ) );
 	const slug = paper.getUrl().replace( /[-_]/ig, " " );
 
 	const keyphraseInSlug = findTopicFormsInString( topicForms, slug, false, paper.getLocale() );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the bug when a compound keyphrase with a hyphen would not be recognized in the slug.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Check if keyphrases with hyphens are correctly recognized in the slug
* Try combining words with and without hyphens in the keyphrase and see if they are correctly recognized in the slug
* Check if keyphrases without hyphens are correctly recognized in the slug

Fixes #2121 
