### PR TITLE
Add specs for German morphology exception nouns

### DIFF
--- a/spec/morphology/german/generateNounExceptionFormsSpec.js
+++ b/spec/morphology/german/generateNounExceptionFormsSpec.js
@@ -230,8 +230,8 @@ describe( "Test for checking adjective exceptions in German", () => {
 	it( "creates forms for a singular noun that ends in a consonant + s", () => {
 		expect( generateNounExceptionForms( morphologyDataDE.nouns, "krebs" ) ).toEqual( [
 			"krebs",
-			"krebse",
 			"krebses",
+			"krebse",
 			"krebsen",
 		] );
 	} );

--- a/spec/morphology/german/generateNounExceptionFormsSpec.js
+++ b/spec/morphology/german/generateNounExceptionFormsSpec.js
@@ -226,4 +226,13 @@ describe( "Test for checking adjective exceptions in German", () => {
 		// "Sprung" is an exception to the general -ung rule.
 		expect( generateNounExceptionForms( morphologyDataDE.nouns, "hochsprung" ) ).toEqual( [] );
 	} );
+
+	it( "creates forms for a singular noun that ends in a consonant + s", () => {
+		expect( generateNounExceptionForms( morphologyDataDE.nouns, "krebs" ) ).toEqual( [
+			"krebs",
+			"krebse",
+			"krebses",
+			"krebsen",
+		] );
+	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Adds specs that check whether words from the German noun exception list that end in a consonant + s get stemmed correctly

## Test instructions

This PR can be tested by following these steps:

* Run the spec and make sure there are no errors
