### PR TITLE
Fix grammar and typos in assessments

### DIFF
--- a/spec/assessments/pageTitleWidthSpec.js
+++ b/spec/assessments/pageTitleWidthSpec.js
@@ -39,6 +39,6 @@ describe( "the SEO title length assessment", function() {
 		var paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
 		var result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );
 		expect( result.getScore() ).toEqual( 3 );
-		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: The SEO title wider than the viewable limit. <a href='https://yoa.st/34i' target='_blank'>Try to make it shorter</a>." );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: The SEO title is wider than the viewable limit. <a href='https://yoa.st/34i' target='_blank'>Try to make it shorter</a>." );
 	} );
 } );

--- a/src/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/src/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -67,7 +67,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {Object} Result object with score and text.
 	 */
 	calculateResult( i18n ) {
-		// GOOD result when the meta description contains keyhrase or a synonym 1 or 2 times.
+		// GOOD result when the meta description contains a keyphrase or synonym 1 or 2 times.
 		if ( this._keyphraseCounts === 1 || this._keyphraseCounts === 2 ) {
 			return {
 				score: this._config.scores.good,

--- a/src/assessments/seo/PageTitleWidthAssessment.js
+++ b/src/assessments/seo/PageTitleWidthAssessment.js
@@ -9,7 +9,7 @@ const maximumLength = 600;
 /**
  * Represents the assessment that will calculate if the width of the page title is correct.
  */
-export default class PageTitleWidthAssesment extends Assessment {
+export default class PageTitleWidthAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *

--- a/src/assessments/seo/PageTitleWidthAssessment.js
+++ b/src/assessments/seo/PageTitleWidthAssessment.js
@@ -131,7 +131,7 @@ export default class PageTitleWidthAssesment extends Assessment {
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sSEO title width%3$s: The SEO title wider than the viewable limit. %2$sTry to make it shorter%3$s."
+					"%1$sSEO title width%3$s: The SEO title is wider than the viewable limit. %2$sTry to make it shorter%3$s."
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,


### PR DESCRIPTION
Original PRs: https://github.com/Yoast/YoastSEO.js/pull/2117 and https://github.com/Yoast/YoastSEO.js/pull/2116

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a grammar mistake and two typos in the assessments. Props @Kingdutch 

## Relevant technical choices:

*


## Test instructions

This PR can be tested by following these steps:

* Check whether the PageTitleWidthAssessment still works as before.

Fixes #
