### PR TITLE
Improve list of Catalan transition words

### DIFF
--- a/spec/researches/findTransitionWordsSpec.js
+++ b/spec/researches/findTransitionWordsSpec.js
@@ -333,6 +333,14 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
 
+	it( "returns 1 when a transition word with a punt volat (·) is found in a sentence (Catalan)", function() {
+		// Transition word: per il·lustrar.
+		mockPaper = new Paper( "Roma proposa un concurs de curtmetratges per il·lustrar com ha de ser la ciutat ideal", { locale: "ca_ES" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+
 	it( "returns 1 when a two-part transition word is found in a sentence (Catalan)", function() {
 		// Transition word: ni...ni
 		mockPaper = new Paper( "No era ni un gat ni un gos.", { locale: "ca_ES" } );

--- a/src/researches/catalan/transitionWords.js
+++ b/src/researches/catalan/transitionWords.js
@@ -1,26 +1,30 @@
 /** @module config/transitionWords */
 
-const singleWords = [	"abans", "així", "altrament", "anteriorment", "breument", "contràriament", "després", "doncs",
-	"efectivament", "endemés", "finalment", "generalment", "igualment", "malgrat", "mentre", "parallelament", "paral·lelament",
-	"però", "perquè", "primerament", "resumidament", "resumint", "sinó", "sobretot", "també", "tanmateix" ];
+const singleWords = [ "abans", "així", "alhora", "aleshores", "altrament", "anteriorment", "breument", "bàsicament",
+	"contràriament", "després", "doncs", "efectivament", "endemés", "especialment", "evidentment", "finalment", "fins a",
+	"fins que", "generalment", "igualment", "malgrat", "mentre", "mentrestant", "parallelament", "paral·lelament", "però",
+	"perquè", "quan", "primerament", "resumidament", "resumint", "segurament", "segons això", "sens dubte", "sinó",
+	"sobretot", "també", "tanmateix" ];
 
-const multipleWords = [ "a banda d'això", "a continuació", "a fi de", "a fi que", "a força de", "a manera de resum", "a més",
+const multipleWords = [ "a banda d'això", "a continuació", "a diferència de", "a fi de", "a fi que", "a força de",
+	"a manera de resum", "a més", "a partir d'aquí", "a partir d'ara",
 	"a tall d'exemple", "a tall de recapitulació", "a tall de resum", "al capdavall", "al contrari", "al mateix temps",
-	"amb relació a", "amb tot plegat", "ara bé", "atès que", "com a conseqüència", "com a exemple", "com a resultat",
+	"amb relació a", "tot plegat", "ara bé", "atès que", "com a conseqüència", "com a exemple", "com a resultat",
 	"com a resum", "com que", "comptat i debatut", "considerant que", "convé destacar", "convé recalcar",
 	"convé ressaltar que", "d'altra banda", "d’una banda", "d’una forma breu", "de la mateixa manera", "de manera parallela",
-	"de manera que", "degut a", "deixant de banda", "dit d'una altra manera", "donat que", "en a resum", "en altres paraules",
-	"en canvi", "en conclusió", "en conjunt", "en conseqüència", "encara que", "en darrer lloc", "en darrer terme",
-	"en definitiva", "en efect", "en general", "en particular", "en pocs mots", "en poques paraules", "en primer lloc",
-	"en relació amb", "en resum", "en segon lloc", "en síntesi", "en suma", "en tercer lloc", "en últim terme", "és a dir",
-	"és més", "és per això que", "fins i tot", "gràcies a", "gràcies de", "igual com", "igual que", "ja que", "llevat que",
-	"més aviat", "més tard", "no obstant", "o sia", "o sigui", "pel fet que", "pel general", "pel que", "per acabar",
-	"per això", "per altra banda", "per aquest motiu", "per causa de", "per causa que", "per cert", "per començar",
-	"per concloure", "per concretar", "per contra", "per exemple", "per illustrar", "per l'altra part", "per l'altre cantó",
-	"per la qual cosa", "per posar un exemple", "per raó de", "per raó que", "per tal de", "per tal que", "per tant",
+	"de manera paral·lela", "de manera que", "de tota manera", "degut a", "deixant de banda", "dit d'una altra manera",
+	"donat que", "en a resum", "en lloc de", "en altres paraules", "en aquest sentit", "en canvi", "en conclusió", "en conjunt",
+	"en conseqüència", "encara que", "en darrer lloc", "en darrer terme", "en definitiva", "en efecte", "en general",
+	"en particular", "en pocs mots", "en poques paraules", "en primer lloc", "en relació amb", "en resum", "en segon lloc",
+	"en síntesi", "en suma", "en tercer lloc", "en últim terme", "és a dir", "és més", "és per això que", "fins i tot",
+	"gràcies a", "gràcies de", "igual com", "igual que", "ja que", "llevat que", "més aviat", "més tard", "més endavant",
+	"no obstant", "o sia", "o sigui", "òbviament", "pel fet que", "pel general", "pel que", "per acabar", "per això",
+	"per altra banda", "per aquest motiu", "per causa de", "per causa que", "per cert", "per començar", "per concloure",
+	"per concretar", "per contra", "per exemple", "per illustrar", "per il·lustrar", "per l'altra part", "per l'altre cantó",
+	"per la qual cosa", "per mitjà de", "per posar un exemple", "per raó de", "per raó que", "per tal de", "per tal que", "per tant",
 	"per últim", "per un cantó", "per un costat", "per una altra banda", "per una part", "quant a", "recapitulant",
-	"respecte de", "s'ha de tenir en compte que", "sempre que", "tal com s’ha dit", "tan bon punt", "tenint en compte que",
-	"tot i", "tot seguit", "val la pena dir que", "vist que" ];
+	"respecte de", "s'ha de tenir en compte que", "sempre que", "tal com s’ha dit", "tan bon punt", "tan aviat com",
+	"tenint en compte que", "tot i", "tot seguit", "val a dir", "val la pena dir que", "vist que" ];
 
 /**
  * Returns lists with transition words to be used by the assessments.

--- a/src/researches/catalan/transitionWords.js
+++ b/src/researches/catalan/transitionWords.js
@@ -1,8 +1,8 @@
 /** @module config/transitionWords */
 
 const singleWords = [	"abans", "així", "altrament", "anteriorment", "breument", "contràriament", "després", "doncs",
-	"efectivament", "endemés", "finalment", "generalment", "igualment", "malgrat", "mentre", "parallelament", "però",
-	"perquè", "primerament", "resumidament", "resumint", "sinó", "sobretot", "també", "tanmateix" ];
+	"efectivament", "endemés", "finalment", "generalment", "igualment", "malgrat", "mentre", "parallelament", "paral·lelament",
+	"però", "perquè", "primerament", "resumidament", "resumint", "sinó", "sobretot", "també", "tanmateix" ];
 
 const multipleWords = [ "a banda d'això", "a continuació", "a fi de", "a fi que", "a força de", "a manera de resum", "a més",
 	"a tall d'exemple", "a tall de recapitulació", "a tall de resum", "al capdavall", "al contrari", "al mateix temps",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves list of Catalan transition words, props to [Sílvia Fustegueres/Ampersand Translations](https://www.ampersand.net/en/).

## Test instructions

This PR can be tested by following these steps:

* Change locale to ca_ES and paste the added transition words into the text editor. Make sure they are marked as transition words.

Fixes #2163
