### PR TITLE
Increase sentence length limit for Catalan

### DIFF
--- a/spec/assessments/sentenceLengthInTextSpec.js
+++ b/spec/assessments/sentenceLengthInTextSpec.js
@@ -168,6 +168,37 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
+	it( "returns the score for 100% long sentences in Catalan", function() {
+		const mockPaper = new Paper( "text", { locale: "ca_ES" } );
+		const sentenceLengthInTextAssessmentCatalan = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentCatalan.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 26 },
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for all short sentences in Catalan", function() {
+		const mockPaper = new Paper( "text", { locale: "ca_ES" } );
+		const sentenceLengthInTextAssessmentCatalan = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentCatalan.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 24 },
+
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
+		expect( assessment.hasMarks() ).toBe( false );
+	} );
+
 	it( "returns the score for all short sentences in Polish", function() {
 		const mockPaper = new Paper( "text", { locale: "pl_PL" } );
 		const sentenceLengthInTextAssessmentPolish = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );

--- a/src/config/content/ca.js
+++ b/src/config/content/ca.js
@@ -1,0 +1,10 @@
+/**
+ * The default limit of 20 words is too strict for Catalan. For more detailed explanation, see:
+ * https://github.com/Yoast/research/wiki/Sentence-Length-Catalan
+ */
+
+export default {
+	sentenceLength: {
+		recommendedWordCount: 25,
+	},
+};

--- a/src/config/content/ca.js
+++ b/src/config/content/ca.js
@@ -1,5 +1,5 @@
 /**
- * The default limit of 20 words is too strict for Catalan. For more detailed explanation, see:
+ * Sentences in Catalan have a similar length distribution as in Spanish, so use the same 25 word limit. For a more detailed explanation, see:
  * https://github.com/Yoast/research/wiki/Sentence-Length-Catalan
  */
 

--- a/src/config/content/combinedConfig.js
+++ b/src/config/content/combinedConfig.js
@@ -5,12 +5,14 @@ import it from "./it";
 import ru from "./ru";
 import pl from "./pl";
 import es from "./es";
+import ca from "./ca";
 
 const configurations = {
 	it: it,
 	ru: ru,
 	pl: pl,
 	es: es,
+	ca: ca,
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Increases the recommended sentence length limit for Catalan, props to [Sílvia Fustegueres](https://www.ampersand.net/en/).

## Test instructions

This PR can be tested by following these steps:

* In your local testing environment, change the locale to ca_ES. 
* Paste a Catalan text.
* Make sure that the correct feedback is returned (e.g. the recommended limit is specified as 25, and the feedback is different than when locale is set to a language with another limit, such as English).

Fixes #2168 
