### PR TITLE
i18n: split translation strings to reduce the number of strings

### DIFF
--- a/src/config/presenter.js
+++ b/src/config/presenter.js
@@ -8,25 +8,25 @@ export default function( i18n ) {
 		feedback: {
 			className: "na",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Feedback" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Has feedback" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "Has feedback" ),
 			screenReaderReadabilityText: "",
 		},
 		bad: {
 			className: "bad",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Needs improvement" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "Needs improvement" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
 		},
 		ok: {
 			className: "ok",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "OK SEO score" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: OK SEO score" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "OK SEO score" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "OK" ),
 		},
 		good: {
 			className: "good",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Good SEO score" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Good SEO score" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "Good SEO score" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Good" ),
 		},
 	};


### PR DESCRIPTION
![yoast29](https://user-images.githubusercontent.com/576623/57283983-fb110200-70b8-11e9-86de-d3c0e4979fbb.png)

Old translation strings:

* `Content optimization: Has feedback`
* `Content optimization: Needs improvement`
* `Content optimization: OK SEO score`
* `Content optimization: Good SEO score`

New translation strings:

* `Content optimization:` - **New**
* `Has feedback` - **New**
* `Needs improvement` - **Already Exist**
* `OK SEO score` - **Already Exist**
* `Good SEO score` - **Already Exist**

This PR replace 4 translation strings with 2 strings by splitting them and using existing translation strings.

I did the same in https://github.com/Yoast/wordpress-seo/pull/12781, replacing 19 strings with only 3.

## Summary

This PR can be summarized in the following changelog entry:

* i18n: split translation strings to reduce the number of strings

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
