### PR TITLE
Change sentence length limit for Spanish

### DIFF
--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -137,6 +137,37 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
+	it( "returns the score for 100% long sentences in Spanish", function() {
+		const mockPaper = new Paper( "text", { locale: "es_ES" } );
+		const sentenceLengthInTextAssessmentSpanish = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentSpanish.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 26 },
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for all short sentences in Spanish", function() {
+		const mockPaper = new Paper( "text", { locale: "es_ES" } );
+		const sentenceLengthInTextAssessmentSpanish = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentSpanish.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 24 },
+
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
+		expect( assessment.hasMarks() ).toBe( false );
+	} );
+
 	it( "returns the score for all short sentences in Polish", function() {
 		const mockPaper = new Paper( "text", { locale: "pl_PL" } );
 		const sentenceLengthInTextAssessmentPolish = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );

--- a/spec/fullTextTests/testTexts/es/spanishPaper3.js
+++ b/spec/fullTextTests/testTexts/es/spanishPaper3.js
@@ -117,8 +117,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 29.7% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/src/config/content/combinedConfig.js
+++ b/src/config/content/combinedConfig.js
@@ -4,11 +4,13 @@ import defaultConfig from "./default";
 import it from "./it";
 import ru from "./ru";
 import pl from "./pl";
+import es from "./es";
 
 const configurations = {
 	it: it,
 	ru: ru,
 	pl: pl,
+	es: es,
 };
 
 /**

--- a/src/config/content/es.js
+++ b/src/config/content/es.js
@@ -1,0 +1,5 @@
+export default {
+	sentenceLength: {
+		recommendedWordCount: 25,
+	},
+};

--- a/src/config/content/es.js
+++ b/src/config/content/es.js
@@ -1,3 +1,9 @@
+/**
+ * Spanish sentences tend to be longer than English ones (for which the recommended limit is 20 words).
+ * This is why the sentence length limit was increased to 25 for Spanish. For more detailed explanation, see:
+ * https://github.com/Yoast/research/wiki/Sentence-Length-Spanish
+ */
+
 export default {
 	sentenceLength: {
 		recommendedWordCount: 25,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Increases the recommended sentence length limit for Spanish, props to [Sílvia Fustegueres/Ampersand Translations](https://www.ampersand.net/en/).

## Test instructions

This PR can be tested by following these steps:

* In your local testing environment, change the locale to es_ES. 
* Paste a Spanish text.
* Make sure that the correct feedback is returned (e.g. the recommended limit is specified as 25; different results are returned than when locale is set to a language with another limit, such as English).

Fixes #2166
