### PR TITLE
Add test cases to analysis web worker spec

### DIFF
--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -2,9 +2,9 @@ import { forEach, isArray, isNumber, isObject } from "lodash-es";
 import { getLogger } from "loglevel";
 import morphologyData from "../../premium-configuration/data/morphologyData.json";
 import Assessment from "../../src/assessment";
+import { createShortlink } from "../../src/helpers/shortlinker";
 import AssessmentResult from "../../src/values/AssessmentResult";
 import Paper from "../../src/values/Paper";
-
 import AnalysisWebWorker from "../../src/worker/AnalysisWebWorker";
 import testTexts from "../fullTextTests/testTexts";
 
@@ -303,6 +303,21 @@ describe( "AnalysisWebWorker", () => {
 
 				expect( worker._researcher.addResearchData ).toHaveBeenNthCalledWith( 1, "morphology", "word forms" );
 				expect( worker._researcher.addResearchData ).toHaveBeenNthCalledWith( 2, "fancy", "feature" );
+			} );
+
+			test( "configures the shortlinker params", () => {
+				const baseUrl = "https://yoast.com";
+
+				// Ensure there are no params registered yet.
+				expect( createShortlink( baseUrl ) ).toBe( baseUrl );
+
+				scope.onmessage( createMessage( "initialize", {
+					defaultQueryParams: {
+						source: "specs",
+					},
+				} ) );
+
+				expect( createShortlink( baseUrl ) ).toBe( `${ baseUrl }?source=specs` );
 			} );
 
 			test( "creates the assessors", () => {

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -1,12 +1,12 @@
-import { forEach, isArray, isObject, isNumber } from "lodash-es";
+import { forEach, isArray, isNumber, isObject } from "lodash-es";
 import { getLogger } from "loglevel";
+import morphologyData from "../../premium-configuration/data/morphologyData.json";
+import Assessment from "../../src/assessment";
+import AssessmentResult from "../../src/values/AssessmentResult";
+import Paper from "../../src/values/Paper";
 
 import AnalysisWebWorker from "../../src/worker/AnalysisWebWorker";
-import Assessment from "../../src/assessment";
-import Paper from "../../src/values/Paper";
-import AssessmentResult from "../../src/values/AssessmentResult";
 import testTexts from "../fullTextTests/testTexts";
-import morphologyData from "../../premium-configuration/data/morphologyData.json";
 
 /**
  * Creates a mocked scope.
@@ -289,6 +289,20 @@ describe( "AnalysisWebWorker", () => {
 				} );
 
 				logger.setLevel( saveLogLevel, false );
+			} );
+
+			test( "adds the research data to the researcher", () => {
+				worker._researcher.addResearchData = jest.fn();
+
+				scope.onmessage( createMessage( "initialize", {
+					researchData: {
+						morphology: "word forms",
+						fancy: "feature",
+					},
+				} ) );
+
+				expect( worker._researcher.addResearchData ).toHaveBeenNthCalledWith( 1, "morphology", "word forms" );
+				expect( worker._researcher.addResearchData ).toHaveBeenNthCalledWith( 2, "fancy", "feature" );
 			} );
 
 			test( "creates the assessors", () => {

--- a/spec/worker/AnalysisWebWorkerSpec.js
+++ b/spec/worker/AnalysisWebWorkerSpec.js
@@ -1,12 +1,15 @@
 import { forEach, isArray, isNumber, isObject } from "lodash-es";
 import { getLogger } from "loglevel";
-import morphologyData from "../../premium-configuration/data/morphologyData.json";
 import Assessment from "../../src/assessment";
 import { createShortlink } from "../../src/helpers/shortlinker";
 import AssessmentResult from "../../src/values/AssessmentResult";
 import Paper from "../../src/values/Paper";
 import AnalysisWebWorker from "../../src/worker/AnalysisWebWorker";
 import testTexts from "../fullTextTests/testTexts";
+import getMorphologyData from "../specHelpers/getMorphologyData";
+
+
+const morphologyData = getMorphologyData( "en" );
 
 /**
  * Creates a mocked scope.
@@ -1038,7 +1041,12 @@ describe( "AnalysisWebWorker", () => {
 					expect( id ).toBe( 0 );
 					expect( isObject( result ) ).toBe( true );
 					expect( result.keyphraseForms ).toEqual( [ [ "voice" ], [ "search" ] ] );
-					expect( result.synonymsForms ).toEqual( [ [ [ "listening" ], [ "reading" ], [ "search" ] ], [ [ "voice" ], [ "query" ] ], [ [ "voice" ], [ "results" ] ] ] );
+					expect( result.synonymsForms )
+						.toEqual( [
+							[ [ "listening" ], [ "reading" ], [ "search" ] ],
+							[ [ "voice" ], [ "query" ] ],
+							[ [ "voice" ], [ "results" ] ],
+						] );
 					done();
 				};
 
@@ -1055,8 +1063,54 @@ describe( "AnalysisWebWorker", () => {
 					expect( id ).toBe( 0 );
 					expect( isObject( result ) ).toBe( true );
 					expect( result.keyphraseForms ).toEqual( [
-						[ "voice", "voices", "voice's", "voices's", "voices'", "voicing", "voiced", "voicely", "voicer", "voicest", "voice‘s", "voice’s", "voice‛s", "voice`s", "voices‘s", "voices’s", "voices‛s", "voices`s", "voices‘", "voices’", "voices‛", "voices`" ],
-						[ "search", "searches", "search's", "searches's", "searches'", "searching", "searched", "searchly", "searcher", "searchest", "search‘s", "search’s", "search‛s", "search`s", "searches‘s", "searches’s", "searches‛s", "searches`s", "searches‘", "searches’", "searches‛", "searches`" ],
+						[
+							"voice",
+							"voices",
+							"voice's",
+							"voices's",
+							"voices'",
+							"voicing",
+							"voiced",
+							"voicely",
+							"voicer",
+							"voicest",
+							"voice‘s",
+							"voice’s",
+							"voice‛s",
+							"voice`s",
+							"voices‘s",
+							"voices’s",
+							"voices‛s",
+							"voices`s",
+							"voices‘",
+							"voices’",
+							"voices‛",
+							"voices`",
+						],
+						[
+							"search",
+							"searches",
+							"search's",
+							"searches's",
+							"searches'",
+							"searching",
+							"searched",
+							"searchly",
+							"searcher",
+							"searchest",
+							"search‘s",
+							"search’s",
+							"search‛s",
+							"search`s",
+							"searches‘s",
+							"searches’s",
+							"searches‛s",
+							"searches`s",
+							"searches‘",
+							"searches’",
+							"searches‛",
+							"searches`",
+						],
 					] );
 					done();
 				};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Adds tests to the Analysis Web Worker spec.

## Relevant technical choices:

* Add spec for the worker initialize with research data.
* Add spec for the worker initialize with default query params.
* Apply auto formatting.
* Using get morphology data spec helper.

## Test instructions

This PR can be tested by following these steps:

* Inspect the specs to see if they are up to par.
* Check the code coverage to see if it is closer to 100% (see the issue for which parts should now be covered).

Fixes #1921 
